### PR TITLE
[Clean-up] Add status badges to README and fix src-tauri license

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -45,8 +45,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # System libraries required to compile the Tauri shell on Linux.
-      - name: Install Tauri system dependencies
+      # System libraries required to compile the Tauri shell and native driver
+      # deps on Linux. libcurl is needed by librdkafka (rdkafka-sys) for its
+      # SASL OAUTHBEARER OIDC support, which includes <curl/curl.h>.
+      - name: Install system dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y \
@@ -55,6 +57,7 @@ jobs:
             libayatana-appindicator3-dev \
             librsvg2-dev \
             libssl-dev \
+            libcurl4-openssl-dev \
             libxdo-dev \
             build-essential \
             file \

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -79,8 +79,11 @@ jobs:
 
       # Unit + doc tests only. Integration tests (tests/*_integration.rs) spin up
       # real database containers and are run separately, not on every PR.
-      - name: Test (unit + doc)
-        run: cargo test --workspace --lib --bins --doc
+      # --doc cannot be combined with --lib/--bins, so run it as its own step.
+      - name: Test (unit)
+        run: cargo test --workspace --lib --bins
+      - name: Test (doc)
+        run: cargo test --workspace --doc
 
       - name: Supply-chain audit
         run: cargo deny check

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2040,9 +2040,9 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.7.3"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42a0d26b245348befa0c121944541476763dcc46ede886c88f9d12e1697d27c3"
+checksum = "1a52aa3fcda4e6302a9f48734f234d35d4721b96f8fe07d073f07ce9df4f0271"
 dependencies = [
  "cpubits",
  "ctutils",
@@ -4473,9 +4473,9 @@ checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.11"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
 dependencies = [
  "ctutils",
  "subtle",
@@ -8379,7 +8379,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",

--- a/README.md
+++ b/README.md
@@ -10,6 +10,14 @@
   <a href="https://github.com/arrisdb/arris/releases/latest/download/Arris-x64.dmg"><b>Download for Intel</b></a>
 </p>
 
+<p align="center">
+  <a href="https://github.com/arrisdb/arris/releases/latest"><img alt="Latest version" src="https://img.shields.io/github/v/release/arrisdb/arris?label=version&color=blue"></a>
+  &nbsp;
+  <a href="https://github.com/arrisdb/arris/actions/workflows/rust.yml"><img alt="Rust tests" src="https://img.shields.io/github/actions/workflow/status/arrisdb/arris/rust.yml?branch=main&label=Rust%20tests"></a>
+  &nbsp;
+  <a href="https://github.com/arrisdb/arris/actions/workflows/frontend.yml"><img alt="Frontend tests" src="https://img.shields.io/github/actions/workflow/status/arrisdb/arris/frontend.yml?branch=main&label=Frontend%20tests"></a>
+</p>
+
 ---
 
 Arris is a desktop data workbench for working with all the most popular database engines. Unlike many database clients that lean heavily on the JVM and consume large amounts of memory, Arris is built on a Rust backend with Rust-based drivers, keeping the app lightweight and fast.

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -2,7 +2,7 @@
 name = "arris-tauri"
 version = "0.6.0"
 edition = "2024"
-license = "MIT"
+license = "AGPL-3.0-only"
 description = "Tauri 2 shell wrapping `arris-engines` command handlers."
 
 [[bin]]


### PR DESCRIPTION
## What does this PR do?

Add version, Rust-tests, and frontend-tests badges to the README header. Correct src-tauri/Cargo.toml license from MIT to AGPL-3.0-only to match the workspace license and the project's stated AGPL-3.0 licensing.

Folding CI changes and cargo version bumps in this PR to resolve minor CI issues.

## Checklist

- [X] I opened an issue first for non-trivial changes, or this is a small fix.
- [ ] Tests added/updated for my change. (N/A)
- [X] **I license my contribution under the MIT License**, per [CONTRIBUTING.md](../CONTRIBUTING.md). I confirm this is my original work, or that I have the right to submit it.
