### PR TITLE
[Feature] Canvas foundation

### DIFF
--- a/crates/arris-engines/src/agent/impl_agent_engine.rs
+++ b/crates/arris-engines/src/agent/impl_agent_engine.rs
@@ -2,10 +2,10 @@
 //!
 //! Each turn builds a self-contained prompt (role + schema + the user's request),
 //! spawns the selected provider's CLI (`codex` or `claude`) in a read-only mode,
-//! and streams its parsed events as [`AgentEvent`]s. The agent only writes or
-//! explains SQL — it needs no live database access, so there is no MCP server:
-//! the schema is inlined into the prompt and the CLI runs with file writes and
-//! tools disabled.
+//! and streams its parsed events as [`AgentEvent`]s. The [`AgentProfile`] selects
+//! the prompt: write/explain SQL, or design canvas objects. Either way the agent
+//! needs no live database access, so there is no MCP server: the schema is
+//! inlined into the prompt and the CLI runs with file writes and tools disabled.
 
 use std::fmt::Write as _;
 use std::path::PathBuf;
@@ -17,7 +17,7 @@ use tokio::sync::{mpsc, oneshot};
 
 use super::constants::SCHEMA_PROMPT_MAX_BYTES;
 use super::errors::AgentError;
-use super::types::{AgentEvent, AgentProvider};
+use super::types::{AgentEvent, AgentProfile, AgentProvider};
 use crate::{DatabaseKind, Engine, SchemaNode, SchemaNodeKind};
 
 /// Orchestrates agentic SQL sessions for writing and explaining queries.
