### PR TITLE
Fix result cell truncated preview

### DIFF
--- a/frontend/src/shared/ui/EditableCell/constants.ts
+++ b/frontend/src/shared/ui/EditableCell/constants.ts
@@ -1,0 +1,8 @@
+// Cap on the single-line preview rendered in a table cell. The full value stays
+// in `display` (used for editing) and in the row detail pane; this only bounds
+// what the grid shows so a multi-KB JSON / long text cell renders a readable
+// truncated string ("{"id":1,"name":...…") instead of a bare ellipsis.
+// TODO: consolidate into a configurable setting in the Settings pane.
+const MAX_PREVIEW_CHARS = 500;
+
+export { MAX_PREVIEW_CHARS };

--- a/frontend/src/shared/ui/EditableCell/index.test.tsx
+++ b/frontend/src/shared/ui/EditableCell/index.test.tsx
@@ -15,6 +15,40 @@ describe("EditableCell", () => {
     expect(cell.className).toContain("mdbc-editable-cell-readonly-value");
   });
 
+  it("renders a truncated single-line preview for long values", () => {
+    const long = JSON.stringify({ items: Array.from({ length: 200 }, (_, i) => i) });
+    render(
+      <EditableCell readOnly value={{ kind: "json", value: long } as any} onCommit={() => {}} />,
+    );
+    const cell = document.querySelector(".mdbc-editable-cell-readonly-value") as HTMLElement;
+    expect(cell.textContent!.length).toBeLessThan(long.length);
+    expect(cell.textContent!.endsWith("…")).toBe(true);
+  });
+
+  it("collapses newlines into a single-line preview", () => {
+    render(
+      <EditableCell
+        readOnly
+        value={{ kind: "text", value: "line one\nline two\nline three" } as any}
+        onCommit={() => {}}
+      />,
+    );
+    const cell = document.querySelector(".mdbc-editable-cell-readonly-value") as HTMLElement;
+    expect(cell.textContent).toBe("line one line two line three");
+  });
+
+  it("edits the full value, not the truncated preview", () => {
+    const onCommit = vi.fn();
+    const long = "x".repeat(800);
+    render(
+      <EditableCell value={{ kind: "text", value: long } as any} onCommit={onCommit} />,
+    );
+    const cell = document.querySelector(".mdbc-editable-cell-display") as HTMLElement;
+    fireEvent.doubleClick(cell);
+    // The input is seeded with the full value, not the truncated cell preview.
+    expect(screen.getByDisplayValue(long)).toBeTruthy();
+  });
+
   it("commits edited text on Enter", () => {
     const onCommit = vi.fn();
     render(

--- a/frontend/src/shared/ui/EditableCell/index.tsx
+++ b/frontend/src/shared/ui/EditableCell/index.tsx
@@ -2,6 +2,7 @@
 import { useEffect, useRef, useState } from "react";
 import type { QueryValue, QueryValueKind } from "@shared";
 import { coerceQueryValue } from "@shared";
+import { MAX_PREVIEW_CHARS } from "./constants";
 
 interface Props {
   value: QueryValue | null;
@@ -93,12 +94,6 @@ function displayString(v: QueryValue | null): string {
   if (v.kind === "null") return "NULL";
   return String(v.value ?? "");
 }
-
-// Cap on the single-line preview rendered in a table cell. The full value stays
-// in `display` (used for editing) and in the row detail pane; this only bounds
-// what the grid shows so a multi-KB JSON / long text cell renders a readable
-// truncated string ("{"id":1,"name":...…") instead of a bare ellipsis.
-const MAX_PREVIEW_CHARS = 500;
 
 function previewString(s: string): string {
   // Fast path: short, single-line value needs no transformation.

--- a/frontend/src/shared/ui/EditableCell/index.tsx
+++ b/frontend/src/shared/ui/EditableCell/index.tsx
@@ -25,6 +25,7 @@ function EditableCell({
   const inputRef = useRef<HTMLInputElement>(null);
 
   const display = displayString(value);
+  const preview = previewString(display);
   const isNull = value?.kind === "null";
 
   useEffect(() => {
@@ -48,7 +49,7 @@ function EditableCell({
       <span className="mdbc-editable-cell-readonly-value"
         style={{ "--mdbc-editable-cell-readonly-color": isNull ? "var(--m-fg-4)" : "var(--m-fg, #f5f5f7)", "--mdbc-editable-cell-readonly-font-style": isNull ? "italic" : "normal" } as any}
       >
-        {display}
+        {preview}
       </span>
     );
   }
@@ -82,7 +83,7 @@ function EditableCell({
       className={[[staged ? "staged" : "", "mdbc-editable-cell-display"].filter(Boolean).join(" "), "mdbc-editable-cell-editable-value"].filter(Boolean).join(" ")}
       style={{ "--mdbc-editable-cell-editable-color": isNull ? "var(--m-fg-4)" : "var(--m-fg, #f5f5f7)", "--mdbc-editable-cell-editable-font-style": isNull ? "italic" : "normal" } as any}
     >
-      {isPendingInsert && !value ? "default" : display}
+      {isPendingInsert && !value ? "default" : preview}
     </span>
   );
 }
@@ -91,6 +92,21 @@ function displayString(v: QueryValue | null): string {
   if (!v) return "";
   if (v.kind === "null") return "NULL";
   return String(v.value ?? "");
+}
+
+// Cap on the single-line preview rendered in a table cell. The full value stays
+// in `display` (used for editing) and in the row detail pane; this only bounds
+// what the grid shows so a multi-KB JSON / long text cell renders a readable
+// truncated string ("{"id":1,"name":...…") instead of a bare ellipsis.
+const MAX_PREVIEW_CHARS = 500;
+
+function previewString(s: string): string {
+  // Fast path: short, single-line value needs no transformation.
+  if (s.length <= MAX_PREVIEW_CHARS && !/[\n\r\t]/.test(s)) return s;
+  const collapsed = s.replace(/\s+/g, " ").trim();
+  return collapsed.length > MAX_PREVIEW_CHARS
+    ? collapsed.slice(0, MAX_PREVIEW_CHARS) + "…"
+    : collapsed;
 }
 
 export {

--- a/frontend/src/shared/ui/styles/style-support.css
+++ b/frontend/src/shared/ui/styles/style-support.css
@@ -32,6 +32,10 @@
 .mdbc-editable-cell-display {
   display: block;
   cursor: text;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .mdbc-text-muted-sm {
   font-size: var(--m-fs-sm);
@@ -48,6 +52,11 @@
   font-size: var(--mdbc-db-kind-symbol-size);
 }
 .mdbc-editable-cell-readonly-value {
+  display: block;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   color: var(--mdbc-editable-cell-readonly-color);
   font-style: var(--mdbc-editable-cell-readonly-font-style);
 }


### PR DESCRIPTION
## What does this PR do?

Results viewer truncates the output completely as ... instead of showing the preview.

<img width="502" height="79" alt="image" src="https://github.com/user-attachments/assets/880d9a36-40b9-4e08-b5ad-6ad9d8348c68" />

## Checklist

- [x] I opened an issue first for non-trivial changes, or this is a small fix.
- [X] Tests added/updated and the relevant suite passes (`cargo test`, `npm test`).
- [X] For Rust dependency changes, `cargo deny check` passes.
- [X] **I license my contribution under the MIT License**, per [CONTRIBUTING.md](../CONTRIBUTING.md). I confirm this is my original work, or that I have the right to submit it.