### PR TITLE
[Feature] Add BigQuery data location in connection field

### DIFF
--- a/crates/arris-engines/src/connection/types.rs
+++ b/crates/arris-engines/src/connection/types.rs
@@ -158,6 +158,10 @@ pub struct ConnectionConfig {
     pub sasl_mechanism: Option<SaslMechanism>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub credentials_file: Option<String>,
+    /// BigQuery processing location (region/multi-region, e.g. `US`, `EU`,
+    /// `asia-northeast1`). Optional; when unset BigQuery infers it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub location: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ssh_host: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -191,6 +195,7 @@ impl ConnectionConfig {
             schema_registry_url: None,
             sasl_mechanism: None,
             credentials_file: None,
+            location: None,
             ssh_host: None,
             ssh_port: None,
             ssh_user: None,

--- a/crates/arris-engines/src/drivers/bigquery/definition.rs
+++ b/crates/arris-engines/src/drivers/bigquery/definition.rs
@@ -6,7 +6,6 @@
 //! no reconstruction. (Routines would use `INFORMATION_SCHEMA.ROUTINES`, but the
 //! schema browser never surfaces them.)
 
-use gcp_bigquery_client::model::query_request::QueryRequest;
 use gcp_bigquery_client::Client;
 
 use crate::drivers::errors::Result;
@@ -82,6 +81,7 @@ pub(super) async fn object_definition(
     client: &Client,
     project: &str,
     object: &ObjectRef,
+    location: Option<&str>,
 ) -> Result<String> {
     let sql = match object.kind {
         SchemaNodeKind::Schema => schema_ddl_sql(project, object),
@@ -89,7 +89,7 @@ pub(super) async fn object_definition(
     };
     let resp = client
         .job()
-        .query(project, QueryRequest::new(&sql))
+        .query(project, super::driver::build_query_request(&sql, location))
         .await
         .map_err(|e| DriverError::QueryFailed(format!("{e}")))?;
 

--- a/crates/arris-engines/src/drivers/bigquery/driver.rs
+++ b/crates/arris-engines/src/drivers/bigquery/driver.rs
@@ -20,6 +20,26 @@ use crate::{
 struct ConnState {
     client: Arc<Client>,
     project_id: String,
+    /// Optional BigQuery processing location (region/multi-region, e.g. `US`,
+    /// `EU`, `asia-northeast1`). When set it is threaded into every
+    /// `QueryRequest` so jobs run in the region that holds the datasets;
+    /// otherwise BigQuery infers the location and may reject cross-region jobs.
+    location: Option<String>,
+}
+
+impl ConnState {
+    /// Builds a `QueryRequest` for `sql` with this connection's location applied.
+    fn query_request(&self, sql: &str) -> QueryRequest {
+        build_query_request(sql, self.location.as_deref())
+    }
+}
+
+/// Builds a `QueryRequest` for `sql`, threading the optional BigQuery
+/// processing `location` so the job runs in the region that holds the data.
+pub(super) fn build_query_request(sql: &str, location: Option<&str>) -> QueryRequest {
+    let mut req = QueryRequest::new(sql);
+    req.location = location.map(str::to_owned);
+    req
 }
 
 pub struct BigqueryDriver {
@@ -40,6 +60,7 @@ impl BigqueryDriver {
         client: &Client,
         project: &str,
         dataset_id: &str,
+        location: Option<&str>,
     ) -> Result<Vec<(TableMeta, Vec<ColumnMeta>)>> {
         let tables_sql = format!(
             "SELECT table_name, table_type FROM `{project}.{dataset_id}`.INFORMATION_SCHEMA.TABLES"
@@ -50,7 +71,7 @@ impl BigqueryDriver {
         // list so the dataset still renders (with no tables) and every
         // accessible dataset keeps showing.
         let tables_info: Vec<(String, String)> =
-            match client.job().query(project, QueryRequest::new(&tables_sql)).await {
+            match client.job().query(project, build_query_request(&tables_sql, location)).await {
                 Ok(tables_resp) => tables_resp
                     .rows
                     .as_deref()
@@ -73,7 +94,7 @@ impl BigqueryDriver {
         );
         let mut columns_map: std::collections::HashMap<String, Vec<ColumnMeta>> =
             std::collections::HashMap::new();
-        if let Ok(resp) = client.job().query(project, QueryRequest::new(&col_sql)).await {
+        if let Ok(resp) = client.job().query(project, build_query_request(&col_sql, location)).await {
             for row in resp.rows.as_deref().unwrap_or_default() {
                 if let Some(cells) = row.columns.as_ref() {
                     if let (Some(tname), Some(cname), Some(dtype)) = (
@@ -138,9 +159,18 @@ impl DatabaseDriver for BigqueryDriver {
                 })?,
         };
 
+        let location = config
+            .location
+            .as_ref()
+            .map(|s| s.trim().to_owned())
+            .filter(|s| !s.is_empty());
+
         client
             .job()
-            .query(&config.database, QueryRequest::new("SELECT 1"))
+            .query(
+                &config.database,
+                build_query_request("SELECT 1", location.as_deref()),
+            )
             .await
             .map_err(|e| {
                 DriverError::ConnectionFailed(format!("BigQuery connection test failed: {e}"))
@@ -149,6 +179,7 @@ impl DatabaseDriver for BigqueryDriver {
         *self.inner.lock().await = Some(ConnState {
             client: Arc::new(client),
             project_id: config.database.clone(),
+            location,
         });
 
         Ok(())
@@ -173,7 +204,7 @@ impl DatabaseDriver for BigqueryDriver {
         );
         let ds_resp = client
             .job()
-            .query(project, QueryRequest::new(&ds_sql))
+            .query(project, state.query_request(&ds_sql))
             .await
             .map_err(|e| DriverError::QueryFailed(format!("Failed to list datasets: {e}")))?;
 
@@ -204,7 +235,9 @@ impl DatabaseDriver for BigqueryDriver {
         let state = guard.as_ref().ok_or(DriverError::NotConnected)?;
         let project = &state.project_id;
 
-        let tables = Self::fetch_dataset_tables(&state.client, project, schema).await?;
+        let tables =
+            Self::fetch_dataset_tables(&state.client, project, schema, state.location.as_deref())
+                .await?;
         let dataset = DatasetMeta {
             id: schema.to_owned(),
         };
@@ -226,7 +259,7 @@ impl DatabaseDriver for BigqueryDriver {
         let resp = state
             .client
             .job()
-            .query(&state.project_id, QueryRequest::new(text))
+            .query(&state.project_id, state.query_request(text))
             .await
             .map_err(|e| DriverError::QueryFailed(format!("{e}")))?;
 
@@ -255,7 +288,13 @@ impl DatabaseDriver for BigqueryDriver {
     async fn object_definition(&self, object: &crate::ObjectRef) -> Result<String> {
         let guard = self.inner.lock().await;
         let state = guard.as_ref().ok_or(DriverError::NotConnected)?;
-        super::definition::object_definition(&state.client, &state.project_id, object).await
+        super::definition::object_definition(
+            &state.client,
+            &state.project_id,
+            object,
+            state.location.as_deref(),
+        )
+        .await
     }
 
     async fn supports_explain(&self, mode: ExplainMode) -> bool {
@@ -276,7 +315,7 @@ impl DatabaseDriver for BigqueryDriver {
         let guard = self.inner.lock().await;
         let state = guard.as_ref().ok_or(DriverError::NotConnected)?;
 
-        let mut req = QueryRequest::new(text);
+        let mut req = state.query_request(text);
         req.dry_run = Some(true);
 
         let resp = state
@@ -312,7 +351,7 @@ impl DatabaseDriver for BigqueryDriver {
             table.name
         );
 
-        match state.client.job().query(&state.project_id, QueryRequest::new(&sql)).await {
+        match state.client.job().query(&state.project_id, state.query_request(&sql)).await {
             Ok(resp) => {
                 let keys: Vec<String> = resp
                     .rows
@@ -356,7 +395,7 @@ impl DatabaseDriver for BigqueryDriver {
         state
             .client
             .job()
-            .query(&state.project_id, QueryRequest::new(&inlined))
+            .query(&state.project_id, state.query_request(&inlined))
             .await
             .map_err(|e| DriverError::QueryFailed(format!("{e}")))?;
 
@@ -387,7 +426,7 @@ impl DatabaseDriver for BigqueryDriver {
             state
                 .client
                 .job()
-                .query(&state.project_id, QueryRequest::new(&inlined))
+                .query(&state.project_id, state.query_request(&inlined))
                 .await
                 .map_err(|e| DriverError::QueryFailed(format!("{e}")))?;
             result.rows_affected += 1;
@@ -417,7 +456,7 @@ impl DatabaseDriver for BigqueryDriver {
             state
                 .client
                 .job()
-                .query(&state.project_id, QueryRequest::new(&inlined))
+                .query(&state.project_id, state.query_request(&inlined))
                 .await
                 .map_err(|e| DriverError::QueryFailed(format!("{e}")))?;
             result.rows_affected += 1;
@@ -510,5 +549,18 @@ mod tests {
     fn inline_params_no_placeholders() {
         let result = inline_params("SELECT 1", vec![]);
         assert_eq!(result, "SELECT 1");
+    }
+
+    #[test]
+    fn build_query_request_applies_location() {
+        let req = build_query_request("SELECT 1", Some("EU"));
+        assert_eq!(req.location.as_deref(), Some("EU"));
+        assert_eq!(req.query, "SELECT 1");
+    }
+
+    #[test]
+    fn build_query_request_omits_location_when_none() {
+        let req = build_query_request("SELECT 1", None);
+        assert!(req.location.is_none());
     }
 }

--- a/docs/src/pages/supported-data-sources/bigquery.astro
+++ b/docs/src/pages/supported-data-sources/bigquery.astro
@@ -58,7 +58,7 @@ import DocTable from "../../components/docs/DocTable/DocTable.astro";
         <td>Path to a service account JSON key file. Leave empty to use Application Default Credentials.</td>
       </tr>
       <tr>
-        <td class="font-medium text-fg">Location</td>
+        <td class="font-medium text-fg">Data Location</td>
         <td>BigQuery processing location (region or multi-region) for your datasets, such as <code>US</code>, <code>EU</code>, or <code>asia-northeast1</code>. Leave empty to let BigQuery infer it. Set this when your datasets live outside the default region, otherwise jobs run in the wrong location and fail.</td>
       </tr>
       <tr>

--- a/docs/src/pages/supported-data-sources/bigquery.astro
+++ b/docs/src/pages/supported-data-sources/bigquery.astro
@@ -58,6 +58,10 @@ import DocTable from "../../components/docs/DocTable/DocTable.astro";
         <td>Path to a service account JSON key file. Leave empty to use Application Default Credentials.</td>
       </tr>
       <tr>
+        <td class="font-medium text-fg">Location</td>
+        <td>BigQuery processing location (region or multi-region) for your datasets, such as <code>US</code>, <code>EU</code>, or <code>asia-northeast1</code>. Leave empty to let BigQuery infer it. Set this when your datasets live outside the default region, otherwise jobs run in the wrong location and fail.</td>
+      </tr>
+      <tr>
         <td class="font-medium text-fg">Options</td>
         <td>Additional parameters as <code>key1=val1&amp;key2=val2</code>.</td>
       </tr>

--- a/frontend/src/domains/connection/components/CombinedConnectionsTree/types.ts
+++ b/frontend/src/domains/connection/components/CombinedConnectionsTree/types.ts
@@ -32,6 +32,7 @@ interface ConnectionConfig {
   schemaRegistryURL?: string;
   saslMechanism?: SaslMechanism;
   credentialsFile?: string;
+  location?: string;
   sshHost?: string;
   sshPort?: number;
   sshUser?: string;

--- a/frontend/src/domains/connection/components/ConnectionEditorSheet/fields/bigquery.tsx
+++ b/frontend/src/domains/connection/components/ConnectionEditorSheet/fields/bigquery.tsx
@@ -17,6 +17,14 @@ function BigqueryFields({ config, patch }: FieldsProps) {
           testId="bigquery-credentials-browse"
         />
       </FormRow>
+      <FormRow label="Location">
+        <Field
+          value={config.location ?? ""}
+          onChange={(v) => patch("location", v)}
+          monospace
+          placeholder="US, EU, asia-northeast1"
+        />
+      </FormRow>
       <FormRow label="Options">
         <Field value={config.options} onChange={(v) => patch("options", v)} monospace placeholder="key=val&key=val" />
       </FormRow>

--- a/frontend/src/domains/connection/components/ConnectionEditorSheet/fields/bigquery.tsx
+++ b/frontend/src/domains/connection/components/ConnectionEditorSheet/fields/bigquery.tsx
@@ -17,7 +17,7 @@ function BigqueryFields({ config, patch }: FieldsProps) {
           testId="bigquery-credentials-browse"
         />
       </FormRow>
-      <FormRow label="Location">
+      <FormRow label="Data Location">
         <Field
           value={config.location ?? ""}
           onChange={(v) => patch("location", v)}

--- a/frontend/src/domains/connection/components/ConnectionEditorSheet/index.test.tsx
+++ b/frontend/src/domains/connection/components/ConnectionEditorSheet/index.test.tsx
@@ -472,3 +472,19 @@ describe("ConnectionEditorSheet save scope", () => {
     }
   });
 });
+
+describe("ConnectionEditorSheet bigquery location field", () => {
+  it("persists the BigQuery Location into the saved config", async () => {
+    saveConnectionMock.mockClear();
+    render(<ConnectionEditorSheet open={true} onClose={() => {}} initial={null} kind="bigquery" />);
+
+    fireEvent.change(screen.getByPlaceholderText("US, EU, asia-northeast1"), {
+      target: { value: "EU" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(saveConnectionMock).toHaveBeenCalledTimes(1));
+    const savedConfig = saveConnectionMock.mock.calls[0][0] as Record<string, unknown>;
+    expect(savedConfig.location).toBe("EU");
+  });
+});

--- a/frontend/src/shared/backendTypes.ts
+++ b/frontend/src/shared/backendTypes.ts
@@ -52,6 +52,7 @@ interface ConnectionConfig {
   schemaRegistryURL?: string;
   saslMechanism?: SaslMechanism;
   credentialsFile?: string;
+  location?: string;
   sshHost?: string;
   sshPort?: number;
   sshUser?: string;


### PR DESCRIPTION
## What does this PR do?

BigQuery jobs default to the US multi-region when no location is set, so connections whose datasets live in EU or a specific region failed with cross-region errors and had no way to specify the region.

Add an optional Location connection field that threads into every `QueryRequest` via a single build_query_request helper, so jobs run in the region that holds the datasets.

## Checklist

- [X] I opened an issue first for non-trivial changes, or this is a small fix.
- [X] Tests added/updated and the relevant suite passes (`cargo test`, `npm test`).
- [X] For Rust dependency changes, `cargo deny check` passes.
- [X] **I license my contribution under the MIT License**, per [CONTRIBUTING.md](../CONTRIBUTING.md). I confirm this is my original work, or that I have the right to submit it.