@@ -43,6 +43,7 @@ impl AgentEngine {
     pub async fn send(
         &self,
         provider: AgentProvider,
+        profile: AgentProfile,
         dialect: Option<DatabaseKind>,
         schema_ddl: String,
         user_prompt: String,
@@ -50,7 +51,7 @@ impl AgentEngine {
         cancel: oneshot::Receiver<()>,
     ) -> Result<mpsc::Receiver<AgentEvent>, AgentError> {
         let (tx, rx) = mpsc::channel(64);
-        let prompt = Self::build_prompt(dialect, &schema_ddl, &user_prompt);
+        let prompt = Self::build_prompt(profile, dialect, &schema_ddl, &user_prompt);
         let cwd = Self::working_dir()?;
         let cli = provider.cli();
         let binary = cli.binary();
@@ -154,21 +155,36 @@ impl AgentEngine {
 // ── prompt construction ──────────────────────────────────────────────────────
 
 impl AgentEngine {
-    /// Build the full prompt: role, schema snapshot, rules, and the user's
-    /// request. Self-contained so the turn needs no tools or file access.
+    /// Build the full prompt for `profile`: role, schema snapshot, rules, and the
+    /// user's request. Self-contained so the turn needs no tools or file access.
     pub(super) fn build_prompt(
+        profile: AgentProfile,
         dialect: Option<DatabaseKind>,
         schema_ddl: &str,
         user_prompt: &str,
     ) -> String {
         let name = dialect.map(Self::dialect_name).unwrap_or("SQL");
-        let schema = if schema_ddl.len() > SCHEMA_PROMPT_MAX_BYTES {
+        let schema = Self::clamp_schema(schema_ddl);
+        match profile {
+            AgentProfile::Sql => Self::build_sql_prompt(name, &schema, user_prompt),
+            AgentProfile::Canvas => Self::build_canvas_prompt(name, &schema, user_prompt),
+        }
+    }
+
+    /// Trim the inlined schema DDL to [`SCHEMA_PROMPT_MAX_BYTES`] so a large
+    /// database cannot blow the model's context window.
+    fn clamp_schema(schema_ddl: &str) -> String {
+        if schema_ddl.len() > SCHEMA_PROMPT_MAX_BYTES {
             let mut truncated: String = schema_ddl.chars().take(SCHEMA_PROMPT_MAX_BYTES).collect();
             truncated.push_str("\n-- (schema truncated)\n");
             truncated
         } else {
             schema_ddl.to_string()
-        };
+        }
+    }
+
+    /// The query-assistant prompt: write or explain one SQL block.
+    fn build_sql_prompt(name: &str, schema: &str, user_prompt: &str) -> String {
         format!(
             "You are a SQL assistant embedded in a database client. You ONLY write \
              or explain SQL queries for the user's {name} database — nothing else. \
@@ -182,6 +198,51 @@ impl AgentEngine {
              - When asked to explain a query, describe what it does in plain prose; \
              include SQL only if you are proposing a revision.\n\
              - You cannot execute anything — never claim you ran a query.\n\n\
+             # Request\n\
+             {user_prompt}\n",
+        )
+    }
+
+    /// The canvas prompt: design analytics objects and emit them as one
+    /// `arris-canvas` JSON block. The client parses the block, creates the
+    /// objects, runs each query object, and binds charts to their source query's
+    /// results. The contract mirrors the frontend `CanvasComponent` union.
+    fn build_canvas_prompt(name: &str, schema: &str, user_prompt: &str) -> String {
+        format!(
+            "You design analytics objects on a visual canvas inside a database \
+             client, for the user's {name} database. You do not chat at length and \
+             you cannot run shell commands, read files, or execute queries.\n\n\
+             # Database schema ({name})\n\
+             {schema}\n\n\
+             # Output contract\n\
+             Reply with ONE fenced code block tagged `arris-canvas` containing a \
+             single JSON object, optionally preceded by one short sentence of \
+             prose. The JSON has this shape:\n\
+             ```arris-canvas\n\
+             {{\n\
+             \x20 \"components\": [\n\
+             \x20   {{ \"kind\": \"query\", \"id\": \"q1\", \"title\": \"<label>\", \"sql\": \"<one {name} statement>\" }},\n\
+             \x20   {{ \"kind\": \"chart\", \"id\": \"c1\", \"sourceQueryId\": \"q1\",\n\
+             \x20     \"spec\": {{ \"kind\": \"bar\", \"xColumn\": \"<col>\", \"yColumns\": [\"<col>\"], \"seriesColumn\": \"<col?>\", \"aggregation\": \"sum\", \"title\": \"<title>\", \"style\": {{ \"stackMode\": \"stacked\" }} }} }},\n\
+             \x20   {{ \"kind\": \"text\", \"id\": \"t1\", \"text\": \"## Heading\\nMarkdown commentary.\" }}\n\
+             \x20 ],\n\
+             \x20 \"edges\": [ {{ \"id\": \"e1\", \"source\": \"q1\", \"target\": \"c1\" }} ]\n\
+             }}\n\
+             ```\n\n\
+             # Rules\n\
+             - Use dialect-appropriate {name} syntax and only the tables/columns above.\n\
+             - Every `chart` MUST set `sourceQueryId` to the `id` of a `query` in the \
+             same block; `xColumn`/`yColumns`/`seriesColumn` MUST be columns that \
+             query returns. `spec.kind` is one of bar, line, area, pie, scatter, \
+             combo, donut, radar, treemap, funnel, kpi. Omit `seriesColumn` and \
+             `style` when not needed; `aggregation` is one of none, sum, avg, min, \
+             max, count.\n\
+             - Each `query.sql` is exactly one statement, no trailing semicolon, no \
+             comments. Prefer a single query that returns tidy rows for charting \
+             (e.g. group by the x bucket and the series column).\n\
+             - Add a short `text` object summarising the finding. Do not invent ids; \
+             reference queries only by ids you defined. Positions/sizes are optional \
+             (the client lays objects out). Emit nothing after the closing fence.\n\n\
              # Request\n\
              {user_prompt}\n",
         )
@@ -314,6 +375,7 @@ mod tests {
     #[test]
     fn build_prompt_inlines_schema_and_request() {
         let prompt = AgentEngine::build_prompt(
+            AgentProfile::Sql,
             Some(DatabaseKind::Postgres),
             "CREATE TABLE users (id INT);",
             "list all users",
@@ -327,7 +389,7 @@ mod tests {
     #[test]
     fn build_prompt_without_dialect_uses_generic_sql() {
         // No connection selected: the agent still writes/explains generic SQL.
-        let prompt = AgentEngine::build_prompt(None, "", "write a select");
+        let prompt = AgentEngine::build_prompt(AgentProfile::Sql, None, "", "write a select");
         assert!(prompt.contains("SQL"));
         assert!(!prompt.contains("PostgreSQL"));
         assert!(prompt.contains("write a select"));
@@ -336,7 +398,39 @@ mod tests {
     #[test]
     fn build_prompt_truncates_oversized_schema() {
         let huge = "x".repeat(SCHEMA_PROMPT_MAX_BYTES + 1000);
-        let prompt = AgentEngine::build_prompt(Some(DatabaseKind::Sqlite), &huge, "go");
+        let prompt = AgentEngine::build_prompt(
+            AgentProfile::Sql,
+            Some(DatabaseKind::Sqlite),
+            &huge,
+            "go",
+        );
+        assert!(prompt.contains("(schema truncated)"));
+    }
+
+    #[test]
+    fn canvas_prompt_describes_object_contract() {
+        let prompt = AgentEngine::build_prompt(
+            AgentProfile::Canvas,
+            Some(DatabaseKind::Postgres),
+            "CREATE TABLE orders (id INT, ordered_at TIMESTAMP, category TEXT, total NUMERIC);",
+            "monthly sales by category",
+        );
+        // Schema and request are inlined.
+        assert!(prompt.contains("PostgreSQL"));
+        assert!(prompt.contains("CREATE TABLE orders"));
+        assert!(prompt.contains("monthly sales by category"));
+        // The canvas contract markers are present (and it is NOT the SQL prompt).
+        assert!(prompt.contains("```arris-canvas"));
+        assert!(prompt.contains("sourceQueryId"));
+        assert!(prompt.contains("\"kind\": \"query\""));
+        assert!(prompt.contains("\"kind\": \"chart\""));
+        assert!(!prompt.contains("return exactly one ```sql fenced block"));
+    }
+
+    #[test]
+    fn canvas_prompt_truncates_oversized_schema() {
+        let huge = "x".repeat(SCHEMA_PROMPT_MAX_BYTES + 1000);
+        let prompt = AgentEngine::build_prompt(AgentProfile::Canvas, None, &huge, "go");
         assert!(prompt.contains("(schema truncated)"));
     }
 }

--- a/crates/arris-engines/src/agent/mod.rs
+++ b/crates/arris-engines/src/agent/mod.rs
@@ -6,4 +6,4 @@ mod types;
 
 pub use errors::*;
 pub use impl_agent_engine::AgentEngine;
-pub use types::{AgentEvent, AgentProvider};
+pub use types::{AgentEvent, AgentProfile, AgentProvider};

--- a/crates/arris-engines/src/agent/types.rs
+++ b/crates/arris-engines/src/agent/types.rs
@@ -28,6 +28,21 @@ impl std::fmt::Display for AgentProvider {
     }
 }
 
+// ── agent profile (which prompt the turn uses) ───────────────────────────────
+
+/// Which task the agent turn serves, selecting the system prompt. `Sql` is the
+/// query-assistant prompt (write/explain one SQL block); `Canvas` instructs the
+/// agent to emit a structured `arris-canvas` block describing canvas objects to
+/// create (query/chart/text). Defaults to `Sql` so existing callers are
+/// unaffected.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentProfile {
+    #[default]
+    Sql,
+    Canvas,
+}
+
 // ── streamed agent events (forwarded to the frontend) ────────────────────────
 
 /// A single event parsed from a provider's streamed output, forwarded to the

--- a/docs/src/data/docs-nav.ts
+++ b/docs/src/data/docs-nav.ts
@@ -76,6 +76,7 @@ const docsNav: NavGroup[] = [
     title: "AI",
     items: [
       { label: "AI Agent", href: "/ai/agent" },
+      { label: "Canvas", href: "/ai/canvas" },
     ],
   },
   {

--- a/docs/src/pages/ai/agent.astro
+++ b/docs/src/pages/ai/agent.astro
@@ -21,7 +21,7 @@ import Screenshot from "../../components/docs/Screenshot/Screenshot.astro";
   ]}
   currentPath="/ai/agent"
   prev={{ label: "SQLMesh", href: "/analytics-engineering/sqlmesh", section: "Analytics engineering" }}
-  next={{ label: "Keyboard shortcuts", href: "/reference/shortcuts", section: "Reference" }}
+  next={{ label: "Canvas", href: "/ai/canvas", section: "AI" }}
 >
   <h2 id="cli">Choosing a provider</h2>
 

--- a/docs/src/pages/ai/canvas.astro
+++ b/docs/src/pages/ai/canvas.astro
@@ -1,0 +1,133 @@
+---
+import "../../styles/global.css";
+import DocsLayout from "../../layouts/DocsLayout.astro";
+import DocTable from "../../components/docs/DocTable/DocTable.astro";
+---
+
+<!--
+  Screenshots to capture for this page (use the shared Screenshot component):
+  - The canvas board with an agent-generated query + chart + text, and the
+    Agent panel on the left.
+  - The New Canvas (+) button in the editor tab bar.
+-->
+
+<DocsLayout
+  title="Canvas - Arris Docs"
+  breadcrumbs={[{ label: "Docs", href: "/" }, { label: "AI" }, { label: "Canvas" }]}
+  heading="Canvas"
+  lede="A visual board where you chat with an AI agent that reads your schema and builds analytics objects for you: a query that runs, a chart of its results, and text that explains them."
+  tocItems={[
+    { label: "What the canvas is", href: "#overview" },
+    { label: "Opening a canvas", href: "#opening" },
+    { label: "Objects", href: "#objects" },
+    { label: "Building with the agent", href: "#agent" },
+    { label: "Working on the board", href: "#board" },
+    { label: "Saving", href: "#saving" },
+  ]}
+  currentPath="/ai/canvas"
+  prev={{ label: "AI Agent", href: "/ai/agent", section: "AI" }}
+  next={{ label: "Keyboard shortcuts", href: "/reference/shortcuts", section: "Reference" }}
+>
+  <h2 id="overview">What the canvas is</h2>
+
+  <p>
+    The canvas is an infinite, freeform board (pan, zoom, and drag) where the unit of work is an
+    <strong>object</strong> rather than a single query tab. Each object sits at its own position and
+    size and can overlap its neighbours. An object is one of four kinds today: a <strong>query</strong>
+    that runs SQL and shows its rows, a <strong>chart</strong> that visualizes another query's
+    results, a block of <strong>text</strong>, or a simple <strong>shape</strong>. The kinds are
+    designed to grow, so more object types can be added later.
+  </p>
+
+  <p>
+    The point of the board is to assemble an analysis you can see all at once: the query that pulls
+    the data, the chart that makes it legible, and the commentary that explains it, side by side. You
+    can build that by hand, but the fastest path is to ask the agent.
+  </p>
+
+  <h2 id="opening">Opening a canvas</h2>
+
+  <p>
+    Open a new board with the <strong>New Canvas</strong> button (the sparkles icon) in the editor
+    tab bar, or run the <strong>New Canvas</strong> command from the keymap. A canvas opens as a
+    center tab, just like a query or a notebook, and you can rename it. The board inherits the
+    connection that is currently selected, so its query objects and the agent both target that
+    database; pick a connection before creating the canvas if you want a specific one.
+  </p>
+
+  <h2 id="objects">Objects</h2>
+
+  <DocTable>
+    <thead>
+      <tr>
+        <th>Object</th>
+        <th>What it does</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td class="font-medium text-fg">Query</td>
+        <td>
+          Holds one SQL statement with a <strong>Run</strong> button and a compact result grid. It
+          runs against the canvas's connection, the same engine the editor uses.
+        </td>
+      </tr>
+      <tr>
+        <td class="font-medium text-fg">Chart</td>
+        <td>
+          Visualizes a query object's results. A chart is bound to its source query, so when that
+          query runs the chart updates. It uses the same chart engine as the results viewer.
+        </td>
+      </tr>
+      <tr>
+        <td class="font-medium text-fg">Text</td>
+        <td>Free text for headings and commentary. Click to edit in place.</td>
+      </tr>
+      <tr>
+        <td class="font-medium text-fg">Shape</td>
+        <td>A rectangle, ellipse, or line for grouping and annotation.</td>
+      </tr>
+    </tbody>
+  </DocTable>
+
+  <h2 id="agent">Building with the agent</h2>
+
+  <p>
+    The <strong>Agent</strong> panel runs down the left of the board. Type a request, for example
+    <em>"monthly sales by category"</em>, and the agent reads the connection's schema and replies
+    with a set of objects to add. A typical answer is a query object (the SQL that aggregates your
+    data), a chart object bound to it, and a short text summary. Arris places the new objects on the
+    board, runs the query automatically, and the chart renders from the result.
+  </p>
+
+  <p>
+    The agent uses Anthropic's <strong>Claude CLI</strong> (<code>claude -p</code>) under the same
+    guardrails as the SQL agent: it runs locally in a read-only mode, never touches your filesystem,
+    and only receives your prompt plus the connection's <strong>schema as DDL</strong> and dialect
+    (capped in size). Your row data is not sent. Because the agent needs the schema to write correct
+    SQL, the chat asks you to connect a database to the canvas first.
+  </p>
+
+  <p>
+    Follow-up messages refine the same board: ask for a different chart type, another breakdown, or a
+    second query, and the new objects are added alongside the existing ones.
+  </p>
+
+  <h2 id="board">Working on the board</h2>
+
+  <ul>
+    <li><strong>Move</strong> an object by dragging it; objects may overlap.</li>
+    <li><strong>Pan</strong> by dragging the empty canvas, and <strong>zoom</strong> with the scroll wheel or the controls in the corner.</li>
+    <li><strong>Add</strong> a text or shape object by hand from the toolbar in the top-left.</li>
+    <li><strong>Delete</strong> a selected object with <kbd>Delete</kbd> or <kbd>Backspace</kbd>.</li>
+    <li><strong>Run</strong> a query object at any time with its Run button to refresh the charts bound to it.</li>
+  </ul>
+
+  <h2 id="saving">Saving</h2>
+
+  <p>
+    A board is saved with your workspace, so it survives closing and reopening the tab and restarting
+    Arris. Query results are not saved with the board; reopen a canvas and run its query objects to
+    refresh the data.
+  </p>
+</DocsLayout>

--- a/frontend/src/domains/canvas/components/CanvasAgentChat/hooks.test.ts
+++ b/frontend/src/domains/canvas/components/CanvasAgentChat/hooks.test.ts
@@ -1,0 +1,105 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { EditorTab } from "@shell/types";
+
+const hoisted = vi.hoisted(() => ({
+  handler: null as null | ((e: unknown) => void),
+}));
+
+vi.mock("./ipc", () => ({
+  sendCanvasAgentIPC: vi.fn().mockResolvedValue(undefined),
+  cancelCanvasAgentIPC: vi.fn().mockResolvedValue(undefined),
+  listenCanvasAgentEventsIPC: vi.fn((h: (e: unknown) => void) => {
+    hoisted.handler = h;
+    return Promise.resolve(() => {});
+  }),
+}));
+
+vi.mock("../../ipc", () => ({
+  runCanvasQueryIPC: vi.fn().mockResolvedValue({ columns: [], rows: [], elapsed: 0 }),
+}));
+
+import { runCanvasQueryIPC } from "../../ipc";
+import { useCanvasStore } from "../../hooks";
+import { sendCanvasAgentIPC } from "./ipc";
+import { useCanvasAgentChat } from "./hooks";
+
+const TAB = "tab-1";
+const withConn = { id: TAB, text: "", connectionId: "conn-1" } as unknown as EditorTab;
+const noConn = { id: TAB, text: "" } as unknown as EditorTab;
+
+const reply = (json: unknown) =>
+  "Building it now.\n```arris-canvas\n" + JSON.stringify(json) + "\n```";
+
+function fire(event: Record<string, unknown>) {
+  act(() => hoisted.handler?.(event));
+}
+
+describe("useCanvasAgentChat", () => {
+  beforeEach(() => {
+    useCanvasStore.setState({ boards: {} });
+    useCanvasStore.getState().ensureBoard(TAB, "");
+    vi.clearAllMocks();
+    hoisted.handler = null;
+  });
+
+  it("dispatches a canvas turn and shows a user + pending agent entry", () => {
+    const { result } = renderHook(() => useCanvasAgentChat(withConn));
+    act(() => result.current.send("monthly sales by category"));
+    expect(sendCanvasAgentIPC).toHaveBeenCalledTimes(1);
+    expect(result.current.entries).toHaveLength(2);
+    expect(result.current.entries[0]).toMatchObject({ role: "user" });
+    expect(result.current.entries[1]).toMatchObject({ role: "agent", pending: true });
+    expect(result.current.streaming).toBe(true);
+  });
+
+  it("warns and does not dispatch when the canvas has no connection", () => {
+    const { result } = renderHook(() => useCanvasAgentChat(noConn));
+    act(() => result.current.send("do something"));
+    expect(sendCanvasAgentIPC).not.toHaveBeenCalled();
+    expect(result.current.streaming).toBe(false);
+    expect(result.current.entries.at(-1)?.text).toMatch(/Connect a database/);
+  });
+
+  it("on done, parses the spec into objects and auto-runs the query", async () => {
+    const { result } = renderHook(() => useCanvasAgentChat(withConn));
+    act(() => result.current.send("monthly sales by category"));
+    const turnId = vi.mocked(sendCanvasAgentIPC).mock.calls[0][0].turnId;
+
+    fire({
+      turn_id: turnId,
+      kind: "message",
+      text: reply({
+        components: [
+          { kind: "query", id: "q1", sql: "select category, sum(total) t from orders group by 1" },
+          {
+            kind: "chart",
+            id: "c1",
+            sourceQueryId: "q1",
+            spec: { kind: "bar", xColumn: "category", yColumns: ["t"] },
+          },
+          { kind: "text", id: "t1", text: "## Sales" },
+        ],
+        edges: [],
+      }),
+    });
+    await act(async () => {
+      hoisted.handler?.({ turn_id: turnId, kind: "done" });
+      await Promise.resolve();
+    });
+
+    const board = useCanvasStore.getState().boards[TAB];
+    expect(board.doc.components).toHaveLength(3);
+    expect(vi.mocked(runCanvasQueryIPC)).toHaveBeenCalledWith("conn-1", expect.any(String));
+    expect(result.current.streaming).toBe(false);
+    expect(result.current.entries.at(-1)?.text).toMatch(/Added 3 objects/);
+  });
+
+  it("ignores events from a different turn", () => {
+    const { result } = renderHook(() => useCanvasAgentChat(withConn));
+    act(() => result.current.send("hi"));
+    fire({ turn_id: "some-other-turn", kind: "done" });
+    // Still streaming: the foreign done was ignored.
+    expect(result.current.streaming).toBe(true);
+  });
+});

--- a/frontend/src/domains/canvas/components/CanvasAgentChat/hooks.ts
+++ b/frontend/src/domains/canvas/components/CanvasAgentChat/hooks.ts
@@ -1,0 +1,163 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import type { EditorTab } from "@shell/types";
+
+import { CANVAS_SPEC_FENCE } from "../../constants";
+import { useCanvasStore } from "../../hooks";
+import { genId, parseAgentCanvas } from "../../utils";
+import {
+  cancelCanvasAgentIPC,
+  listenCanvasAgentEventsIPC,
+  sendCanvasAgentIPC,
+} from "./ipc";
+import type { CanvasAgentEventEnvelope } from "./ipc";
+import type { ChatEntry } from "./types";
+
+/// Strip the arris-canvas fenced block from the agent's reply so the chat shows
+/// only the prose. Used for the streaming bubble and the final fallback text.
+function displayText(raw: string): string {
+  const re = new RegExp("```" + CANVAS_SPEC_FENCE + "[\\s\\S]*?```", "g");
+  return raw.replace(re, "").trim();
+}
+
+function errToString(err: unknown): string {
+  if (typeof err === "string") return err;
+  if (err instanceof Error) return err.message;
+  return String(err);
+}
+
+/// Drive the canvas chat: send a prompt as a canvas-profile agent turn, stream
+/// the reply, and on completion parse the arris-canvas block into board objects,
+/// auto-running any query objects. Filters `agent-event`s to its own turn so it
+/// never picks up the SQL chat's turns.
+function useCanvasAgentChat(tab: EditorTab) {
+  const tabId = tab.id;
+  const connectionId = tab.connectionId ?? null;
+
+  const [entries, setEntries] = useState<ChatEntry[]>([]);
+  const [streaming, setStreaming] = useState(false);
+
+  const turnIdRef = useRef<string | null>(null);
+  const agentEntryIdRef = useRef<string | null>(null);
+  const accumRef = useRef("");
+  const sessionRef = useRef<string | null>(null);
+
+  const setAgentText = useCallback((text: string, pending: boolean) => {
+    const id = agentEntryIdRef.current;
+    if (!id) return;
+    setEntries((prev) => prev.map((e) => (e.id === id ? { ...e, text, pending } : e)));
+  }, []);
+
+  const endTurn = useCallback(() => {
+    turnIdRef.current = null;
+    setStreaming(false);
+  }, []);
+
+  const handleEvent = useCallback(
+    (evt: CanvasAgentEventEnvelope) => {
+      if (!turnIdRef.current || evt.turn_id !== turnIdRef.current) return;
+      switch (evt.kind) {
+        case "session_started":
+          if (evt.session_id) sessionRef.current = evt.session_id;
+          return;
+        case "message":
+          if (evt.text) {
+            accumRef.current += evt.text;
+            setAgentText(displayText(accumRef.current) || "Working…", true);
+          }
+          return;
+        case "error":
+          setAgentText(`Error: ${evt.message ?? "the agent failed."}`, false);
+          endTurn();
+          return;
+        case "done": {
+          const spec = parseAgentCanvas(accumRef.current);
+          if (spec) {
+            const queryIds = useCanvasStore
+              .getState()
+              .applyAgentSpec(tabId, spec, connectionId);
+            for (const id of queryIds) {
+              void useCanvasStore.getState().runQueryComponent(tabId, id);
+            }
+            const n = spec.components.length;
+            const prose = displayText(accumRef.current);
+            const summary = `Added ${n} object${n === 1 ? "" : "s"} to the canvas.`;
+            setAgentText(prose ? `${prose}\n\n${summary}` : summary, false);
+          } else {
+            setAgentText(displayText(accumRef.current) || "No objects were generated.", false);
+          }
+          endTurn();
+          return;
+        }
+        default:
+          return;
+      }
+    },
+    [connectionId, endTurn, setAgentText, tabId],
+  );
+
+  useEffect(() => {
+    let active = true;
+    let unlisten: (() => void) | null = null;
+    listenCanvasAgentEventsIPC(handleEvent).then((un) => {
+      if (active) unlisten = un;
+      else un();
+    });
+    return () => {
+      active = false;
+      unlisten?.();
+    };
+  }, [handleEvent]);
+
+  const send = useCallback(
+    (prompt: string) => {
+      const text = prompt.trim();
+      if (!text || streaming) return;
+      if (!connectionId) {
+        setEntries((prev) => [
+          ...prev,
+          { id: genId("msg"), role: "user", text },
+          {
+            id: genId("msg"),
+            role: "agent",
+            text: "Connect a database to this canvas first so I can read its schema.",
+          },
+        ]);
+        return;
+      }
+      const turnId = genId("turn");
+      turnIdRef.current = turnId;
+      accumRef.current = "";
+      const agentId = genId("msg");
+      agentEntryIdRef.current = agentId;
+      setEntries((prev) => [
+        ...prev,
+        { id: genId("msg"), role: "user", text },
+        { id: agentId, role: "agent", text: "Working…", pending: true },
+      ]);
+      setStreaming(true);
+      sendCanvasAgentIPC({
+        connectionId,
+        prompt: text,
+        turnId,
+        resumeSession: sessionRef.current,
+      }).catch((e) => {
+        setAgentText(`Error: ${errToString(e)}`, false);
+        endTurn();
+      });
+    },
+    [connectionId, endTurn, setAgentText, streaming],
+  );
+
+  const cancel = useCallback(() => {
+    const turnId = turnIdRef.current;
+    if (!turnId) return;
+    void cancelCanvasAgentIPC(turnId);
+    setAgentText("Stopped.", false);
+    endTurn();
+  }, [endTurn, setAgentText]);
+
+  return { cancel, connectionId, entries, send, streaming };
+}
+
+export { useCanvasAgentChat };

--- a/frontend/src/domains/canvas/components/CanvasAgentChat/index.css
+++ b/frontend/src/domains/canvas/components/CanvasAgentChat/index.css
@@ -1,0 +1,94 @@
+.mdbc-canvas-chat {
+  flex: 0 0 320px;
+  width: 320px;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  background: var(--m-bg-sidebar);
+  border-right: 1px solid var(--m-sep);
+  font-family: var(--m-font);
+}
+
+.mdbc-canvas-chat-head {
+  flex: 0 0 auto;
+  padding: 10px;
+  border-bottom: 1px solid var(--m-sep);
+}
+
+.mdbc-canvas-chat-title {
+  font-size: var(--m-fs-sm);
+  font-weight: 600;
+  color: var(--m-fg-2);
+}
+
+.mdbc-canvas-chat-log {
+  flex: 1 1 auto;
+  overflow-y: auto;
+  padding: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.mdbc-canvas-chat-empty {
+  color: var(--m-fg-3);
+  font-size: var(--m-fs-xs);
+  line-height: 1.5;
+}
+
+.mdbc-canvas-chat-msg {
+  font-size: var(--m-fs-sm);
+  line-height: 1.45;
+  white-space: pre-wrap;
+  border-radius: var(--m-r-md);
+  padding: 8px 10px;
+  max-width: 100%;
+  word-break: break-word;
+}
+
+.mdbc-canvas-chat-msg.user {
+  align-self: flex-end;
+  background: var(--m-accent-tint);
+  color: var(--m-fg);
+}
+
+.mdbc-canvas-chat-msg.agent {
+  align-self: flex-start;
+  background: var(--m-bg-card);
+  border: 1px solid var(--m-sep);
+  color: var(--m-fg);
+}
+
+.mdbc-canvas-chat-msg.pending {
+  color: var(--m-fg-3);
+  font-style: italic;
+}
+
+.mdbc-canvas-chat-input {
+  flex: 0 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 10px;
+  border-top: 1px solid var(--m-sep);
+}
+
+.mdbc-canvas-chat-textarea {
+  width: 100%;
+  box-sizing: border-box;
+  resize: none;
+  border: 1px solid var(--m-sep);
+  border-radius: var(--m-r-md);
+  background: var(--m-bg-editor);
+  color: var(--m-fg);
+  font-family: var(--m-font);
+  font-size: var(--m-fs-sm);
+  line-height: 1.4;
+  padding: 8px;
+  outline: none;
+}
+
+.mdbc-canvas-chat-textarea:focus {
+  border-color: var(--m-accent);
+}

--- a/frontend/src/domains/canvas/components/CanvasAgentChat/index.tsx
+++ b/frontend/src/domains/canvas/components/CanvasAgentChat/index.tsx
@@ -1,0 +1,71 @@
+import { useState } from "react";
+import type { KeyboardEvent } from "react";
+
+import { useCanvasAgentChat } from "./hooks";
+import type { CanvasAgentChatProps } from "./types";
+import "./index.css";
+
+/// The board's agent chat: type a request, the agent designs objects and adds
+/// them to this canvas. Mirrors the reference's left "Agents" panel.
+function CanvasAgentChat({ tab }: CanvasAgentChatProps) {
+  const { cancel, connectionId, entries, send, streaming } = useCanvasAgentChat(tab);
+  const [draft, setDraft] = useState("");
+
+  const submit = () => {
+    if (!draft.trim() || streaming) return;
+    send(draft);
+    setDraft("");
+  };
+
+  const onKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      submit();
+    }
+  };
+
+  return (
+    <div className="mdbc-canvas-chat">
+      <div className="mdbc-canvas-chat-head">
+        <span className="mdbc-canvas-chat-title">Agent</span>
+      </div>
+      <div className="mdbc-canvas-chat-log">
+        {entries.length === 0 ? (
+          <div className="mdbc-canvas-chat-empty">
+            Ask the agent to build something, like "monthly sales by category".
+          </div>
+        ) : (
+          entries.map((entry) => (
+            <div
+              key={entry.id}
+              className={`mdbc-canvas-chat-msg ${entry.role}${entry.pending ? " pending" : ""}`}
+            >
+              {entry.text}
+            </div>
+          ))
+        )}
+      </div>
+      <div className="mdbc-canvas-chat-input">
+        <textarea
+          className="mdbc-canvas-chat-textarea"
+          value={draft}
+          rows={2}
+          placeholder={connectionId ? "Ask the agent…" : "Connect a database to use the agent"}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={onKeyDown}
+        />
+        {streaming ? (
+          <button type="button" className="mdbc-btn danger" onClick={cancel}>
+            Stop
+          </button>
+        ) : (
+          <button type="button" className="mdbc-btn primary" disabled={!draft.trim()} onClick={submit}>
+            Send
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export { CanvasAgentChat };

--- a/frontend/src/domains/canvas/components/CanvasAgentChat/ipc.ts
+++ b/frontend/src/domains/canvas/components/CanvasAgentChat/ipc.ts
@@ -1,0 +1,50 @@
+import { invoke } from "@tauri-apps/api/core";
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+
+type CanvasAgentEventKind = "session_started" | "message" | "tool_call" | "done" | "error";
+
+/// The `agent-event` payload (AgentEvent flattened + the originating turn id).
+/// Owned locally by this boundary, not imported from the central IPC types.
+interface CanvasAgentEventEnvelope {
+  turn_id: string;
+  kind: CanvasAgentEventKind;
+  text?: string;
+  tool?: string;
+  summary?: string;
+  session_id?: string;
+  model?: string | null;
+  message?: string;
+}
+
+interface SendCanvasAgentArgs {
+  connectionId: string | null;
+  prompt: string;
+  turnId: string;
+  resumeSession: string | null;
+}
+
+/// Start one canvas-profile agent turn (Claude). The backend injects the
+/// connection's schema and the arris-canvas contract, then streams `agent-event`s.
+function sendCanvasAgentIPC(args: SendCanvasAgentArgs): Promise<void> {
+  return invoke("cmd_agent_send", {
+    provider: "claude",
+    profile: "canvas",
+    connectionId: args.connectionId,
+    prompt: args.prompt,
+    turnId: args.turnId,
+    resumeSession: args.resumeSession,
+  });
+}
+
+function cancelCanvasAgentIPC(turnId: string): Promise<void> {
+  return invoke("cmd_agent_cancel", { turnId });
+}
+
+function listenCanvasAgentEventsIPC(
+  handler: (event: CanvasAgentEventEnvelope) => void,
+): Promise<UnlistenFn> {
+  return listen<CanvasAgentEventEnvelope>("agent-event", (evt) => handler(evt.payload));
+}
+
+export { cancelCanvasAgentIPC, listenCanvasAgentEventsIPC, sendCanvasAgentIPC };
+export type { CanvasAgentEventEnvelope };

--- a/frontend/src/domains/canvas/components/CanvasAgentChat/types.ts
+++ b/frontend/src/domains/canvas/components/CanvasAgentChat/types.ts
@@ -1,0 +1,18 @@
+import type { EditorTab } from "@shell/types";
+
+type ChatRole = "user" | "agent";
+
+/// One turn in the canvas chat log. The agent entry streams (`pending`) then
+/// settles into a summary of what was added.
+interface ChatEntry {
+  id: string;
+  role: ChatRole;
+  text: string;
+  pending?: boolean;
+}
+
+interface CanvasAgentChatProps {
+  tab: EditorTab;
+}
+
+export type { CanvasAgentChatProps, ChatEntry, ChatRole };

--- a/frontend/src/domains/canvas/components/CanvasView/components/CanvasToolbar/index.tsx
+++ b/frontend/src/domains/canvas/components/CanvasView/components/CanvasToolbar/index.tsx
@@ -1,0 +1,18 @@
+import type { CanvasToolbarProps } from "../../types";
+
+/// Floating toolbar for adding objects by hand. The agent chat adds objects too;
+/// this covers manual text/shape annotations.
+function CanvasToolbar({ onAddText, onAddShape }: CanvasToolbarProps) {
+  return (
+    <div className="mdbc-canvas-toolbar">
+      <button type="button" className="mdbc-btn ghost" onClick={onAddText}>
+        Text
+      </button>
+      <button type="button" className="mdbc-btn ghost" onClick={onAddShape}>
+        Shape
+      </button>
+    </div>
+  );
+}
+
+export { CanvasToolbar };

--- a/frontend/src/domains/canvas/components/CanvasView/components/ChartNode/index.test.tsx
+++ b/frontend/src/domains/canvas/components/CanvasView/components/ChartNode/index.test.tsx
@@ -1,0 +1,37 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import type { NodeProps } from "reactflow";
+
+vi.mock("@domains/chart", () => ({
+  ChartView: () => <div data-testid="chart-view" />,
+}));
+
+import { useCanvasStore } from "../../../../hooks";
+import { makeComponent } from "../../../../utils";
+import type { CanvasNodeData } from "../../types";
+import { ChartNode } from "./index";
+
+const TAB = "tab-1";
+
+const nodeProps = (id: string) =>
+  ({ id, data: { tabId: TAB }, selected: false }) as unknown as NodeProps<CanvasNodeData>;
+
+describe("ChartNode", () => {
+  beforeEach(() => useCanvasStore.setState({ boards: {} }));
+
+  it("renders the chart view bound to its source query's result", () => {
+    useCanvasStore.getState().ensureBoard(TAB, "");
+    useCanvasStore.getState().addComponent(
+      TAB,
+      makeComponent({
+        kind: "chart",
+        id: "c",
+        sourceQueryId: "q",
+        spec: { kind: "bar", xColumn: "x", yColumns: ["y"] },
+      }),
+    );
+    useCanvasStore.getState().setRun(TAB, "q", { result: { columns: [], rows: [], elapsed: 0 } });
+    render(<ChartNode {...nodeProps("c")} />);
+    expect(screen.getByTestId("chart-view")).toBeTruthy();
+  });
+});

--- a/frontend/src/domains/canvas/components/CanvasView/components/ChartNode/index.tsx
+++ b/frontend/src/domains/canvas/components/CanvasView/components/ChartNode/index.tsx
@@ -1,0 +1,40 @@
+import { memo } from "react";
+import type { NodeProps } from "reactflow";
+import { ChartView } from "@domains/chart";
+
+import { useCanvasStore } from "../../../../hooks";
+import type { CanvasNodeData } from "../../types";
+
+/// A chart object bound to a query object by `sourceQueryId`. Renders through the
+/// shared ChartView with the upstream query's run result, so it updates whenever
+/// that query re-runs. `nowheel` lets the chart scroll/zoom without panning.
+function ChartNodeImpl({ id, data, selected }: NodeProps<CanvasNodeData>) {
+  const { tabId } = data;
+  const board = useCanvasStore((s) => s.boards[tabId]);
+  const component = board?.doc.components.find((c) => c.id === id);
+  if (!component || component.kind !== "chart") return null;
+  const run = board?.runs[component.sourceQueryId];
+
+  return (
+    <div className={`mdbc-canvas-node mdbc-canvas-chart nowheel${selected ? " selected" : ""}`}>
+      {component.title ? (
+        <div className="mdbc-canvas-node-head">
+          <span className="mdbc-canvas-node-title">{component.title}</span>
+        </div>
+      ) : null}
+      <div className="mdbc-canvas-chart-body">
+        <ChartView
+          spec={component.spec}
+          result={run?.result}
+          isRunning={run?.running}
+          error={run?.error}
+          onEdit={() => {}}
+        />
+      </div>
+    </div>
+  );
+}
+
+const ChartNode = memo(ChartNodeImpl);
+
+export { ChartNode };

--- a/frontend/src/domains/canvas/components/CanvasView/components/QueryNode/index.test.tsx
+++ b/frontend/src/domains/canvas/components/CanvasView/components/QueryNode/index.test.tsx
@@ -1,0 +1,43 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import type { NodeProps } from "reactflow";
+
+import { useCanvasStore } from "../../../../hooks";
+import { makeComponent } from "../../../../utils";
+import type { CanvasComponent } from "../../../../types";
+import type { CanvasNodeData } from "../../types";
+import { QueryNode } from "./index";
+
+const TAB = "tab-1";
+
+function seed(component: CanvasComponent) {
+  useCanvasStore.setState({ boards: {} });
+  useCanvasStore.getState().ensureBoard(TAB, "");
+  useCanvasStore.getState().addComponent(TAB, component);
+}
+
+const nodeProps = (id: string) =>
+  ({ id, data: { tabId: TAB }, selected: false }) as unknown as NodeProps<CanvasNodeData>;
+
+describe("QueryNode", () => {
+  beforeEach(() => useCanvasStore.setState({ boards: {} }));
+
+  it("renders the SQL and writes edits back to the store", () => {
+    seed(makeComponent({ kind: "query", id: "q", sql: "select 1", connectionId: "c" }));
+    render(<QueryNode {...nodeProps("q")} />);
+    const input = screen.getByPlaceholderText("SELECT …") as HTMLTextAreaElement;
+    expect(input.value).toBe("select 1");
+    fireEvent.change(input, { target: { value: "select 2" } });
+    expect(useCanvasStore.getState().boards[TAB].doc.components[0]).toMatchObject({
+      kind: "query",
+      sql: "select 2",
+    });
+  });
+
+  it("Run surfaces an error when the object has no connection", async () => {
+    seed(makeComponent({ kind: "query", id: "q", sql: "select 1", connectionId: null }));
+    render(<QueryNode {...nodeProps("q")} />);
+    fireEvent.click(screen.getByRole("button", { name: "Run" }));
+    expect(await screen.findByText(/Pick a connection/)).toBeTruthy();
+  });
+});

--- a/frontend/src/domains/canvas/components/CanvasView/components/QueryNode/index.tsx
+++ b/frontend/src/domains/canvas/components/CanvasView/components/QueryNode/index.tsx
@@ -1,0 +1,79 @@
+import { memo } from "react";
+import type { NodeProps } from "reactflow";
+import type { QueryValue } from "@shared";
+
+import { useCanvasStore } from "../../../../hooks";
+import type { CanvasNodeData } from "../../types";
+
+const PREVIEW_ROWS = 50;
+
+/// Render one cell value for the compact result preview.
+function cellText(value: QueryValue): string {
+  if (!value || value.kind === "null" || value.value == null) return "NULL";
+  return String(value.value);
+}
+
+/// A SQL object: editable query, a Run button, and a compact result grid. The
+/// chart objects bound to it (by `sourceQueryId`) read the same run result.
+function QueryNodeImpl({ id, data, selected }: NodeProps<CanvasNodeData>) {
+  const { tabId } = data;
+  const board = useCanvasStore((s) => s.boards[tabId]);
+  const updateComponent = useCanvasStore((s) => s.updateComponent);
+  const runQueryComponent = useCanvasStore((s) => s.runQueryComponent);
+  const component = board?.doc.components.find((c) => c.id === id);
+  if (!component || component.kind !== "query") return null;
+  const run = board?.runs[id];
+
+  return (
+    <div className={`mdbc-canvas-node mdbc-canvas-query${selected ? " selected" : ""}`}>
+      <div className="mdbc-canvas-node-head">
+        <span className="mdbc-canvas-node-title">{component.title ?? "Query"}</span>
+        <button
+          type="button"
+          className="mdbc-btn primary text-only mdbc-canvas-run"
+          disabled={run?.running}
+          onClick={() => void runQueryComponent(tabId, id)}
+        >
+          {run?.running ? "Running…" : "Run"}
+        </button>
+      </div>
+      <textarea
+        className="nodrag nowheel mdbc-canvas-sql"
+        value={component.sql}
+        spellCheck={false}
+        placeholder="SELECT …"
+        onChange={(e) => updateComponent(tabId, id, { sql: e.target.value })}
+      />
+      <div className="nowheel mdbc-canvas-result">
+        {run?.error ? (
+          <div className="mdbc-canvas-result-error">{run.error}</div>
+        ) : run?.result ? (
+          <table className="mdbc-canvas-result-table">
+            <thead>
+              <tr>
+                {run.result.columns.map((col) => (
+                  <th key={col.name}>{col.name}</th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {run.result.rows.slice(0, PREVIEW_ROWS).map((row, ri) => (
+                <tr key={ri}>
+                  {row.map((value, ci) => (
+                    <td key={ci}>{cellText(value)}</td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        ) : (
+          <div className="mdbc-canvas-result-empty">Run to see results</div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+const QueryNode = memo(QueryNodeImpl);
+
+export { QueryNode };

--- a/frontend/src/domains/canvas/components/CanvasView/components/ShapeNode/index.test.tsx
+++ b/frontend/src/domains/canvas/components/CanvasView/components/ShapeNode/index.test.tsx
@@ -1,0 +1,30 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { render } from "@testing-library/react";
+import type { NodeProps } from "reactflow";
+
+import { useCanvasStore } from "../../../../hooks";
+import { makeComponent } from "../../../../utils";
+import type { CanvasNodeData } from "../../types";
+import { ShapeNode } from "./index";
+
+const TAB = "tab-1";
+
+const nodeProps = (id: string) =>
+  ({ id, data: { tabId: TAB }, selected: false }) as unknown as NodeProps<CanvasNodeData>;
+
+describe("ShapeNode", () => {
+  beforeEach(() => useCanvasStore.setState({ boards: {} }));
+
+  it("renders a shape box for the object", () => {
+    useCanvasStore.getState().ensureBoard(TAB, "");
+    useCanvasStore.getState().addComponent(TAB, makeComponent({ kind: "shape", id: "s", shape: "ellipse" }));
+    const { container } = render(<ShapeNode {...nodeProps("s")} />);
+    expect(container.querySelector(".mdbc-canvas-shape")).toBeTruthy();
+  });
+
+  it("renders nothing for an unknown object", () => {
+    useCanvasStore.getState().ensureBoard(TAB, "");
+    const { container } = render(<ShapeNode {...nodeProps("missing")} />);
+    expect(container.querySelector(".mdbc-canvas-shape")).toBeNull();
+  });
+});

--- a/frontend/src/domains/canvas/components/CanvasView/components/ShapeNode/index.tsx
+++ b/frontend/src/domains/canvas/components/CanvasView/components/ShapeNode/index.tsx
@@ -1,0 +1,38 @@
+import { memo } from "react";
+import type { NodeProps } from "reactflow";
+
+import { useCanvasStore } from "../../../../hooks";
+import type { CanvasNodeData } from "../../types";
+
+/// A decorative shape (rectangle, ellipse, or horizontal line). Fills its node
+/// box; the radius/line treatment is chosen by the shape kind.
+function ShapeNodeImpl({ id, data, selected }: NodeProps<CanvasNodeData>) {
+  const { tabId } = data;
+  const component = useCanvasStore((s) =>
+    s.boards[tabId]?.doc.components.find((c) => c.id === id),
+  );
+  if (!component || component.kind !== "shape") return null;
+  const style = component.style ?? {};
+  const css = {
+    background: component.shape === "line" ? "transparent" : (style.fill ?? "rgb(var(--m-accent-rgb) / 0.12)"),
+    border:
+      component.shape === "line"
+        ? "none"
+        : `${style.strokeWidth ?? 1}px solid ${style.stroke ?? "rgb(var(--m-accent-rgb) / 0.5)"}`,
+    borderTop:
+      component.shape === "line"
+        ? `${style.strokeWidth ?? 2}px solid ${style.stroke ?? "rgb(var(--m-accent-rgb) / 0.6)"}`
+        : undefined,
+    borderRadius: component.shape === "ellipse" ? "50%" : "var(--m-r-md)",
+  };
+  return (
+    <div
+      className={`mdbc-canvas-node mdbc-canvas-shape${selected ? " selected" : ""}`}
+      style={css}
+    />
+  );
+}
+
+const ShapeNode = memo(ShapeNodeImpl);
+
+export { ShapeNode };

--- a/frontend/src/domains/canvas/components/CanvasView/components/TextNode/index.test.tsx
+++ b/frontend/src/domains/canvas/components/CanvasView/components/TextNode/index.test.tsx
@@ -1,0 +1,36 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import type { NodeProps } from "reactflow";
+
+import { useCanvasStore } from "../../../../hooks";
+import { makeComponent } from "../../../../utils";
+import type { CanvasComponent } from "../../../../types";
+import type { CanvasNodeData } from "../../types";
+import { TextNode } from "./index";
+
+const TAB = "tab-1";
+
+function seed(component: CanvasComponent) {
+  useCanvasStore.setState({ boards: {} });
+  useCanvasStore.getState().ensureBoard(TAB, "");
+  useCanvasStore.getState().addComponent(TAB, component);
+}
+
+const nodeProps = (id: string) =>
+  ({ id, data: { tabId: TAB }, selected: false }) as unknown as NodeProps<CanvasNodeData>;
+
+describe("TextNode", () => {
+  beforeEach(() => useCanvasStore.setState({ boards: {} }));
+
+  it("renders the object's text and writes edits back to the store", () => {
+    seed(makeComponent({ kind: "text", id: "t", text: "hello" }));
+    render(<TextNode {...nodeProps("t")} />);
+    const input = screen.getByPlaceholderText("Type text…") as HTMLTextAreaElement;
+    expect(input.value).toBe("hello");
+    fireEvent.change(input, { target: { value: "world" } });
+    expect(useCanvasStore.getState().boards[TAB].doc.components[0]).toMatchObject({
+      kind: "text",
+      text: "world",
+    });
+  });
+});

--- a/frontend/src/domains/canvas/components/CanvasView/components/TextNode/index.tsx
+++ b/frontend/src/domains/canvas/components/CanvasView/components/TextNode/index.tsx
@@ -1,0 +1,30 @@
+import { memo } from "react";
+import type { NodeProps } from "reactflow";
+
+import { useCanvasStore } from "../../../../hooks";
+import type { CanvasNodeData } from "../../types";
+
+/// A free-text object. Always editable (a transparent textarea styled to read as
+/// prose); `nodrag`/`nowheel` keep ReactFlow from hijacking pointer + scroll.
+function TextNodeImpl({ id, data, selected }: NodeProps<CanvasNodeData>) {
+  const { tabId } = data;
+  const component = useCanvasStore((s) =>
+    s.boards[tabId]?.doc.components.find((c) => c.id === id),
+  );
+  const updateComponent = useCanvasStore((s) => s.updateComponent);
+  if (!component || component.kind !== "text") return null;
+  return (
+    <div className={`mdbc-canvas-node mdbc-canvas-text${selected ? " selected" : ""}`}>
+      <textarea
+        className="nodrag nowheel mdbc-canvas-text-input"
+        value={component.text}
+        placeholder="Type text…"
+        onChange={(e) => updateComponent(tabId, id, { text: e.target.value })}
+      />
+    </div>
+  );
+}
+
+const TextNode = memo(TextNodeImpl);
+
+export { TextNode };

--- a/frontend/src/domains/canvas/components/CanvasView/hooks.test.ts
+++ b/frontend/src/domains/canvas/components/CanvasView/hooks.test.ts
@@ -1,0 +1,32 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import type { EditorTab } from "@shell/types";
+
+import { useCanvasStore } from "../../hooks";
+import { useCanvas } from "./hooks";
+
+const tab = { id: "tab-1", text: "" } as unknown as EditorTab;
+
+describe("useCanvas", () => {
+  beforeEach(() => useCanvasStore.setState({ boards: {} }));
+
+  it("parses the tab text into a board on mount", () => {
+    renderHook(() => useCanvas(tab));
+    expect(useCanvasStore.getState().boards["tab-1"]).toBeDefined();
+  });
+
+  it("addText appends a text object", () => {
+    const { result } = renderHook(() => useCanvas(tab));
+    act(() => result.current.addText());
+    const comps = useCanvasStore.getState().boards["tab-1"].doc.components;
+    expect(comps).toHaveLength(1);
+    expect(comps[0].kind).toBe("text");
+  });
+
+  it("addShape appends a shape object", () => {
+    const { result } = renderHook(() => useCanvas(tab));
+    act(() => result.current.addShape());
+    const comps = useCanvasStore.getState().boards["tab-1"].doc.components;
+    expect(comps[0].kind).toBe("shape");
+  });
+});

--- a/frontend/src/domains/canvas/components/CanvasView/hooks.ts
+++ b/frontend/src/domains/canvas/components/CanvasView/hooks.ts
@@ -1,0 +1,131 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { applyNodeChanges } from "reactflow";
+import type { Node, NodeChange, Viewport } from "reactflow";
+
+import { useTabsStore } from "@shell/hooks/tabsStore";
+import type { EditorTab } from "@shell/types";
+
+import { CANVAS_SAVE_DEBOUNCE_MS, LAYOUT_ORIGIN } from "../../constants";
+import { useCanvasStore } from "../../hooks";
+import type { CanvasComponent, CanvasEdge } from "../../types";
+import { makeComponent, serializeDoc } from "../../utils";
+import type { CanvasNodeData } from "./types";
+import { toFlowEdges, toFlowNodes } from "./utils";
+
+const EMPTY_COMPONENTS: CanvasComponent[] = [];
+const EMPTY_EDGES: CanvasEdge[] = [];
+const DEFAULT_VIEWPORT: Viewport = { x: 0, y: 0, zoom: 1 };
+
+/// Drive one canvas board: parse the tab into objects once, mirror them into
+/// ReactFlow's node state (positions stay live during drag, structural adds/
+/// removes reseed), persist geometry + viewport back to the store, and serialize
+/// the board into the tab's text on a short debounce so it survives reopen.
+function useCanvas(tab: EditorTab) {
+  const tabId = tab.id;
+  const board = useCanvasStore((s) => s.boards[tabId]);
+  const ensureBoard = useCanvasStore((s) => s.ensureBoard);
+  const addComponent = useCanvasStore((s) => s.addComponent);
+  const updateComponent = useCanvasStore((s) => s.updateComponent);
+  const removeComponent = useCanvasStore((s) => s.removeComponent);
+  const setViewport = useCanvasStore((s) => s.setViewport);
+
+  // Parse the tab's text into a board exactly once (a re-mount is a no-op).
+  useEffect(() => {
+    ensureBoard(tabId, tab.text ?? "");
+    // Re-parse only when the tab identity changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tabId]);
+
+  const components = board?.doc.components ?? EMPTY_COMPONENTS;
+  const edges = board?.doc.edges ?? EMPTY_EDGES;
+
+  const flowNodes = useMemo(() => toFlowNodes(components, tabId), [components, tabId]);
+  const rfEdges = useMemo(() => toFlowEdges(edges), [edges]);
+
+  const [rfNodes, setRfNodes] = useState<Node<CanvasNodeData>[]>(flowNodes);
+
+  // Reseed local nodes only when the SET of objects changes (add/remove);
+  // otherwise keep the live drag positions and just refresh node identity.
+  const structuralKey = useMemo(
+    () => components.map((c) => `${c.id}:${c.kind}`).sort().join(","),
+    [components],
+  );
+  const prevKeyRef = useRef(structuralKey);
+  useEffect(() => {
+    if (structuralKey !== prevKeyRef.current) {
+      prevKeyRef.current = structuralKey;
+      setRfNodes(flowNodes);
+      return;
+    }
+    setRfNodes((prev) => {
+      const positions = new Map(prev.map((n) => [n.id, n.position]));
+      return flowNodes.map((n) => ({ ...n, position: positions.get(n.id) ?? n.position }));
+    });
+  }, [flowNodes, structuralKey]);
+
+  const onNodesChange = useCallback(
+    (changes: NodeChange[]) => setRfNodes((nds) => applyNodeChanges(changes, nds)),
+    [],
+  );
+
+  const onNodeDragStop = useCallback(
+    (_event: unknown, node: Node) => {
+      updateComponent(tabId, node.id, { x: node.position.x, y: node.position.y });
+    },
+    [tabId, updateComponent],
+  );
+
+  const onNodesDelete = useCallback(
+    (deleted: Node[]) => {
+      for (const node of deleted) removeComponent(tabId, node.id);
+    },
+    [tabId, removeComponent],
+  );
+
+  const onMoveEnd = useCallback(
+    (_event: unknown, viewport: Viewport) => setViewport(tabId, viewport),
+    [tabId, setViewport],
+  );
+
+  // Cascade manually-added objects so they don't stack exactly on top.
+  const placementFor = useCallback(() => {
+    const n = (board?.doc.components.length ?? 0) % 8;
+    return { x: LAYOUT_ORIGIN.x + n * 24, y: LAYOUT_ORIGIN.y + n * 24 };
+  }, [board]);
+
+  const addText = useCallback(() => {
+    addComponent(tabId, makeComponent({ kind: "text", ...placementFor(), text: "" }));
+  }, [addComponent, placementFor, tabId]);
+
+  const addShape = useCallback(() => {
+    addComponent(tabId, makeComponent({ kind: "shape", shape: "rect", ...placementFor() }));
+  }, [addComponent, placementFor, tabId]);
+
+  // Debounced serialize of the live board into the tab's text (persistence).
+  const doc = board?.doc;
+  const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => {
+    if (!doc) return;
+    if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
+    saveTimerRef.current = setTimeout(() => {
+      useTabsStore.getState().updateTab(tabId, { text: serializeDoc(doc) });
+    }, CANVAS_SAVE_DEBOUNCE_MS);
+    return () => {
+      if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
+    };
+  }, [doc, tabId]);
+
+  return {
+    rfNodes,
+    rfEdges,
+    onNodesChange,
+    onNodeDragStop,
+    onNodesDelete,
+    onMoveEnd,
+    defaultViewport: board?.doc.viewport ?? DEFAULT_VIEWPORT,
+    addText,
+    addShape,
+  };
+}
+
+export { useCanvas };

--- a/frontend/src/domains/canvas/components/CanvasView/index.css
+++ b/frontend/src/domains/canvas/components/CanvasView/index.css
@@ -1,0 +1,178 @@
+.mdbc-canvas-view {
+  display: flex;
+  height: 100%;
+  width: 100%;
+  min-height: 0;
+}
+
+.mdbc-canvas-board {
+  position: relative;
+  flex: 1 1 auto;
+  min-width: 0;
+  height: 100%;
+}
+
+.mdbc-canvas-board .react-flow {
+  width: 100%;
+  height: 100%;
+  background: var(--m-bg-app);
+}
+
+.mdbc-canvas-toolbar {
+  position: absolute;
+  top: 12px;
+  left: 12px;
+  z-index: 5;
+  display: flex;
+  gap: 6px;
+}
+
+/* ── object node base ─────────────────────────────────────────────────────── */
+
+.mdbc-canvas-node {
+  box-sizing: border-box;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  background: var(--m-bg-card);
+  border: 1px solid var(--m-sep);
+  border-radius: var(--m-r-md);
+  box-shadow: var(--m-shadow-card);
+  color: var(--m-fg);
+  font-family: var(--m-font);
+  font-size: var(--m-fs-sm);
+}
+
+.mdbc-canvas-node.selected {
+  border-color: var(--m-accent);
+  box-shadow: 0 0 0 1px var(--m-accent), var(--m-shadow-card);
+}
+
+.mdbc-canvas-node-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 6px 10px;
+  border-bottom: 1px solid var(--m-sep);
+  flex: 0 0 auto;
+}
+
+.mdbc-canvas-node-title {
+  font-size: var(--m-fs-sm);
+  font-weight: 600;
+  color: var(--m-fg-2);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.mdbc-canvas-run {
+  flex: 0 0 auto;
+}
+
+/* ── text object ──────────────────────────────────────────────────────────── */
+
+.mdbc-canvas-text {
+  background: transparent;
+  border-color: transparent;
+  box-shadow: none;
+}
+
+.mdbc-canvas-text.selected {
+  border-color: var(--m-accent);
+}
+
+.mdbc-canvas-text-input {
+  flex: 1 1 auto;
+  width: 100%;
+  height: 100%;
+  resize: none;
+  border: none;
+  outline: none;
+  background: transparent;
+  color: var(--m-fg);
+  font-family: var(--m-font);
+  font-size: var(--m-fs-md);
+  line-height: 1.4;
+  padding: 8px 10px;
+}
+
+/* ── query object ─────────────────────────────────────────────────────────── */
+
+.mdbc-canvas-sql {
+  flex: 0 0 auto;
+  height: 96px;
+  width: 100%;
+  box-sizing: border-box;
+  resize: none;
+  border: none;
+  outline: none;
+  border-bottom: 1px solid var(--m-sep);
+  background: var(--m-bg-editor);
+  color: var(--m-fg);
+  font-family: var(--m-font-mono);
+  font-size: var(--m-fs-xs);
+  line-height: 1.5;
+  padding: 8px 10px;
+}
+
+.mdbc-canvas-result {
+  flex: 1 1 auto;
+  overflow: auto;
+  padding: 0;
+}
+
+.mdbc-canvas-result-empty,
+.mdbc-canvas-result-error {
+  padding: 8px 10px;
+  font-size: var(--m-fs-xs);
+  color: var(--m-fg-3);
+}
+
+.mdbc-canvas-result-error {
+  color: var(--m-red);
+  white-space: pre-wrap;
+}
+
+.mdbc-canvas-result-table {
+  border-collapse: collapse;
+  width: 100%;
+  font-size: var(--m-fs-xs);
+  font-family: var(--m-font-mono);
+}
+
+.mdbc-canvas-result-table th,
+.mdbc-canvas-result-table td {
+  border-bottom: 1px solid var(--m-sep);
+  padding: 3px 8px;
+  text-align: left;
+  white-space: nowrap;
+  max-width: 220px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.mdbc-canvas-result-table th {
+  position: sticky;
+  top: 0;
+  background: var(--m-bg-surface);
+  color: var(--m-fg-2);
+  font-weight: 600;
+}
+
+/* ── chart object ─────────────────────────────────────────────────────────── */
+
+.mdbc-canvas-chart-body {
+  flex: 1 1 auto;
+  min-height: 0;
+  position: relative;
+}
+
+/* ── shape object ─────────────────────────────────────────────────────────── */
+
+.mdbc-canvas-shape {
+  overflow: visible;
+}

--- a/frontend/src/domains/canvas/components/CanvasView/index.tsx
+++ b/frontend/src/domains/canvas/components/CanvasView/index.tsx
@@ -1,0 +1,42 @@
+import ReactFlow, { Background, Controls } from "reactflow";
+import "reactflow/dist/style.css";
+import "./index.css";
+
+import { CanvasToolbar } from "./components/CanvasToolbar";
+import { useCanvas } from "./hooks";
+import type { CanvasViewProps } from "./types";
+import { nodeTypes } from "./utils";
+
+/// The canvas thinkboard tab view: an infinite ReactFlow board of objects
+/// (text/query/chart/shape) plus a floating add-toolbar. The agent chat panel is
+/// rendered alongside the board.
+function CanvasView({ activeTab }: CanvasViewProps) {
+  const canvas = useCanvas(activeTab);
+  return (
+    <div className="mdbc-canvas-view">
+      <div className="mdbc-canvas-board">
+        <CanvasToolbar onAddText={canvas.addText} onAddShape={canvas.addShape} />
+        <ReactFlow
+          nodes={canvas.rfNodes}
+          edges={canvas.rfEdges}
+          nodeTypes={nodeTypes}
+          onNodesChange={canvas.onNodesChange}
+          onNodeDragStop={canvas.onNodeDragStop}
+          onNodesDelete={canvas.onNodesDelete}
+          onMoveEnd={canvas.onMoveEnd}
+          defaultViewport={canvas.defaultViewport}
+          minZoom={0.2}
+          maxZoom={2}
+          nodesConnectable={false}
+          deleteKeyCode={["Backspace", "Delete"]}
+          proOptions={{ hideAttribution: true }}
+        >
+          <Background gap={24} size={1} color="rgb(var(--m-overlay-rgb) / 0.06)" />
+          <Controls position="bottom-right" showInteractive={false} />
+        </ReactFlow>
+      </div>
+    </div>
+  );
+}
+
+export { CanvasView };

--- a/frontend/src/domains/canvas/components/CanvasView/index.tsx
+++ b/frontend/src/domains/canvas/components/CanvasView/index.tsx
@@ -2,6 +2,7 @@ import ReactFlow, { Background, Controls } from "reactflow";
 import "reactflow/dist/style.css";
 import "./index.css";
 
+import { CanvasAgentChat } from "../CanvasAgentChat";
 import { CanvasToolbar } from "./components/CanvasToolbar";
 import { useCanvas } from "./hooks";
 import type { CanvasViewProps } from "./types";
@@ -14,6 +15,7 @@ function CanvasView({ activeTab }: CanvasViewProps) {
   const canvas = useCanvas(activeTab);
   return (
     <div className="mdbc-canvas-view">
+      <CanvasAgentChat tab={activeTab} />
       <div className="mdbc-canvas-board">
         <CanvasToolbar onAddText={canvas.addText} onAddShape={canvas.addShape} />
         <ReactFlow

--- a/frontend/src/domains/canvas/components/CanvasView/types.ts
+++ b/frontend/src/domains/canvas/components/CanvasView/types.ts
@@ -1,0 +1,18 @@
+import type { EditorTab } from "@shell/types";
+
+/// Data carried on every ReactFlow node. Nodes read their live object + run
+/// state from the store by `id` (props.id), so only the owning tab is needed.
+interface CanvasNodeData {
+  tabId: string;
+}
+
+interface CanvasViewProps {
+  activeTab: EditorTab;
+}
+
+interface CanvasToolbarProps {
+  onAddText: () => void;
+  onAddShape: () => void;
+}
+
+export type { CanvasNodeData, CanvasToolbarProps, CanvasViewProps };

--- a/frontend/src/domains/canvas/components/CanvasView/utils.test.tsx
+++ b/frontend/src/domains/canvas/components/CanvasView/utils.test.tsx
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import { makeComponent } from "../../utils";
+import { COMPONENT_KINDS, nodeTypes, toFlowEdges, toFlowNodes } from "./utils";
+
+describe("nodeTypes registry", () => {
+  it("has exactly one renderer per component kind (expansion guard)", () => {
+    expect(Object.keys(nodeTypes).sort()).toEqual([...COMPONENT_KINDS].sort());
+  });
+
+  it("every renderer is a defined component", () => {
+    for (const kind of COMPONENT_KINDS) expect(nodeTypes[kind]).toBeTruthy();
+  });
+});
+
+describe("toFlowNodes", () => {
+  it("maps geometry, kind, and the owning tab", () => {
+    const c = makeComponent({ kind: "text", id: "t", x: 10, y: 20, w: 30, h: 40, z: 2 });
+    const [node] = toFlowNodes([c], "tab-1");
+    expect(node).toMatchObject({
+      id: "t",
+      type: "text",
+      position: { x: 10, y: 20 },
+      data: { tabId: "tab-1" },
+      style: { width: 30, height: 40, zIndex: 2 },
+    });
+  });
+});
+
+describe("toFlowEdges", () => {
+  it("maps source and target", () => {
+    expect(toFlowEdges([{ id: "e", source: "a", target: "b" }])).toEqual([
+      { id: "e", source: "a", target: "b" },
+    ]);
+  });
+});

--- a/frontend/src/domains/canvas/components/CanvasView/utils.tsx
+++ b/frontend/src/domains/canvas/components/CanvasView/utils.tsx
@@ -1,0 +1,52 @@
+import type { Edge, Node, NodeTypes } from "reactflow";
+
+import type {
+  CanvasComponent,
+  CanvasEdge,
+  ComponentKind,
+} from "../../types";
+import { ChartNode } from "./components/ChartNode";
+import { QueryNode } from "./components/QueryNode";
+import { ShapeNode } from "./components/ShapeNode";
+import { TextNode } from "./components/TextNode";
+import type { CanvasNodeData } from "./types";
+
+/// Every object kind, in render order. The single list the registry-completeness
+/// guard checks against; adding a kind means adding it here and to `nodeTypes`.
+const COMPONENT_KINDS: ComponentKind[] = ["text", "query", "chart", "shape"];
+
+/// The ReactFlow node-renderer registry: one custom node component per object
+/// kind. This is the extension seam (mirrors the chart RendererRegistry): a new
+/// kind is wired by adding one entry here.
+const nodeTypes: NodeTypes = {
+  text: TextNode,
+  query: QueryNode,
+  chart: ChartNode,
+  shape: ShapeNode,
+};
+
+/// Map board objects to ReactFlow nodes. Position/size/z come from the object;
+/// the node reads its live content from the store by id, so `data` only carries
+/// the owning tab.
+function toFlowNodes(
+  components: CanvasComponent[],
+  tabId: string,
+): Node<CanvasNodeData>[] {
+  return components.map((c) => ({
+    id: c.id,
+    type: c.kind,
+    position: { x: c.x, y: c.y },
+    data: { tabId },
+    style: { width: c.w, height: c.h, zIndex: c.z },
+  }));
+}
+
+function toFlowEdges(edges: CanvasEdge[]): Edge[] {
+  return edges.map((e) => ({
+    id: e.id,
+    source: e.source,
+    target: e.target,
+  }));
+}
+
+export { COMPONENT_KINDS, nodeTypes, toFlowEdges, toFlowNodes };

--- a/frontend/src/domains/canvas/constants.ts
+++ b/frontend/src/domains/canvas/constants.ts
@@ -1,0 +1,35 @@
+import type { ComponentKind } from "./types";
+
+/// Schema version of the serialized `CanvasDoc`. Bump when the persisted shape
+/// changes; `parseDoc` rejects unknown versions and falls back to an empty board.
+const CANVAS_DOC_VERSION = 1;
+
+/// The fenced-block language tag the agent emits and `parseAgentCanvas` reads.
+const CANVAS_SPEC_FENCE = "arris-canvas";
+
+/// Default object sizes (canvas units), per kind. Used by the object factory and
+/// when the agent omits geometry.
+const DEFAULT_SIZE: Record<ComponentKind, { w: number; h: number }> = {
+  text: { w: 320, h: 120 },
+  query: { w: 540, h: 320 },
+  chart: { w: 560, h: 360 },
+  shape: { w: 220, h: 160 },
+};
+
+/// Gap between auto-laid-out objects (canvas units).
+const LAYOUT_GAP = 32;
+
+/// Where the first auto-laid-out object lands when the board is empty.
+const LAYOUT_ORIGIN = { x: 80, y: 80 };
+
+/// Debounce before serializing the live board back into the tab's text.
+const CANVAS_SAVE_DEBOUNCE_MS = 400;
+
+export {
+  CANVAS_DOC_VERSION,
+  CANVAS_SAVE_DEBOUNCE_MS,
+  CANVAS_SPEC_FENCE,
+  DEFAULT_SIZE,
+  LAYOUT_GAP,
+  LAYOUT_ORIGIN,
+};

--- a/frontend/src/domains/canvas/hooks/index.ts
+++ b/frontend/src/domains/canvas/hooks/index.ts
@@ -1,0 +1,1 @@
+export { useCanvasStore } from "./store";

--- a/frontend/src/domains/canvas/hooks/store.test.ts
+++ b/frontend/src/domains/canvas/hooks/store.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../ipc", () => ({ runCanvasQueryIPC: vi.fn() }));
+
+import type { AgentCanvasSpec } from "../types";
+import { makeComponent } from "../utils";
+import { runCanvasQueryIPC } from "../ipc";
+import { useCanvasStore } from "./store";
+
+const TAB = "tab-1";
+const get = () => useCanvasStore.getState();
+
+describe("useCanvasStore", () => {
+  beforeEach(() => {
+    useCanvasStore.setState({ boards: {} });
+    vi.clearAllMocks();
+  });
+
+  it("ensureBoard parses once and never clobbers live edits", () => {
+    get().ensureBoard(TAB, "");
+    get().addComponent(TAB, makeComponent({ kind: "text", id: "t", text: "x" }));
+    // A second ensure (e.g. a re-mount) must not reset the board.
+    get().ensureBoard(TAB, JSON.stringify({ version: 1, components: [], edges: [] }));
+    expect(get().boards[TAB].doc.components).toHaveLength(1);
+  });
+
+  it("adds, updates, and removes an object", () => {
+    get().ensureBoard(TAB, "");
+    get().addComponent(TAB, makeComponent({ kind: "text", id: "t", text: "a" }));
+    get().updateComponent(TAB, "t", { x: 50 });
+    expect(get().boards[TAB].doc.components[0]).toMatchObject({ x: 50 });
+    get().removeComponent(TAB, "t");
+    expect(get().boards[TAB].doc.components).toHaveLength(0);
+  });
+
+  it("removing an object also drops its edges and run state", () => {
+    get().ensureBoard(TAB, "");
+    get().addComponent(TAB, makeComponent({ kind: "query", id: "q1", sql: "s" }));
+    get().addComponent(TAB, makeComponent({ kind: "chart", id: "c1", sourceQueryId: "q1" }));
+    get().setEdges(TAB, [{ id: "e", source: "q1", target: "c1" }]);
+    get().setRun(TAB, "q1", { result: { columns: [], rows: [], elapsed: 0 } });
+    get().removeComponent(TAB, "q1");
+    expect(get().boards[TAB].doc.edges).toHaveLength(0);
+    expect(get().boards[TAB].runs.q1).toBeUndefined();
+  });
+
+  it("setViewport persists the viewport", () => {
+    get().ensureBoard(TAB, "");
+    get().setViewport(TAB, { x: 1, y: 2, zoom: 1.5 });
+    expect(get().boards[TAB].doc.viewport).toEqual({ x: 1, y: 2, zoom: 1.5 });
+  });
+
+  it("applyAgentSpec appends objects and returns the query ids to run", () => {
+    get().ensureBoard(TAB, "");
+    const spec: AgentCanvasSpec = {
+      components: [
+        { kind: "query", id: "q1", sql: "s" },
+        {
+          kind: "chart",
+          id: "c1",
+          sourceQueryId: "q1",
+          spec: { kind: "bar", xColumn: "a", yColumns: ["b"] },
+        },
+      ],
+      edges: [],
+    };
+    const ids = get().applyAgentSpec(TAB, spec, "conn");
+    expect(ids).toEqual(["q1"]);
+    expect(get().boards[TAB].doc.components).toHaveLength(2);
+    expect(get().boards[TAB].doc.edges).toHaveLength(1);
+  });
+
+  it("runQueryComponent stores the result on success", async () => {
+    vi.mocked(runCanvasQueryIPC).mockResolvedValue({ columns: [], rows: [], elapsed: 1 });
+    get().ensureBoard(TAB, "");
+    get().addComponent(
+      TAB,
+      makeComponent({ kind: "query", id: "q1", sql: "select 1", connectionId: "conn" }),
+    );
+    await get().runQueryComponent(TAB, "q1");
+    expect(get().boards[TAB].runs.q1.result).toBeDefined();
+    expect(get().boards[TAB].runs.q1.running).toBe(false);
+  });
+
+  it("runQueryComponent errors (without calling IPC) when no connection is set", async () => {
+    get().ensureBoard(TAB, "");
+    get().addComponent(
+      TAB,
+      makeComponent({ kind: "query", id: "q1", sql: "s", connectionId: null }),
+    );
+    await get().runQueryComponent(TAB, "q1");
+    expect(get().boards[TAB].runs.q1.error).toBeTruthy();
+    expect(runCanvasQueryIPC).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/domains/canvas/hooks/store.ts
+++ b/frontend/src/domains/canvas/hooks/store.ts
@@ -1,0 +1,186 @@
+import { create } from "zustand";
+
+import type {
+  AgentCanvasSpec,
+  CanvasComponent,
+  CanvasDoc,
+  CanvasEdge,
+  CanvasViewport,
+  QueryRunState,
+} from "../types";
+import { parseDoc, specToBoard } from "../utils";
+import { runCanvasQueryIPC } from "../ipc";
+
+interface BoardState {
+  doc: CanvasDoc;
+  /// Runtime query results, keyed by query-object id. Never serialized.
+  runs: Record<string, QueryRunState>;
+}
+
+interface CanvasStore {
+  boards: Record<string, BoardState>;
+  /// Parse a tab's text into a board the first time it mounts; a no-op afterward
+  /// so live edits are never clobbered by a re-mount.
+  ensureBoard: (tabId: string, text: string) => void;
+  addComponent: (tabId: string, component: CanvasComponent) => void;
+  /// Merge a patch into one object (geometry from drag/resize, or prop edits).
+  updateComponent: (
+    tabId: string,
+    id: string,
+    patch: Partial<CanvasComponent>,
+  ) => void;
+  removeComponent: (tabId: string, id: string) => void;
+  setEdges: (tabId: string, edges: CanvasEdge[]) => void;
+  setViewport: (tabId: string, viewport: CanvasViewport) => void;
+  /// Append agent-generated objects, binding query objects to `connectionId`.
+  /// Returns the ids of the query objects added, so the caller can run them.
+  applyAgentSpec: (
+    tabId: string,
+    spec: AgentCanvasSpec,
+    connectionId: string | null,
+  ) => string[];
+  setRun: (tabId: string, id: string, run: QueryRunState) => void;
+  /// Execute a query object and store its result/error in `runs`.
+  runQueryComponent: (tabId: string, id: string) => Promise<void>;
+  removeBoard: (tabId: string) => void;
+}
+
+/// Normalize any thrown value into a readable message.
+function errToString(err: unknown): string {
+  if (typeof err === "string") return err;
+  if (err instanceof Error) return err.message;
+  return String(err);
+}
+
+/// Replace the doc of one board, leaving its runtime results in place.
+function withDoc(
+  boards: Record<string, BoardState>,
+  tabId: string,
+  next: (doc: CanvasDoc) => CanvasDoc,
+): Record<string, BoardState> {
+  const board = boards[tabId];
+  if (!board) return boards;
+  return { ...boards, [tabId]: { ...board, doc: next(board.doc) } };
+}
+
+const useCanvasStore = create<CanvasStore>((set, get) => ({
+  boards: {},
+
+  ensureBoard: (tabId, text) =>
+    set((s) =>
+      s.boards[tabId]
+        ? s
+        : { boards: { ...s.boards, [tabId]: { doc: parseDoc(text), runs: {} } } },
+    ),
+
+  addComponent: (tabId, component) =>
+    set((s) => ({
+      boards: withDoc(s.boards, tabId, (doc) => ({
+        ...doc,
+        components: [...doc.components, component],
+      })),
+    })),
+
+  updateComponent: (tabId, id, patch) =>
+    set((s) => ({
+      boards: withDoc(s.boards, tabId, (doc) => ({
+        ...doc,
+        components: doc.components.map((c) =>
+          c.id === id ? ({ ...c, ...patch } as CanvasComponent) : c,
+        ),
+      })),
+    })),
+
+  removeComponent: (tabId, id) =>
+    set((s) => {
+      const board = s.boards[tabId];
+      if (!board) return s;
+      const { [id]: _dropped, ...runs } = board.runs;
+      return {
+        boards: {
+          ...s.boards,
+          [tabId]: {
+            doc: {
+              ...board.doc,
+              components: board.doc.components.filter((c) => c.id !== id),
+              edges: board.doc.edges.filter(
+                (e) => e.source !== id && e.target !== id,
+              ),
+            },
+            runs,
+          },
+        },
+      };
+    }),
+
+  setEdges: (tabId, edges) =>
+    set((s) => ({
+      boards: withDoc(s.boards, tabId, (doc) => ({ ...doc, edges })),
+    })),
+
+  setViewport: (tabId, viewport) =>
+    set((s) => ({
+      boards: withDoc(s.boards, tabId, (doc) => ({ ...doc, viewport })),
+    })),
+
+  applyAgentSpec: (tabId, spec, connectionId) => {
+    const board = get().boards[tabId];
+    if (!board) return [];
+    const { components, edges } = specToBoard(
+      spec,
+      board.doc.components,
+      connectionId,
+    );
+    set((s) => ({
+      boards: withDoc(s.boards, tabId, (doc) => ({
+        ...doc,
+        components: [...doc.components, ...components],
+        edges: [...doc.edges, ...edges],
+      })),
+    }));
+    return components.filter((c) => c.kind === "query").map((c) => c.id);
+  },
+
+  setRun: (tabId, id, run) =>
+    set((s) => {
+      const board = s.boards[tabId];
+      if (!board) return s;
+      return {
+        boards: {
+          ...s.boards,
+          [tabId]: { ...board, runs: { ...board.runs, [id]: run } },
+        },
+      };
+    }),
+
+  runQueryComponent: async (tabId, id) => {
+    const board = get().boards[tabId];
+    const comp = board?.doc.components.find((c) => c.id === id);
+    if (!comp || comp.kind !== "query") return;
+    if (!comp.connectionId) {
+      get().setRun(tabId, id, { error: "Pick a connection for this query object." });
+      return;
+    }
+    if (!comp.sql.trim()) {
+      get().setRun(tabId, id, { error: "This query object is empty." });
+      return;
+    }
+    get().setRun(tabId, id, { running: true });
+    try {
+      const result = await runCanvasQueryIPC(comp.connectionId, comp.sql);
+      get().setRun(tabId, id, { running: false, result });
+    } catch (e) {
+      get().setRun(tabId, id, { running: false, error: errToString(e) });
+    }
+  },
+
+  removeBoard: (tabId) =>
+    set((s) => {
+      if (!s.boards[tabId]) return s;
+      const next = { ...s.boards };
+      delete next[tabId];
+      return { boards: next };
+    }),
+}));
+
+export { useCanvasStore };

--- a/frontend/src/domains/canvas/index.ts
+++ b/frontend/src/domains/canvas/index.ts
@@ -1,0 +1,12 @@
+import { registerTabView } from "@shared";
+import type { EditorTab } from "@shell/types";
+
+import { CanvasView } from "./components/CanvasView";
+
+/// Register the canvas thinkboard tab view so a tab with `tabType: "canvas"`
+/// renders the board. Called once at app startup from the shell.
+function registerCanvasTabView(): void {
+  registerTabView<EditorTab>({ tabType: "canvas", Component: CanvasView });
+}
+
+export { CanvasView, registerCanvasTabView };

--- a/frontend/src/domains/canvas/ipc.ts
+++ b/frontend/src/domains/canvas/ipc.ts
@@ -1,0 +1,26 @@
+import { invoke } from "@tauri-apps/api/core";
+import type { QueryLanguage, QueryResult, QueryValue } from "@shared";
+
+/// Row cap pulled for a board query object. Charts buffer the whole result, so a
+/// bound keeps a careless `SELECT *` from dragging the board down; `has_more`
+/// on the result signals truncation.
+const CANVAS_QUERY_PAGE_SIZE = 1000;
+
+/// Run a query object's SQL against its connection and return the first page of
+/// rows. Reuses the same `cmd_run_query` command the editor/results grid use.
+function runCanvasQueryIPC(
+  connectionId: string,
+  sql: string,
+  language?: QueryLanguage,
+): Promise<QueryResult> {
+  return invoke("cmd_run_query", {
+    connectionId,
+    sql,
+    params: [] as QueryValue[],
+    language,
+    pageSize: CANVAS_QUERY_PAGE_SIZE,
+    page: 0,
+  });
+}
+
+export { runCanvasQueryIPC };

--- a/frontend/src/domains/canvas/types.ts
+++ b/frontend/src/domains/canvas/types.ts
@@ -1,0 +1,150 @@
+import type { ChartSpec, QueryResult } from "@shared";
+
+/// The kind of a canvas object. The component is the lowest-level object on the
+/// board: it carries its own position, size, and stacking order, and objects may
+/// overlap. This discriminated union is the extension seam: a future object kind
+/// (e.g. a Python cell or a static-file table import) is added here, gains one
+/// renderer-registry entry, and one agent-spec arm. Nothing nests.
+type ComponentKind = "text" | "query" | "chart" | "shape"; // future: "python" | "tableImport"
+
+type ShapeKind = "rect" | "ellipse" | "line";
+type TextAlign = "left" | "center" | "right";
+
+interface TextStyle {
+  fontSize?: number;
+  bold?: boolean;
+  align?: TextAlign;
+  color?: string;
+}
+
+interface ShapeStyle {
+  fill?: string;
+  stroke?: string;
+  strokeWidth?: number;
+}
+
+/// Geometry shared by every object: canvas-space position, size, and z-order.
+interface BaseComponent {
+  id: string;
+  kind: ComponentKind;
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+  z: number;
+}
+
+interface TextComponent extends BaseComponent {
+  kind: "text";
+  text: string;
+  style?: TextStyle;
+}
+
+/// A SQL object: runs `sql` against `connectionId` and shows the result grid.
+/// Results are runtime-only (kept in the store's `runs`, never serialized).
+interface QueryComponent extends BaseComponent {
+  kind: "query";
+  connectionId: string | null;
+  sql: string;
+  title?: string;
+}
+
+/// A chart bound to a query object's data by `sourceQueryId`. Renders through the
+/// shared `@domains/chart` `ChartView` with the upstream query's `QueryResult`.
+interface ChartComponent extends BaseComponent {
+  kind: "chart";
+  sourceQueryId: string;
+  spec: ChartSpec;
+  title?: string;
+}
+
+interface ShapeComponent extends BaseComponent {
+  kind: "shape";
+  shape: ShapeKind;
+  style?: ShapeStyle;
+}
+
+type CanvasComponent =
+  | TextComponent
+  | QueryComponent
+  | ChartComponent
+  | ShapeComponent;
+
+/// A connector between two objects (e.g. a query feeding a chart).
+interface CanvasEdge {
+  id: string;
+  source: string;
+  target: string;
+}
+
+interface CanvasViewport {
+  x: number;
+  y: number;
+  zoom: number;
+}
+
+/// The persisted board document. Serialized into `EditorTab.text` (the same trick
+/// the notebook uses for nbformat), so a board survives close/reopen and restart.
+interface CanvasDoc {
+  version: number;
+  components: CanvasComponent[];
+  edges: CanvasEdge[];
+  viewport?: CanvasViewport;
+}
+
+/// Runtime execution state for a query object. Never part of `CanvasDoc`.
+interface QueryRunState {
+  running?: boolean;
+  result?: QueryResult;
+  error?: string;
+}
+
+// ── agent canvas spec (the `arris-canvas` JSON the agent emits) ───────────────
+
+/// One object in the agent's emitted spec. Loose by design: the agent may omit
+/// geometry (the client lays out), and only the fields for its `kind` are set.
+interface AgentComponentSpec {
+  kind: ComponentKind;
+  id: string;
+  // query
+  sql?: string;
+  connectionId?: string | null;
+  // chart
+  sourceQueryId?: string;
+  spec?: ChartSpec;
+  // text
+  text?: string;
+  // shape
+  shape?: ShapeKind;
+  // shared
+  title?: string;
+  x?: number;
+  y?: number;
+  w?: number;
+  h?: number;
+}
+
+interface AgentCanvasSpec {
+  components: AgentComponentSpec[];
+  edges?: CanvasEdge[];
+}
+
+export type {
+  AgentCanvasSpec,
+  AgentComponentSpec,
+  BaseComponent,
+  CanvasComponent,
+  CanvasDoc,
+  CanvasEdge,
+  CanvasViewport,
+  ChartComponent,
+  ComponentKind,
+  QueryComponent,
+  QueryRunState,
+  ShapeComponent,
+  ShapeKind,
+  ShapeStyle,
+  TextAlign,
+  TextComponent,
+  TextStyle,
+};

--- a/frontend/src/domains/canvas/utils/agentSpec.test.ts
+++ b/frontend/src/domains/canvas/utils/agentSpec.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+
+import type { AgentCanvasSpec } from "../types";
+import { parseAgentCanvas, specToBoard } from "./agentSpec";
+
+const wrap = (json: unknown) =>
+  "Here is your canvas:\n```arris-canvas\n" + JSON.stringify(json) + "\n```\nDone.";
+
+describe("parseAgentCanvas", () => {
+  it("extracts the arris-canvas block", () => {
+    const spec = parseAgentCanvas(
+      wrap({ components: [{ kind: "query", id: "q1", sql: "select 1" }], edges: [] }),
+    );
+    expect(spec?.components).toHaveLength(1);
+    expect(spec?.components[0]).toMatchObject({ kind: "query", id: "q1", sql: "select 1" });
+  });
+
+  it("returns null for prose with no block", () => {
+    expect(parseAgentCanvas("no canvas block here")).toBeNull();
+  });
+
+  it("returns null for malformed JSON", () => {
+    expect(parseAgentCanvas("```arris-canvas\n{not json\n```")).toBeNull();
+  });
+
+  it("drops unknown kinds, null when none remain", () => {
+    expect(parseAgentCanvas(wrap({ components: [{ kind: "bogus", id: "x" }] }))).toBeNull();
+  });
+
+  it("keeps only well-formed components", () => {
+    const spec = parseAgentCanvas(
+      wrap({ components: [{ kind: "text", id: "t", text: "hi" }, { kind: "chart" }] }),
+    );
+    expect(spec?.components).toHaveLength(1);
+  });
+});
+
+describe("specToBoard", () => {
+  const spec: AgentCanvasSpec = {
+    components: [
+      { kind: "query", id: "q1", sql: "select category, sum(total) t from orders group by 1" },
+      {
+        kind: "chart",
+        id: "c1",
+        sourceQueryId: "q1",
+        spec: { kind: "bar", xColumn: "category", yColumns: ["t"] },
+      },
+      { kind: "text", id: "t1", text: "## Sales" },
+    ],
+    edges: [],
+  };
+
+  it("creates objects, binds the query connection, and links chart to query", () => {
+    const { components, edges } = specToBoard(spec, [], "conn-1");
+    expect(components).toHaveLength(3);
+    const q = components.find((c) => c.id === "q1");
+    expect(q).toMatchObject({ kind: "query", connectionId: "conn-1" });
+    expect(edges).toEqual([{ id: expect.any(String), source: "q1", target: "c1" }]);
+  });
+
+  it("does not duplicate an explicit edge", () => {
+    const withEdge: AgentCanvasSpec = {
+      components: spec.components,
+      edges: [{ id: "e1", source: "q1", target: "c1" }],
+    };
+    expect(specToBoard(withEdge, [], null).edges).toHaveLength(1);
+  });
+
+  it("auto-lays-out below existing content", () => {
+    const existing = specToBoard(spec, [], null).components;
+    const more = specToBoard(
+      { components: [{ kind: "text", id: "t2", text: "more" }], edges: [] },
+      existing,
+      null,
+    ).components;
+    const lowestExisting = Math.max(...existing.map((c) => c.y + c.h));
+    expect(more[0].y).toBeGreaterThan(lowestExisting);
+  });
+});

--- a/frontend/src/domains/canvas/utils/agentSpec.ts
+++ b/frontend/src/domains/canvas/utils/agentSpec.ts
@@ -1,0 +1,120 @@
+import { CANVAS_SPEC_FENCE } from "../constants";
+import type {
+  AgentCanvasSpec,
+  AgentComponentSpec,
+  CanvasComponent,
+  CanvasEdge,
+  ComponentKind,
+} from "../types";
+import { autoLayout } from "./layout";
+import { makeComponent, makeEdge } from "./factory";
+import type { ComponentInput } from "./factory";
+
+const KNOWN_KINDS: ComponentKind[] = ["text", "query", "chart", "shape"];
+
+/// Pull the JSON body out of the agent's ```arris-canvas fenced block. Returns
+/// null when no such block is present (the agent replied with prose only).
+function extractBlock(text: string): string | null {
+  const re = new RegExp("```" + CANVAS_SPEC_FENCE + "[^\\n]*\\n([\\s\\S]*?)```");
+  const m = re.exec(text);
+  return m ? m[1].trim() : null;
+}
+
+function isComponentSpec(value: unknown): value is AgentComponentSpec {
+  if (!value || typeof value !== "object") return false;
+  const c = value as Record<string, unknown>;
+  return (
+    typeof c.id === "string" &&
+    typeof c.kind === "string" &&
+    KNOWN_KINDS.includes(c.kind as ComponentKind)
+  );
+}
+
+function isEdgeSpec(value: unknown): value is CanvasEdge {
+  if (!value || typeof value !== "object") return false;
+  const e = value as Record<string, unknown>;
+  return typeof e.source === "string" && typeof e.target === "string";
+}
+
+/// Parse the agent's reply into a canvas spec. Tolerant: a missing block, bad
+/// JSON, or a spec with no usable components all yield null, so a chatty or
+/// malformed turn simply produces no objects rather than an error.
+function parseAgentCanvas(text: string): AgentCanvasSpec | null {
+  const block = extractBlock(text);
+  if (!block) return null;
+  let raw: unknown;
+  try {
+    raw = JSON.parse(block);
+  } catch {
+    return null;
+  }
+  if (!raw || typeof raw !== "object") return null;
+  const obj = raw as Record<string, unknown>;
+  const components = Array.isArray(obj.components)
+    ? (obj.components.filter(isComponentSpec) as AgentComponentSpec[])
+    : [];
+  if (components.length === 0) return null;
+  const edges = Array.isArray(obj.edges)
+    ? (obj.edges.filter(isEdgeSpec) as CanvasEdge[])
+    : [];
+  return { components, edges };
+}
+
+function toInput(spec: AgentComponentSpec, connectionId: string | null): ComponentInput {
+  return {
+    kind: spec.kind,
+    id: spec.id,
+    x: spec.x,
+    y: spec.y,
+    w: spec.w,
+    h: spec.h,
+    title: spec.title,
+    text: spec.text,
+    sql: spec.sql,
+    // The agent does not know the connection id; bind query objects to the board.
+    connectionId: spec.kind === "query" ? connectionId : undefined,
+    sourceQueryId: spec.sourceQueryId,
+    spec: spec.spec,
+    shape: spec.shape,
+  };
+}
+
+/// Edges connecting each chart to its source query, plus any the agent supplied,
+/// deduped by (source, target). Charts always get a connector even when the
+/// agent omitted `edges`, so the data link is visible.
+function buildEdges(
+  spec: AgentCanvasSpec,
+  components: CanvasComponent[],
+): CanvasEdge[] {
+  const ids = new Set(components.map((c) => c.id));
+  const out: CanvasEdge[] = [];
+  const seen = new Set<string>();
+  const push = (source: string, target: string, id?: string) => {
+    if (!ids.has(source) || !ids.has(target)) return;
+    const key = `${source}->${target}`;
+    if (seen.has(key)) return;
+    seen.add(key);
+    out.push(makeEdge(source, target, id));
+  };
+  for (const e of spec.edges ?? []) push(e.source, e.target, e.id);
+  for (const c of components) {
+    if (c.kind === "chart" && c.sourceQueryId) push(c.sourceQueryId, c.id);
+  }
+  return out;
+}
+
+/// Convert a parsed agent spec into board objects: build each object (preserving
+/// agent ids so cross-references hold), auto-lay-out the unplaced ones below the
+/// existing content, and connect charts to their source queries.
+function specToBoard(
+  spec: AgentCanvasSpec,
+  existing: CanvasComponent[],
+  connectionId: string | null,
+): { components: CanvasComponent[]; edges: CanvasEdge[] } {
+  const created = spec.components.map((s) => makeComponent(toInput(s, connectionId)));
+  const components = autoLayout(created, existing);
+  const edges = buildEdges(spec, components);
+  return { components, edges };
+}
+
+export { parseAgentCanvas, specToBoard };

--- a/frontend/src/domains/canvas/utils/factory.test.ts
+++ b/frontend/src/domains/canvas/utils/factory.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import { DEFAULT_SIZE } from "../constants";
+import { makeComponent, makeEdge } from "./factory";
+
+describe("makeComponent", () => {
+  it("builds a text object with default size at the origin", () => {
+    const c = makeComponent({ kind: "text", id: "t1", text: "hello" });
+    expect(c).toMatchObject({
+      id: "t1",
+      kind: "text",
+      text: "hello",
+      x: 0,
+      y: 0,
+      z: 0,
+      w: DEFAULT_SIZE.text.w,
+      h: DEFAULT_SIZE.text.h,
+    });
+  });
+
+  it("binds a query object's connection and sql", () => {
+    const c = makeComponent({
+      kind: "query",
+      id: "q1",
+      sql: "select 1",
+      connectionId: "conn",
+    });
+    expect(c).toMatchObject({ kind: "query", sql: "select 1", connectionId: "conn" });
+  });
+
+  it("gives a chart a source query and a fallback spec", () => {
+    const c = makeComponent({ kind: "chart", id: "c1", sourceQueryId: "q1" });
+    expect(c).toMatchObject({ kind: "chart", sourceQueryId: "q1" });
+    if (c.kind === "chart") expect(c.spec).toBeDefined();
+  });
+
+  it("generates an id when none is supplied", () => {
+    const c = makeComponent({ kind: "shape", shape: "ellipse" });
+    expect(c.id).toBeTruthy();
+    expect(c).toMatchObject({ kind: "shape", shape: "ellipse" });
+  });
+
+  it("respects explicit geometry", () => {
+    const c = makeComponent({ kind: "text", x: 10, y: 20, w: 30, h: 40, z: 2 });
+    expect(c).toMatchObject({ x: 10, y: 20, w: 30, h: 40, z: 2 });
+  });
+});
+
+describe("makeEdge", () => {
+  it("links a source to a target", () => {
+    expect(makeEdge("a", "b", "e1")).toEqual({ id: "e1", source: "a", target: "b" });
+  });
+
+  it("generates an edge id when none is supplied", () => {
+    const e = makeEdge("a", "b");
+    expect(e.id).toBeTruthy();
+    expect(e).toMatchObject({ source: "a", target: "b" });
+  });
+});

--- a/frontend/src/domains/canvas/utils/factory.ts
+++ b/frontend/src/domains/canvas/utils/factory.ts
@@ -1,0 +1,101 @@
+import type { ChartSpec } from "@shared";
+
+import { DEFAULT_SIZE } from "../constants";
+import type {
+  CanvasComponent,
+  CanvasEdge,
+  ComponentKind,
+  ShapeKind,
+} from "../types";
+
+/// A loose description of an object to create. Geometry is optional (the board
+/// lays out anything left unplaced); per-kind fields are read by `makeComponent`.
+interface ComponentInput {
+  kind: ComponentKind;
+  id?: string;
+  x?: number;
+  y?: number;
+  w?: number;
+  h?: number;
+  z?: number;
+  title?: string;
+  // text
+  text?: string;
+  // query
+  connectionId?: string | null;
+  sql?: string;
+  // chart
+  sourceQueryId?: string;
+  spec?: ChartSpec;
+  // shape
+  shape?: ShapeKind;
+}
+
+let seq = 0;
+
+/// A board-unique id. Prefers a uuid (collision-proof across reloads, where a
+/// freshly loaded doc may already hold low counter values); falls back to a
+/// monotonic counter when crypto is unavailable.
+function genId(prefix: string): string {
+  const uuid = globalThis.crypto?.randomUUID?.();
+  if (uuid) return `${prefix}-${uuid.slice(0, 8)}`;
+  seq += 1;
+  return `${prefix}-${seq}`;
+}
+
+/// Resolve geometry: explicit values win, else the kind's default size at (0,0).
+function geometry(input: ComponentInput) {
+  const size = DEFAULT_SIZE[input.kind];
+  return {
+    x: input.x ?? 0,
+    y: input.y ?? 0,
+    w: input.w ?? size.w,
+    h: input.h ?? size.h,
+    z: input.z ?? 0,
+  };
+}
+
+/// A minimal, valid `ChartSpec` so a chart object renders before the agent or
+/// user refines it. Empty columns degrade to ChartView's own empty state.
+function fallbackChartSpec(): ChartSpec {
+  return { kind: "bar", xColumn: "", yColumns: [] };
+}
+
+/// Build a fully-formed `CanvasComponent` from a loose input, filling defaults.
+/// The single place object shape + defaults live; the toolbar and the agent-spec
+/// converter both go through here.
+function makeComponent(input: ComponentInput): CanvasComponent {
+  const id = input.id ?? genId(input.kind);
+  const geom = geometry(input);
+  switch (input.kind) {
+    case "text":
+      return { id, kind: "text", ...geom, text: input.text ?? "" };
+    case "query":
+      return {
+        id,
+        kind: "query",
+        ...geom,
+        connectionId: input.connectionId ?? null,
+        sql: input.sql ?? "",
+        title: input.title,
+      };
+    case "chart":
+      return {
+        id,
+        kind: "chart",
+        ...geom,
+        sourceQueryId: input.sourceQueryId ?? "",
+        spec: input.spec ?? fallbackChartSpec(),
+        title: input.title,
+      };
+    case "shape":
+      return { id, kind: "shape", ...geom, shape: input.shape ?? "rect" };
+  }
+}
+
+function makeEdge(source: string, target: string, id?: string): CanvasEdge {
+  return { id: id ?? genId("edge"), source, target };
+}
+
+export { genId, makeComponent, makeEdge };
+export type { ComponentInput };

--- a/frontend/src/domains/canvas/utils/index.ts
+++ b/frontend/src/domains/canvas/utils/index.ts
@@ -1,0 +1,5 @@
+export { parseAgentCanvas, specToBoard } from "./agentSpec";
+export { genId, makeComponent, makeEdge } from "./factory";
+export type { ComponentInput } from "./factory";
+export { autoLayout, contentBottom } from "./layout";
+export { emptyDoc, parseDoc, serializeDoc } from "./serialize";

--- a/frontend/src/domains/canvas/utils/layout.test.ts
+++ b/frontend/src/domains/canvas/utils/layout.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+
+import { LAYOUT_GAP, LAYOUT_ORIGIN } from "../constants";
+import { makeComponent } from "./factory";
+import { autoLayout, contentBottom } from "./layout";
+
+const text = (over: { id?: string; x?: number; y?: number; h?: number }) =>
+  makeComponent({ kind: "text", ...over });
+
+describe("contentBottom", () => {
+  it("is the origin when empty", () => {
+    expect(contentBottom([])).toBe(LAYOUT_ORIGIN.y);
+  });
+
+  it("is below the lowest object plus the gap", () => {
+    const existing = [text({ id: "e", y: 200, h: 80 })];
+    expect(contentBottom(existing)).toBe(200 + 80 + LAYOUT_GAP);
+  });
+});
+
+describe("autoLayout", () => {
+  it("stacks unplaced objects in a column from the origin", () => {
+    const a = text({ id: "a", h: 100 });
+    const b = text({ id: "b", h: 50 });
+    const [pa, pb] = autoLayout([a, b], []);
+    expect(pa).toMatchObject({ x: LAYOUT_ORIGIN.x, y: LAYOUT_ORIGIN.y });
+    expect(pb.y).toBe(LAYOUT_ORIGIN.y + 100 + LAYOUT_GAP);
+  });
+
+  it("stacks below existing content", () => {
+    const existing = [text({ id: "e", y: 200, h: 80 })];
+    const [placed] = autoLayout([text({ id: "a", h: 40 })], existing);
+    expect(placed.y).toBe(200 + 80 + LAYOUT_GAP);
+  });
+
+  it("leaves already-placed objects untouched", () => {
+    const [placed] = autoLayout([text({ id: "a", x: 5, y: 6 })], []);
+    expect(placed).toMatchObject({ x: 5, y: 6 });
+  });
+});

--- a/frontend/src/domains/canvas/utils/layout.ts
+++ b/frontend/src/domains/canvas/utils/layout.ts
@@ -1,0 +1,29 @@
+import { LAYOUT_GAP, LAYOUT_ORIGIN } from "../constants";
+import type { CanvasComponent } from "../types";
+
+/// The y just below all existing content (where fresh objects should begin), or
+/// the origin when the board is empty.
+function contentBottom(existing: CanvasComponent[]): number {
+  if (existing.length === 0) return LAYOUT_ORIGIN.y;
+  return Math.max(...existing.map((c) => c.y + c.h)) + LAYOUT_GAP;
+}
+
+/// Place any objects left at the default origin (0,0) into a single column below
+/// the board's existing content, preserving input order. Objects that already
+/// carry a position (e.g. coords the agent supplied, or a user-dragged object)
+/// are returned untouched. Minimal but predictable; a smarter side-by-side pass
+/// can replace this without changing callers.
+function autoLayout(
+  components: CanvasComponent[],
+  existing: CanvasComponent[],
+): CanvasComponent[] {
+  let cursorY = contentBottom(existing);
+  return components.map((c) => {
+    if (c.x !== 0 || c.y !== 0) return c;
+    const placed = { ...c, x: LAYOUT_ORIGIN.x, y: cursorY };
+    cursorY += c.h + LAYOUT_GAP;
+    return placed;
+  });
+}
+
+export { autoLayout, contentBottom };

--- a/frontend/src/domains/canvas/utils/serialize.test.ts
+++ b/frontend/src/domains/canvas/utils/serialize.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+import { CANVAS_DOC_VERSION } from "../constants";
+import { emptyDoc, parseDoc, serializeDoc } from "./serialize";
+
+describe("serialize", () => {
+  it("roundtrips a document", () => {
+    const doc = {
+      version: CANVAS_DOC_VERSION,
+      components: [
+        { id: "a", kind: "text" as const, x: 1, y: 2, w: 3, h: 4, z: 0, text: "hi" },
+      ],
+      edges: [{ id: "e", source: "a", target: "b" }],
+    };
+    expect(parseDoc(serializeDoc(doc))).toEqual(doc);
+  });
+
+  it("returns an empty doc for blank text", () => {
+    expect(parseDoc("")).toEqual(emptyDoc());
+    expect(parseDoc("   ")).toEqual(emptyDoc());
+  });
+
+  it("returns an empty doc for invalid JSON", () => {
+    expect(parseDoc("{not json")).toEqual(emptyDoc());
+  });
+
+  it("rejects an unknown version", () => {
+    const text = JSON.stringify({ version: 999, components: [], edges: [] });
+    expect(parseDoc(text)).toEqual(emptyDoc());
+  });
+
+  it("drops malformed components and edges", () => {
+    const text = JSON.stringify({
+      version: CANVAS_DOC_VERSION,
+      components: [
+        { id: "ok", kind: "text", x: 0, y: 0, w: 1, h: 1, z: 0, text: "" },
+        { bad: true },
+      ],
+      edges: [
+        { id: "e", source: "a", target: "b" },
+        { nope: 1 },
+      ],
+    });
+    const doc = parseDoc(text);
+    expect(doc.components).toHaveLength(1);
+    expect(doc.edges).toHaveLength(1);
+  });
+});

--- a/frontend/src/domains/canvas/utils/serialize.ts
+++ b/frontend/src/domains/canvas/utils/serialize.ts
@@ -1,0 +1,67 @@
+import { CANVAS_DOC_VERSION } from "../constants";
+import type { CanvasComponent, CanvasDoc, CanvasEdge } from "../types";
+
+/// A fresh, empty board document.
+function emptyDoc(): CanvasDoc {
+  return { version: CANVAS_DOC_VERSION, components: [], edges: [] };
+}
+
+/// True when a parsed value looks like a component we can render. Defensive: a
+/// hand-edited or future-version doc must never crash the board.
+function isComponent(value: unknown): value is CanvasComponent {
+  if (!value || typeof value !== "object") return false;
+  const c = value as Record<string, unknown>;
+  return (
+    typeof c.id === "string" &&
+    typeof c.kind === "string" &&
+    typeof c.x === "number" &&
+    typeof c.y === "number"
+  );
+}
+
+function isEdge(value: unknown): value is CanvasEdge {
+  if (!value || typeof value !== "object") return false;
+  const e = value as Record<string, unknown>;
+  return (
+    typeof e.id === "string" &&
+    typeof e.source === "string" &&
+    typeof e.target === "string"
+  );
+}
+
+/// Serialize a board to the string stored in `EditorTab.text`.
+function serializeDoc(doc: CanvasDoc): string {
+  return JSON.stringify(doc);
+}
+
+/// Parse a tab's text back into a board. Tolerant by design: blank text, invalid
+/// JSON, or a doc from an unknown version all yield an empty board rather than
+/// throwing, so a corrupt tab never breaks the workspace.
+function parseDoc(text: string): CanvasDoc {
+  const trimmed = (text ?? "").trim();
+  if (!trimmed) return emptyDoc();
+  let raw: unknown;
+  try {
+    raw = JSON.parse(trimmed);
+  } catch {
+    return emptyDoc();
+  }
+  if (!raw || typeof raw !== "object") return emptyDoc();
+  const doc = raw as Record<string, unknown>;
+  if (doc.version !== CANVAS_DOC_VERSION) return emptyDoc();
+  const components = Array.isArray(doc.components)
+    ? (doc.components.filter(isComponent) as CanvasComponent[])
+    : [];
+  const edges = Array.isArray(doc.edges)
+    ? (doc.edges.filter(isEdge) as CanvasEdge[])
+    : [];
+  const viewport =
+    doc.viewport &&
+    typeof doc.viewport === "object" &&
+    typeof (doc.viewport as Record<string, unknown>).zoom === "number"
+      ? (doc.viewport as CanvasDoc["viewport"])
+      : undefined;
+  return { version: CANVAS_DOC_VERSION, components, edges, viewport };
+}
+
+export { emptyDoc, parseDoc, serializeDoc };

--- a/frontend/src/domains/editor/components/EditorPane/components/TabBar/index.tsx
+++ b/frontend/src/domains/editor/components/EditorPane/components/TabBar/index.tsx
@@ -28,11 +28,12 @@ interface Props {
   onAdd: () => void;
   onAddTerminal?: () => void;
   onAddNotebook?: () => void;
+  onAddCanvas?: () => void;
   onSplit?: (id: string, direction: SplitDirection) => void;
   onRename?: (id: string, newTitle: string) => void;
 }
 
-const RENAMEABLE_TAB_TYPES: TabType[] = ["console", "pinned", "terminal", "notebook"];
+const RENAMEABLE_TAB_TYPES: TabType[] = ["console", "pinned", "terminal", "notebook", "canvas"];
 
 function isRenameable(tabType?: TabType): boolean {
   return !!tabType && RENAMEABLE_TAB_TYPES.includes(tabType);
@@ -47,6 +48,7 @@ function TabBar({
   onAdd,
   onAddTerminal,
   onAddNotebook,
+  onAddCanvas,
   onSplit,
   onRename,
 }: Props) {
@@ -186,6 +188,13 @@ function TabBar({
               onClick={onAddNotebook}
             >
               <Icon name="notebook" size={12} />
+            </button>
+          </Tooltip>
+        )}
+        {onAddCanvas && (
+          <Tooltip label="New Canvas">
+            <button className="mdbc-tab-add" data-testid="tab-add-canvas" onClick={onAddCanvas}>
+              <Icon name="sparkles" size={12} />
             </button>
           </Tooltip>
         )}

--- a/frontend/src/domains/editor/components/EditorPane/index.tsx
+++ b/frontend/src/domains/editor/components/EditorPane/index.tsx
@@ -335,6 +335,7 @@ function PaneGroupView({ groupId }: { groupId: string }) {
   const addTab = useTabsStore((s) => s.addTab);
   const openTerminalTab = useTabsStore((s) => s.openTerminalTab);
   const openUntitledNotebookTab = useTabsStore((s) => s.openUntitledNotebookTab);
+  const openUntitledCanvasTab = useTabsStore((s) => s.openUntitledCanvasTab);
   const selectedConnectionId = useConnectionsStore((s) => s.selectedId);
   const selectConnection = useConnectionsStore((s) => s.selectConnection);
   const connections = useConnectionsStore((s) => s.connections);
@@ -609,6 +610,11 @@ function PaneGroupView({ groupId }: { groupId: string }) {
   function newNotebookTab() {
     focusGroup(groupId);
     openUntitledNotebookTab();
+  }
+
+  function newCanvasTab() {
+    focusGroup(groupId);
+    openUntitledCanvasTab(selectedConnectionId ?? undefined);
   }
 
   const tabConnectionId = resolveTabConnectionId({
@@ -1834,6 +1840,7 @@ function PaneGroupView({ groupId }: { groupId: string }) {
       splitBottom: { run: () => { if (activeTab) handleSplit(activeTab.id, "down"); }, isEnabled: () => !!activeTab },
       newTerminalTab: { run: () => newTerminalTab() },
       newNotebookTab: { run: () => newNotebookTab() },
+      newCanvasTab: { run: () => newCanvasTab() },
       switchTab: {
         run: () => {
           const index = groupTabs.findIndex((tab) => tab.id === activeId);
@@ -1863,6 +1870,7 @@ function PaneGroupView({ groupId }: { groupId: string }) {
         onAdd={newTab}
         onAddTerminal={newTerminalTab}
         onAddNotebook={newNotebookTab}
+        onAddCanvas={newCanvasTab}
         onSplit={handleSplit}
         onRename={handleRename}
       />

--- a/frontend/src/shared/backendTypes.ts
+++ b/frontend/src/shared/backendTypes.ts
@@ -267,7 +267,8 @@ type TabType =
   | "gitdiff"
   | "gitcommitdiff"
   | "githistory"
-  | "gitconflict";
+  | "gitconflict"
+  | "canvas";
 
 /** Identity of the object a `definition` tab shows DDL for; drives one-tab-per-object dedup. */
 interface ObjectIdentity {

--- a/frontend/src/shared/settings/constants.ts
+++ b/frontend/src/shared/settings/constants.ts
@@ -31,6 +31,7 @@ export const ACTIONS = {
   splitBottom: { label: "Split Editor Bottom", category: "tabs", defaultShortcut: null },
   newTerminalTab: { label: "New Terminal Tab", category: "tabs", defaultShortcut: null },
   newNotebookTab: { label: "New Jupyter Notebook", category: "tabs", defaultShortcut: null },
+  newCanvasTab: { label: "New Canvas", category: "tabs", defaultShortcut: null },
   runCellAndInsertBelow: { label: "Run Cell and Insert Below", category: "tabs", defaultShortcut: { key: "Shift-Enter" } },
 
   openSettings: { label: "Open Settings", category: "navigation", defaultShortcut: { key: "Mod-," } },

--- a/frontend/src/shell/hooks/tabsStore.ts
+++ b/frontend/src/shell/hooks/tabsStore.ts
@@ -62,6 +62,7 @@ interface TabsState {
   /// Open a brand-new untitled in-memory notebook tab (not backed by a file).
   /// The NotebookView seeds it with a single empty Python cell on mount.
   openUntitledNotebookTab: () => EditorTab;
+  openUntitledCanvasTab: (connectionId?: string) => EditorTab;
   /// Open (or refocus) the single "Uncommitted Changes" git diff tab. Only one
   /// can ever exist; a second call refocuses the existing one.
   openGitDiffTab: () => EditorTab;
@@ -561,6 +562,30 @@ const useTabsStore = create<TabsState>((set, get) => ({
       kind: "notebook",
       cursor: 0,
       tabType: "notebook",
+      createdAt: Date.now(),
+    };
+    set((s) => appendTabToFocusedGroup(s, tab));
+    useSettingsStore.getState().hideBottomPane();
+    return tab;
+  },
+  openUntitledCanvasTab: (connectionId) => {
+    // Number from the highest existing "Canvas N" (closed boards linger in
+    // tabs[]), mirroring the notebook scheme so numbers never collide. An empty
+    // text parses to an empty board; the connection seeds query objects + the
+    // agent's schema context.
+    const maxSeq = get().tabs.reduce((max, t) => {
+      if (t.tabType !== "canvas") return max;
+      const m = /^Canvas (\d+)$/.exec(t.title);
+      return m ? Math.max(max, Number(m[1])) : max;
+    }, 0);
+    const tab: EditorTab = {
+      id: makeId(),
+      title: `Canvas ${maxSeq + 1}`,
+      text: "",
+      kind: "canvas",
+      connectionId,
+      cursor: 0,
+      tabType: "canvas",
       createdAt: Date.now(),
     };
     set((s) => appendTabToFocusedGroup(s, tab));

--- a/frontend/src/shell/index.ts
+++ b/frontend/src/shell/index.ts
@@ -1,4 +1,5 @@
 import { registerAgentPane } from "@domains/agent";
+import { registerCanvasTabView } from "@domains/canvas";
 import { registerConnectionsPane, registerDefinitionTabView } from "@domains/connection";
 import { registerChartPane } from "@domains/chart";
 import { registerPinnedQueriesPane } from "@domains/pinnedQueries";
@@ -32,6 +33,7 @@ function registerPanes(): void {
   registerGitPane();
   // Editor tab views contributed by domains.
   registerNotebookTabView();
+  registerCanvasTabView();
   registerGitTabViews();
   registerMediaTabView();
   registerDefinitionTabView();

--- a/src-tauri/src/commands/agent.rs
+++ b/src-tauri/src/commands/agent.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
-use arris_engines::agent::{AgentEvent, AgentProvider};
+use arris_engines::agent::{AgentEvent, AgentProfile, AgentProvider};
 use arris_engines::{AppEnvironment, IpcError};
 use serde::Serialize;
 use tauri::{AppHandle, Emitter, State};
@@ -50,6 +50,7 @@ pub async fn cmd_agent_send(
     env: State<'_, Arc<AppEnvironment>>,
     runs: State<'_, AgentRuns>,
     provider: AgentProvider,
+    profile: Option<AgentProfile>,
     connection_id: Option<Uuid>,
     prompt: String,
     turn_id: String,
@@ -57,6 +58,7 @@ pub async fn cmd_agent_send(
 ) -> Result<(), IpcError> {
     let env = Arc::clone(env.inner());
     let runs = runs.inner().clone();
+    let profile = profile.unwrap_or_default();
     let (cancel_tx, cancel_rx) = oneshot::channel();
     runs.inner.lock().await.insert(turn_id.clone(), cancel_tx);
     tokio::spawn(async move {
@@ -64,6 +66,7 @@ pub async fn cmd_agent_send(
             &app,
             &env,
             provider,
+            profile,
             connection_id,
             prompt,
             turn_id.clone(),
@@ -91,6 +94,7 @@ async fn run_turn(
     app: &AppHandle,
     env: &AppEnvironment,
     provider: AgentProvider,
+    profile: AgentProfile,
     connection_id: Option<Uuid>,
     prompt: String,
     turn_id: String,
@@ -146,7 +150,15 @@ async fn run_turn(
 
     match env
         .agent
-        .send(provider, dialect, schema_ddl, prompt, resume_session, cancel)
+        .send(
+            provider,
+            profile,
+            dialect,
+            schema_ddl,
+            prompt,
+            resume_session,
+            cancel,
+        )
         .await
     {
         Ok(mut rx) => {


### PR DESCRIPTION
## What does this PR do?

Introduces the Canvas thinkboard: a new canvas tab type backed by a ReactFlow board where objects (text, query, chart, shape) live as free-positioned nodes, plus a canvas-scoped agent chat that generates those objects from a connection's schema.

Included
- Agent engine gains a Canvas profile + prompt that emits a structured arris-canvas spec (backend).
- New domains/canvas core: types (CanvasComponent union, CanvasDoc), store, serialize/factory/agent-spec utils.
- ReactFlow board view with per-kind object nodes.
- Canvas agent chat panel.
- Tab type, New Canvas keymap command, tab-view registration.
- Docs page for the thinkboard.

## Checklist

- [ ] I opened an issue first for non-trivial changes, or this is a small fix.
- [X] Tests added/updated for my change.
- [X] **I license my contribution under the MIT License**, per [CONTRIBUTING.md](../CONTRIBUTING.md). I confirm this is my original work, or that I have the right to submit it.