### PR TITLE
[Feature] Canvas cell chaining

### DIFF
--- a/crates/arris-engines/src/app.rs
+++ b/crates/arris-engines/src/app.rs
@@ -24,6 +24,7 @@ pub enum AppEnvironmentError {
 
 pub struct AppEnvironment {
     pub agent: crate::agent::AgentEngine,
+    pub canvas: crate::canvas::CanvasEngine,
     pub connection: crate::connection::ConnectionEngine,
     pub dbt: crate::dbt::DbtEngine,
     pub file: crate::file::FileEngine,
@@ -51,12 +52,20 @@ impl AppEnvironment {
     pub async fn init_at(dir: PathBuf) -> Result<Arc<Self>, AppEnvironmentError> {
         let connection = crate::connection::ConnectionEngine::new(dir.clone()).await;
         let logs_dir = dir.join(DEBUG_LOGS_DIR_NAME);
+        // Canvas cell-chaining keeps each cell's result as Arrow; the cache spills
+        // to this directory past its memory tier and is hard-capped on disk.
+        let cell_cache = Arc::new(crate::canvas::CellResultCache::new(
+            dir.join("canvas-cell-cache"),
+            crate::canvas::CELL_CACHE_MEMORY_BUDGET,
+            crate::canvas::CELL_CACHE_TOTAL_BUDGET,
+        ));
         let preferences_store = AppPreferencesStore::new(dir);
         let preferences = preferences_store.load().await.unwrap_or_default();
         let debug_log = DebugLogHandle::new(logs_dir, preferences.debug_mode);
 
         Ok(Arc::new(Self {
             agent: crate::agent::AgentEngine::new(),
+            canvas: crate::canvas::CanvasEngine::new(cell_cache),
             connection,
             dbt: crate::dbt::DbtEngine::new(),
             file: crate::file::FileEngine::new(),

--- a/crates/arris-engines/src/canvas/constants.rs
+++ b/crates/arris-engines/src/canvas/constants.rs
@@ -1,0 +1,13 @@
+/// Hard cap on the combined in-memory + on-disk footprint of one board's
+/// cell-result cache. Once crossed, least-recently-used cell results are evicted.
+pub const CELL_CACHE_TOTAL_BUDGET: usize = 10 * 1024 * 1024 * 1024;
+
+/// Soft cap on the in-memory tier of the cell-result cache. Results above this
+/// (coldest first) spill to Arrow IPC on disk; they stay queryable, just read
+/// back from the file on demand.
+pub const CELL_CACHE_MEMORY_BUDGET: usize = 1024 * 1024 * 1024;
+
+/// Memory pool for a single chained-cell DataFusion query. Separate from the
+/// cache budget above: this bounds one query's working set (it spills to disk
+/// past the limit), the cache budget bounds stored results.
+pub(crate) const QUERY_MEMORY_POOL_SIZE: usize = 512 * 1024 * 1024;

--- a/crates/arris-engines/src/canvas/errors.rs
+++ b/crates/arris-engines/src/canvas/errors.rs
@@ -1,0 +1,13 @@
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum CanvasError {
+    #[error("cell cache I/O error: {0}")]
+    Io(String),
+    #[error("arrow error: {0}")]
+    Arrow(String),
+    #[error("result conversion error: {0}")]
+    Conversion(String),
+    #[error("query engine error: {0}")]
+    Engine(String),
+}

--- a/crates/arris-engines/src/canvas/impl_canvas_engine.rs
+++ b/crates/arris-engines/src/canvas/impl_canvas_engine.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -12,6 +13,7 @@ use datafusion::prelude::{SessionConfig, SessionContext};
 use super::constants::QUERY_MEMORY_POOL_SIZE;
 use super::errors::CanvasError;
 use super::impl_cell_result_cache::CellResultCache;
+use super::types::CanvasCellSpec;
 use crate::federation::FederationEngine;
 use crate::QueryResult;
 
@@ -22,8 +24,9 @@ use crate::QueryResult;
 /// canvas cell-chaining feature: cell B can `SELECT ... FROM a` where `a` is the
 /// sanitized title of cell A.
 ///
-/// Scope today (Phase 1): cell-to-cell references only. A cell that also reads a
-/// live database table is a later phase (it reuses the federation scan path).
+/// Cache entries are board-scoped, so two boards may reuse the same cell titles
+/// without colliding. Planning (`plan`) and reference parsing (`table_refs`) are
+/// pure helpers the command layer uses to drive the auto-run-upstream order.
 pub struct CanvasEngine {
     cache: Arc<CellResultCache>,
 }
@@ -64,10 +67,10 @@ impl CanvasEngine {
     }
 
     /// The table names referenced after `FROM`/`JOIN`, lowercased and stripped to
-    /// their leading identifier. Used to decide which cached cells to register.
-    /// A dotted name (`conn.schema.table`) reduces to its first segment, which a
-    /// cell title never matches, so federation refs are simply ignored here.
-    fn referenced_tables(sql: &str) -> Vec<String> {
+    /// their leading identifier. A dotted name (`conn.schema.table`) reduces to
+    /// its first segment, which a cell title never matches, so a federation/live
+    /// reference simply doesn't resolve to a cell here.
+    pub fn table_refs(sql: &str) -> Vec<String> {
         let tokens: Vec<&str> = sql
             .split(|c: char| c.is_whitespace() || c == ',' || c == '(' || c == ')')
             .filter(|t| !t.is_empty())
@@ -89,6 +92,65 @@ impl CanvasEngine {
         out
     }
 
+    /// Board-scoped cache key for a cell title.
+    fn key(board: &str, title: &str) -> String {
+        format!("{board}\u{1}{}", Self::sanitize_title(title))
+    }
+
+    /// Topologically order the target cell and its transitive cell dependencies
+    /// (dependencies first, target last), so the caller runs upstream cells
+    /// before the ones that read them. Returns an error on a dependency cycle or
+    /// an unknown target.
+    pub fn plan(cells: &[CanvasCellSpec], target_id: &str) -> Result<Vec<String>, CanvasError> {
+        let by_id: HashMap<&str, &CanvasCellSpec> =
+            cells.iter().map(|c| (c.id.as_str(), c)).collect();
+        if !by_id.contains_key(target_id) {
+            return Err(CanvasError::Engine(format!("unknown target cell {target_id}")));
+        }
+        // Sanitized title -> cell id. Last cell wins on a title collision.
+        let title_to_id: HashMap<String, String> = cells
+            .iter()
+            .map(|c| (Self::sanitize_title(&c.title), c.id.clone()))
+            .collect();
+
+        let mut order: Vec<String> = Vec::new();
+        // 0 = on the current DFS stack (cycle if re-seen), 1 = finished.
+        let mut state: HashMap<String, u8> = HashMap::new();
+        Self::visit(target_id, &by_id, &title_to_id, &mut state, &mut order)?;
+        Ok(order)
+    }
+
+    fn visit(
+        id: &str,
+        by_id: &HashMap<&str, &CanvasCellSpec>,
+        title_to_id: &HashMap<String, String>,
+        state: &mut HashMap<String, u8>,
+        order: &mut Vec<String>,
+    ) -> Result<(), CanvasError> {
+        match state.get(id) {
+            Some(1) => return Ok(()),
+            Some(_) => {
+                return Err(CanvasError::Engine(format!(
+                    "dependency cycle involving cell {id}"
+                )))
+            }
+            None => {}
+        }
+        state.insert(id.to_string(), 0);
+        if let Some(cell) = by_id.get(id) {
+            for dep_title in Self::table_refs(&cell.sql) {
+                if let Some(dep_id) = title_to_id.get(&dep_title) {
+                    if dep_id != id {
+                        Self::visit(dep_id, by_id, title_to_id, state, order)?;
+                    }
+                }
+            }
+        }
+        state.insert(id.to_string(), 1);
+        order.push(id.to_string());
+        Ok(())
+    }
+
     /// A DataFusion session with a bounded, disk-spilling memory pool. Mirrors the
     /// federation engine's setup so chained-cell queries spill rather than OOM.
     fn session_context() -> Result<SessionContext, CanvasError> {
@@ -102,23 +164,35 @@ impl CanvasEngine {
         Ok(SessionContext::new_with_config_rt(config, runtime))
     }
 
-    /// Store a plain (non-chained) cell's result so downstream cells can read it.
-    /// Call this after running any ordinary query object on the board.
-    pub fn cache_result(&self, title: &str, result: &QueryResult) -> Result<(), CanvasError> {
+    /// Store a plain (non-chained) cell's result so downstream cells on the same
+    /// board can read it. Call this after running any ordinary query object.
+    pub fn cache_result(
+        &self,
+        board: &str,
+        title: &str,
+        result: &QueryResult,
+    ) -> Result<(), CanvasError> {
         let (_schema, batch) =
             FederationEngine::query_result_to_batch(result).map_err(CanvasError::Conversion)?;
-        self.cache.put(&Self::sanitize_title(title), vec![batch])
+        self.cache.put(&Self::key(board, title), vec![batch])
     }
 
-    /// Run one cell's SQL, registering every referenced cell that has a cached
-    /// result as a `MemTable`, then cache this cell's own output under its
-    /// sanitized title (so cells downstream of it can read it in turn).
-    pub async fn run_cell(&self, title: &str, sql: &str) -> Result<QueryResult, CanvasError> {
+    /// Run one cell's SQL, registering every referenced cell on this board that has
+    /// a cached result as a `MemTable`, then cache this cell's own output under its
+    /// sanitized title (so cells downstream of it can read it in turn). A trailing
+    /// semicolon is stripped (DataFusion rejects it).
+    pub async fn run_cell(
+        &self,
+        board: &str,
+        title: &str,
+        sql: &str,
+    ) -> Result<QueryResult, CanvasError> {
+        let sql = sql.trim().trim_end_matches(';').trim();
         let start = Instant::now();
         let ctx = Self::session_context()?;
 
-        for name in Self::referenced_tables(sql) {
-            if let Some(batches) = self.cache.get(&name)? {
+        for name in Self::table_refs(sql) {
+            if let Some(batches) = self.cache.get(&Self::key(board, &name))? {
                 let schema = batches[0].schema();
                 let table = MemTable::try_new(schema, vec![batches])
                     .map_err(|e| CanvasError::Engine(e.to_string()))?;
@@ -140,20 +214,30 @@ impl CanvasEngine {
             batches.push(RecordBatch::new_empty(schema));
         }
 
-        let result = FederationEngine::batches_to_query_result(&batches, start.elapsed().as_secs_f64());
-        self.cache.put(&Self::sanitize_title(title), batches)?;
+        let result =
+            FederationEngine::batches_to_query_result(&batches, start.elapsed().as_secs_f64());
+        self.cache.put(&Self::key(board, title), batches)?;
         Ok(result)
+    }
+
+    /// Drop every cached result for a board (e.g. when its tab closes).
+    pub fn clear_board(&self, board: &str, titles: &[String]) {
+        for title in titles {
+            self.cache.remove(&Self::key(board, title));
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::sync::atomic::{AtomicU64, Ordering};
     use std::path::PathBuf;
+    use std::sync::atomic::{AtomicU64, Ordering};
 
     use crate::{ColumnSpec, QueryValue, StatementType};
 
     use super::*;
+
+    const BOARD: &str = "board-1";
 
     static DIR_SEQ: AtomicU64 = AtomicU64::new(0);
 
@@ -190,6 +274,15 @@ mod tests {
         }
     }
 
+    fn spec(id: &str, title: &str, sql: &str) -> CanvasCellSpec {
+        CanvasCellSpec {
+            id: id.to_string(),
+            title: title.to_string(),
+            sql: sql.to_string(),
+            connection_id: None,
+        }
+    }
+
     fn text_at(result: &QueryResult, row: usize, col: usize) -> String {
         match &result.rows[row][col] {
             QueryValue::Text(s) => s.clone(),
@@ -207,10 +300,11 @@ mod tests {
     #[tokio::test]
     async fn cell_b_aggregates_cell_a_cached_result() {
         let engine = engine();
-        engine.cache_result("a", &sales_result()).unwrap();
+        engine.cache_result(BOARD, "a", &sales_result()).unwrap();
 
         let out = engine
             .run_cell(
+                BOARD,
                 "b",
                 "SELECT category, SUM(total) AS total FROM a GROUP BY category ORDER BY category",
             )
@@ -229,30 +323,84 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn select_star_with_trailing_semicolon_reads_the_cell() {
+        let engine = engine();
+        engine.cache_result(BOARD, "abc", &sales_result()).unwrap();
+        // Mirrors the UI: a `SELECT * fROM abc;` reading another cell's result.
+        let out = engine.run_cell(BOARD, "query", "SELECT * fROM abc;").await.unwrap();
+        assert_eq!(out.rows.len(), 3);
+        assert_eq!(out.columns.len(), 2);
+    }
+
+    #[tokio::test]
     async fn a_chained_cell_is_cached_for_its_own_downstream() {
         let engine = engine();
-        engine.cache_result("a", &sales_result()).unwrap();
-        // b depends on a; c depends on b. Running b then c proves a two-hop chain.
+        engine.cache_result(BOARD, "a", &sales_result()).unwrap();
         engine
-            .run_cell("b", "SELECT category, SUM(total) AS total FROM a GROUP BY category")
+            .run_cell(BOARD, "b", "SELECT category, SUM(total) AS total FROM a GROUP BY category")
             .await
             .unwrap();
-        assert!(engine.cache().contains("b"));
+        assert!(engine.cache().contains(&CanvasEngine::key(BOARD, "b")));
 
         let out = engine
-            .run_cell("c", "SELECT SUM(total) AS grand FROM b")
+            .run_cell(BOARD, "c", "SELECT SUM(total) AS grand FROM b")
             .await
             .unwrap();
         assert_eq!(int_at(&out, 0, 0), 18);
     }
 
     #[tokio::test]
+    async fn board_scoping_keeps_same_titled_cells_apart() {
+        let engine = engine();
+        let mut other = sales_result();
+        other.rows.clear();
+        engine.cache_result("board-A", "a", &sales_result()).unwrap();
+        engine.cache_result("board-B", "a", &other).unwrap();
+        let a = engine.run_cell("board-A", "x", "SELECT * FROM a").await.unwrap();
+        let b = engine.run_cell("board-B", "x", "SELECT * FROM a").await.unwrap();
+        assert_eq!(a.rows.len(), 3);
+        assert_eq!(b.rows.len(), 0);
+    }
+
+    #[tokio::test]
     async fn referencing_an_unknown_cell_errors() {
         let engine = engine();
         let err = engine
-            .run_cell("b", "SELECT * FROM does_not_exist")
+            .run_cell(BOARD, "b", "SELECT * FROM does_not_exist")
             .await
             .unwrap_err();
+        assert!(matches!(err, CanvasError::Engine(_)));
+    }
+
+    #[test]
+    fn plan_orders_dependencies_before_the_target() {
+        let cells = vec![
+            spec("id_q", "Query", "SELECT * FROM abc"),
+            spec("id_abc", "abc", "SELECT * FROM public.sales"),
+        ];
+        let order = CanvasEngine::plan(&cells, "id_q").unwrap();
+        assert_eq!(order, vec!["id_abc".to_string(), "id_q".to_string()]);
+    }
+
+    #[test]
+    fn plan_runs_only_the_targets_ancestors() {
+        let cells = vec![
+            spec("a", "a", "SELECT 1"),
+            spec("b", "b", "SELECT * FROM a"),
+            spec("c", "c", "SELECT 2"),
+        ];
+        // Target b pulls in a, but not the unrelated c.
+        let order = CanvasEngine::plan(&cells, "b").unwrap();
+        assert_eq!(order, vec!["a".to_string(), "b".to_string()]);
+    }
+
+    #[test]
+    fn plan_detects_a_dependency_cycle() {
+        let cells = vec![
+            spec("a", "a", "SELECT * FROM b"),
+            spec("b", "b", "SELECT * FROM a"),
+        ];
+        let err = CanvasEngine::plan(&cells, "a").unwrap_err();
         assert!(matches!(err, CanvasError::Engine(_)));
     }
 
@@ -266,10 +414,9 @@ mod tests {
     }
 
     #[test]
-    fn referenced_tables_picks_out_from_and_join_targets() {
-        let refs = CanvasEngine::referenced_tables(
-            "SELECT * FROM Orders o JOIN customers c ON o.cid = c.id",
-        );
+    fn table_refs_picks_out_from_and_join_targets() {
+        let refs =
+            CanvasEngine::table_refs("SELECT * FROM Orders o JOIN customers c ON o.cid = c.id");
         assert_eq!(refs, vec!["orders", "customers"]);
     }
 }

--- a/crates/arris-engines/src/canvas/impl_canvas_engine.rs
+++ b/crates/arris-engines/src/canvas/impl_canvas_engine.rs
@@ -1,0 +1,275 @@
+use std::sync::Arc;
+use std::time::Instant;
+
+use datafusion::arrow::datatypes::SchemaRef;
+use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::datasource::MemTable;
+use datafusion::execution::disk_manager::DiskManagerBuilder;
+use datafusion::execution::memory_pool::FairSpillPool;
+use datafusion::execution::runtime_env::RuntimeEnvBuilder;
+use datafusion::prelude::{SessionConfig, SessionContext};
+
+use super::constants::QUERY_MEMORY_POOL_SIZE;
+use super::errors::CanvasError;
+use super::impl_cell_result_cache::CellResultCache;
+use crate::federation::FederationEngine;
+use crate::QueryResult;
+
+/// Runs canvas query cells that read OTHER cells' results. Each cell's output is
+/// kept (as Arrow) in a [`CellResultCache`]; when a cell's SQL references another
+/// cell by its (sanitized) title, that cached result is registered as a DataFusion
+/// `MemTable` and the query executes in-process. This is the engine half of the
+/// canvas cell-chaining feature: cell B can `SELECT ... FROM a` where `a` is the
+/// sanitized title of cell A.
+///
+/// Scope today (Phase 1): cell-to-cell references only. A cell that also reads a
+/// live database table is a later phase (it reuses the federation scan path).
+pub struct CanvasEngine {
+    cache: Arc<CellResultCache>,
+}
+
+impl CanvasEngine {
+    pub fn new(cache: Arc<CellResultCache>) -> Self {
+        Self { cache }
+    }
+
+    pub fn cache(&self) -> &Arc<CellResultCache> {
+        &self.cache
+    }
+
+    /// Turn a cell title into a SQL-safe table identifier: lowercased, every
+    /// non-alphanumeric run collapsed to a single underscore, trimmed, and
+    /// prefixed if it would otherwise start with a digit. This is the name a
+    /// downstream cell uses to reference it.
+    pub fn sanitize_title(title: &str) -> String {
+        let mut out = String::new();
+        let mut prev_underscore = false;
+        for ch in title.chars() {
+            if ch.is_ascii_alphanumeric() {
+                out.push(ch.to_ascii_lowercase());
+                prev_underscore = false;
+            } else if !prev_underscore {
+                out.push('_');
+                prev_underscore = true;
+            }
+        }
+        let trimmed = out.trim_matches('_');
+        if trimmed.is_empty() {
+            return "cell".to_string();
+        }
+        if trimmed.starts_with(|c: char| c.is_ascii_digit()) {
+            return format!("_{trimmed}");
+        }
+        trimmed.to_string()
+    }
+
+    /// The table names referenced after `FROM`/`JOIN`, lowercased and stripped to
+    /// their leading identifier. Used to decide which cached cells to register.
+    /// A dotted name (`conn.schema.table`) reduces to its first segment, which a
+    /// cell title never matches, so federation refs are simply ignored here.
+    fn referenced_tables(sql: &str) -> Vec<String> {
+        let tokens: Vec<&str> = sql
+            .split(|c: char| c.is_whitespace() || c == ',' || c == '(' || c == ')')
+            .filter(|t| !t.is_empty())
+            .collect();
+        let mut out: Vec<String> = Vec::new();
+        for (i, tok) in tokens.iter().enumerate() {
+            let upper = tok.to_ascii_uppercase();
+            if (upper == "FROM" || upper == "JOIN") && i + 1 < tokens.len() {
+                let ident: String = tokens[i + 1]
+                    .chars()
+                    .take_while(|c| c.is_ascii_alphanumeric() || *c == '_')
+                    .collect::<String>()
+                    .to_ascii_lowercase();
+                if !ident.is_empty() && !out.contains(&ident) {
+                    out.push(ident);
+                }
+            }
+        }
+        out
+    }
+
+    /// A DataFusion session with a bounded, disk-spilling memory pool. Mirrors the
+    /// federation engine's setup so chained-cell queries spill rather than OOM.
+    fn session_context() -> Result<SessionContext, CanvasError> {
+        let runtime = RuntimeEnvBuilder::new()
+            .with_memory_pool(Arc::new(FairSpillPool::new(QUERY_MEMORY_POOL_SIZE)))
+            .with_disk_manager_builder(DiskManagerBuilder::default())
+            .build_arc()
+            .map_err(|e| CanvasError::Engine(e.to_string()))?;
+        let mut config = SessionConfig::new();
+        config.options_mut().optimizer.prefer_hash_join = false;
+        Ok(SessionContext::new_with_config_rt(config, runtime))
+    }
+
+    /// Store a plain (non-chained) cell's result so downstream cells can read it.
+    /// Call this after running any ordinary query object on the board.
+    pub fn cache_result(&self, title: &str, result: &QueryResult) -> Result<(), CanvasError> {
+        let (_schema, batch) =
+            FederationEngine::query_result_to_batch(result).map_err(CanvasError::Conversion)?;
+        self.cache.put(&Self::sanitize_title(title), vec![batch])
+    }
+
+    /// Run one cell's SQL, registering every referenced cell that has a cached
+    /// result as a `MemTable`, then cache this cell's own output under its
+    /// sanitized title (so cells downstream of it can read it in turn).
+    pub async fn run_cell(&self, title: &str, sql: &str) -> Result<QueryResult, CanvasError> {
+        let start = Instant::now();
+        let ctx = Self::session_context()?;
+
+        for name in Self::referenced_tables(sql) {
+            if let Some(batches) = self.cache.get(&name)? {
+                let schema = batches[0].schema();
+                let table = MemTable::try_new(schema, vec![batches])
+                    .map_err(|e| CanvasError::Engine(e.to_string()))?;
+                ctx.register_table(name.as_str(), Arc::new(table))
+                    .map_err(|e| CanvasError::Engine(e.to_string()))?;
+            }
+        }
+
+        let df = ctx
+            .sql(sql)
+            .await
+            .map_err(|e| CanvasError::Engine(e.to_string()))?;
+        let schema: SchemaRef = Arc::new(df.schema().as_arrow().clone());
+        let mut batches = df
+            .collect()
+            .await
+            .map_err(|e| CanvasError::Engine(e.to_string()))?;
+        if batches.is_empty() {
+            batches.push(RecordBatch::new_empty(schema));
+        }
+
+        let result = FederationEngine::batches_to_query_result(&batches, start.elapsed().as_secs_f64());
+        self.cache.put(&Self::sanitize_title(title), batches)?;
+        Ok(result)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::path::PathBuf;
+
+    use crate::{ColumnSpec, QueryValue, StatementType};
+
+    use super::*;
+
+    static DIR_SEQ: AtomicU64 = AtomicU64::new(0);
+
+    fn temp_dir() -> PathBuf {
+        let n = DIR_SEQ.fetch_add(1, Ordering::Relaxed);
+        std::env::temp_dir().join(format!("arris-canvasengine-{}-{}", std::process::id(), n))
+    }
+
+    fn engine() -> CanvasEngine {
+        let cache = Arc::new(CellResultCache::new(temp_dir(), 1 << 30, 1 << 30));
+        CanvasEngine::new(cache)
+    }
+
+    fn col(name: &str, hint: &str) -> ColumnSpec {
+        ColumnSpec {
+            name: name.to_string(),
+            type_hint: hint.to_string(),
+        }
+    }
+
+    /// A two-column (category TEXT, total INT) result used as the upstream cell.
+    fn sales_result() -> QueryResult {
+        QueryResult {
+            columns: vec![col("category", "text"), col("total", "int")],
+            rows: vec![
+                vec![QueryValue::Text("books".into()), QueryValue::Int(10)],
+                vec![QueryValue::Text("toys".into()), QueryValue::Int(5)],
+                vec![QueryValue::Text("books".into()), QueryValue::Int(3)],
+            ],
+            rows_affected: None,
+            elapsed: 0.0,
+            has_more: None,
+            statement_type: StatementType::Query,
+        }
+    }
+
+    fn text_at(result: &QueryResult, row: usize, col: usize) -> String {
+        match &result.rows[row][col] {
+            QueryValue::Text(s) => s.clone(),
+            other => panic!("expected text, got {other:?}"),
+        }
+    }
+
+    fn int_at(result: &QueryResult, row: usize, col: usize) -> i64 {
+        match &result.rows[row][col] {
+            QueryValue::Int(n) => *n,
+            other => panic!("expected int, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn cell_b_aggregates_cell_a_cached_result() {
+        let engine = engine();
+        engine.cache_result("a", &sales_result()).unwrap();
+
+        let out = engine
+            .run_cell(
+                "b",
+                "SELECT category, SUM(total) AS total FROM a GROUP BY category ORDER BY category",
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            out.columns.iter().map(|c| c.name.as_str()).collect::<Vec<_>>(),
+            vec!["category", "total"]
+        );
+        assert_eq!(out.rows.len(), 2);
+        assert_eq!(text_at(&out, 0, 0), "books");
+        assert_eq!(int_at(&out, 0, 1), 13);
+        assert_eq!(text_at(&out, 1, 0), "toys");
+        assert_eq!(int_at(&out, 1, 1), 5);
+    }
+
+    #[tokio::test]
+    async fn a_chained_cell_is_cached_for_its_own_downstream() {
+        let engine = engine();
+        engine.cache_result("a", &sales_result()).unwrap();
+        // b depends on a; c depends on b. Running b then c proves a two-hop chain.
+        engine
+            .run_cell("b", "SELECT category, SUM(total) AS total FROM a GROUP BY category")
+            .await
+            .unwrap();
+        assert!(engine.cache().contains("b"));
+
+        let out = engine
+            .run_cell("c", "SELECT SUM(total) AS grand FROM b")
+            .await
+            .unwrap();
+        assert_eq!(int_at(&out, 0, 0), 18);
+    }
+
+    #[tokio::test]
+    async fn referencing_an_unknown_cell_errors() {
+        let engine = engine();
+        let err = engine
+            .run_cell("b", "SELECT * FROM does_not_exist")
+            .await
+            .unwrap_err();
+        assert!(matches!(err, CanvasError::Engine(_)));
+    }
+
+    #[test]
+    fn sanitize_title_makes_a_sql_safe_identifier() {
+        assert_eq!(CanvasEngine::sanitize_title("Monthly Sales"), "monthly_sales");
+        assert_eq!(CanvasEngine::sanitize_title("  spaced  "), "spaced");
+        assert_eq!(CanvasEngine::sanitize_title("2024 totals"), "_2024_totals");
+        assert_eq!(CanvasEngine::sanitize_title("a--b__c"), "a_b_c");
+        assert_eq!(CanvasEngine::sanitize_title("!!!"), "cell");
+    }
+
+    #[test]
+    fn referenced_tables_picks_out_from_and_join_targets() {
+        let refs = CanvasEngine::referenced_tables(
+            "SELECT * FROM Orders o JOIN customers c ON o.cid = c.id",
+        );
+        assert_eq!(refs, vec!["orders", "customers"]);
+    }
+}

--- a/crates/arris-engines/src/canvas/impl_cell_result_cache.rs
+++ b/crates/arris-engines/src/canvas/impl_cell_result_cache.rs
@@ -1,0 +1,325 @@
+use std::collections::HashMap;
+use std::fs::File;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+use datafusion::arrow::ipc::reader::FileReader;
+use datafusion::arrow::ipc::writer::FileWriter;
+use datafusion::arrow::record_batch::RecordBatch;
+
+use super::errors::CanvasError;
+
+/// Where one cached cell result physically lives.
+enum Store {
+    /// Hot tier: batches kept in memory.
+    Mem(Vec<RecordBatch>),
+    /// Cold tier: spilled to an Arrow IPC file; read back from disk on demand.
+    Disk(PathBuf),
+}
+
+struct Entry {
+    bytes: usize,
+    store: Store,
+}
+
+struct Inner {
+    entries: HashMap<String, Entry>,
+    /// LRU order: front = least-recently-used, back = most-recently-touched.
+    order: Vec<String>,
+    mem_bytes: usize,
+    disk_bytes: usize,
+    /// Monotonic suffix for spill filenames (avoids needing a clock/RNG).
+    seq: u64,
+}
+
+/// A per-board cache of query-cell results, stored as Arrow so a downstream cell
+/// can read an upstream cell's output back through a DataFusion `MemTable`.
+///
+/// Two tiers: a hot in-memory tier bounded by `mem_budget`, and a cold on-disk
+/// Arrow IPC tier. The COMBINED footprint is hard-capped at `total_budget`;
+/// crossing it evicts least-recently-used cells (the newest is always kept).
+/// Keyed by the sanitized cell title.
+pub struct CellResultCache {
+    inner: Mutex<Inner>,
+    mem_budget: usize,
+    total_budget: usize,
+    spill_dir: PathBuf,
+}
+
+impl CellResultCache {
+    pub fn new(spill_dir: PathBuf, mem_budget: usize, total_budget: usize) -> Self {
+        Self {
+            inner: Mutex::new(Inner {
+                entries: HashMap::new(),
+                order: Vec::new(),
+                mem_bytes: 0,
+                disk_bytes: 0,
+                seq: 0,
+            }),
+            mem_budget,
+            total_budget,
+            spill_dir,
+        }
+    }
+
+    fn batches_bytes(batches: &[RecordBatch]) -> usize {
+        batches.iter().map(|b| b.get_array_memory_size()).sum()
+    }
+
+    /// Move `key` to the most-recently-used position.
+    fn touch(order: &mut Vec<String>, key: &str) {
+        if let Some(pos) = order.iter().position(|k| k == key) {
+            order.remove(pos);
+        }
+        order.push(key.to_string());
+    }
+
+    fn write_ipc(path: &Path, batches: &[RecordBatch]) -> Result<(), CanvasError> {
+        let file = File::create(path).map_err(|e| CanvasError::Io(e.to_string()))?;
+        let schema = batches[0].schema();
+        let mut writer =
+            FileWriter::try_new(file, &schema).map_err(|e| CanvasError::Arrow(e.to_string()))?;
+        for batch in batches {
+            writer
+                .write(batch)
+                .map_err(|e| CanvasError::Arrow(e.to_string()))?;
+        }
+        writer
+            .finish()
+            .map_err(|e| CanvasError::Arrow(e.to_string()))?;
+        Ok(())
+    }
+
+    fn read_ipc(path: &Path) -> Result<Vec<RecordBatch>, CanvasError> {
+        let file = File::open(path).map_err(|e| CanvasError::Io(e.to_string()))?;
+        let reader =
+            FileReader::try_new(file, None).map_err(|e| CanvasError::Arrow(e.to_string()))?;
+        let mut out = Vec::new();
+        for batch in reader {
+            out.push(batch.map_err(|e| CanvasError::Arrow(e.to_string()))?);
+        }
+        Ok(out)
+    }
+
+    /// Drop an entry, releasing its memory/disk accounting and deleting its spill
+    /// file if it had one.
+    fn remove_locked(inner: &mut Inner, key: &str) {
+        if let Some(entry) = inner.entries.remove(key) {
+            match &entry.store {
+                Store::Mem(_) => inner.mem_bytes -= entry.bytes,
+                Store::Disk(path) => {
+                    inner.disk_bytes -= entry.bytes;
+                    let _ = std::fs::remove_file(path);
+                }
+            }
+            if let Some(pos) = inner.order.iter().position(|k| k == key) {
+                inner.order.remove(pos);
+            }
+        }
+    }
+
+    /// Spill one in-memory entry to an Arrow IPC file, moving its bytes from the
+    /// memory tier to the disk tier. No-op if the entry is already on disk.
+    fn spill_locked(inner: &mut Inner, key: &str, spill_dir: &Path) -> Result<(), CanvasError> {
+        let batches = match inner.entries.get(key).map(|e| &e.store) {
+            Some(Store::Mem(b)) => b.clone(),
+            _ => return Ok(()),
+        };
+        std::fs::create_dir_all(spill_dir).map_err(|e| CanvasError::Io(e.to_string()))?;
+        inner.seq += 1;
+        let path = spill_dir.join(format!("cell-{}.arrow", inner.seq));
+        Self::write_ipc(&path, &batches)?;
+        if let Some(entry) = inner.entries.get_mut(key) {
+            inner.mem_bytes -= entry.bytes;
+            inner.disk_bytes += entry.bytes;
+            entry.store = Store::Disk(path);
+        }
+        Ok(())
+    }
+
+    /// Bring both tiers back within budget: first spill the coldest in-memory
+    /// entries until the memory tier fits, then evict the coldest entries
+    /// outright until the combined footprint fits (always keeping the newest).
+    fn enforce(
+        inner: &mut Inner,
+        mem_budget: usize,
+        total_budget: usize,
+        spill_dir: &Path,
+    ) -> Result<(), CanvasError> {
+        while inner.mem_bytes > mem_budget {
+            let coldest_mem = inner
+                .order
+                .iter()
+                .find(|k| matches!(inner.entries.get(*k).map(|e| &e.store), Some(Store::Mem(_))))
+                .cloned();
+            let Some(key) = coldest_mem else { break };
+            Self::spill_locked(inner, &key, spill_dir)?;
+        }
+        while inner.mem_bytes + inner.disk_bytes > total_budget && inner.order.len() > 1 {
+            let Some(victim) = inner.order.first().cloned() else {
+                break;
+            };
+            Self::remove_locked(inner, &victim);
+        }
+        Ok(())
+    }
+
+    /// Store (or replace) a cell's result. Inserts into the memory tier, then
+    /// enforces the budgets (spill/evict as needed). An empty batch set is a
+    /// no-op (nothing to cache).
+    pub fn put(&self, key: &str, batches: Vec<RecordBatch>) -> Result<(), CanvasError> {
+        if batches.is_empty() {
+            return Ok(());
+        }
+        let bytes = Self::batches_bytes(&batches);
+        let mut inner = self.inner.lock().unwrap();
+        Self::remove_locked(&mut inner, key);
+        inner.entries.insert(
+            key.to_string(),
+            Entry {
+                bytes,
+                store: Store::Mem(batches),
+            },
+        );
+        inner.mem_bytes += bytes;
+        Self::touch(&mut inner.order, key);
+        Self::enforce(&mut inner, self.mem_budget, self.total_budget, &self.spill_dir)?;
+        Ok(())
+    }
+
+    /// Fetch a cell's cached result, reading it back from disk if it was spilled.
+    /// Marks the entry most-recently-used. `None` if absent (never run, or evicted).
+    pub fn get(&self, key: &str) -> Result<Option<Vec<RecordBatch>>, CanvasError> {
+        let mut inner = self.inner.lock().unwrap();
+        let batches = match inner.entries.get(key).map(|e| &e.store) {
+            None => return Ok(None),
+            Some(Store::Mem(b)) => b.clone(),
+            Some(Store::Disk(path)) => Self::read_ipc(&path.clone())?,
+        };
+        Self::touch(&mut inner.order, key);
+        Ok(Some(batches))
+    }
+
+    pub fn contains(&self, key: &str) -> bool {
+        self.inner.lock().unwrap().entries.contains_key(key)
+    }
+
+    pub fn remove(&self, key: &str) {
+        let mut inner = self.inner.lock().unwrap();
+        Self::remove_locked(&mut inner, key);
+    }
+
+    #[cfg(test)]
+    fn is_on_disk(&self, key: &str) -> bool {
+        matches!(
+            self.inner.lock().unwrap().entries.get(key).map(|e| &e.store),
+            Some(Store::Disk(_))
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::sync::Arc;
+
+    use datafusion::arrow::array::{Int64Array, StringArray};
+    use datafusion::arrow::datatypes::{DataType, Field, Schema};
+
+    use super::*;
+
+    const BIG: usize = 1 << 30;
+
+    static DIR_SEQ: AtomicU64 = AtomicU64::new(0);
+
+    fn temp_dir() -> PathBuf {
+        let n = DIR_SEQ.fetch_add(1, Ordering::Relaxed);
+        std::env::temp_dir().join(format!("arris-cellcache-{}-{}", std::process::id(), n))
+    }
+
+    fn batch(values: &[i64]) -> RecordBatch {
+        let schema = Arc::new(Schema::new(vec![Field::new("n", DataType::Int64, false)]));
+        RecordBatch::try_new(schema, vec![Arc::new(Int64Array::from(values.to_vec()))]).unwrap()
+    }
+
+    fn text_batch(values: &[&str]) -> RecordBatch {
+        let schema = Arc::new(Schema::new(vec![Field::new("s", DataType::Utf8, false)]));
+        let arr = StringArray::from(values.to_vec());
+        RecordBatch::try_new(schema, vec![Arc::new(arr)]).unwrap()
+    }
+
+    fn first_col_i64(batches: &[RecordBatch]) -> Vec<i64> {
+        let mut out = Vec::new();
+        for b in batches {
+            let arr = b
+                .column(0)
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .unwrap();
+            for i in 0..arr.len() {
+                out.push(arr.value(i));
+            }
+        }
+        out
+    }
+
+    #[test]
+    fn put_then_get_roundtrips_the_batches() {
+        let cache = CellResultCache::new(temp_dir(), BIG, BIG);
+        cache.put("a", vec![batch(&[1, 2, 3])]).unwrap();
+        let got = cache.get("a").unwrap().unwrap();
+        assert_eq!(first_col_i64(&got), vec![1, 2, 3]);
+        assert!(cache.contains("a"));
+        assert!(!cache.is_on_disk("a"));
+    }
+
+    #[test]
+    fn re_putting_a_key_replaces_the_prior_result() {
+        let cache = CellResultCache::new(temp_dir(), BIG, BIG);
+        cache.put("a", vec![batch(&[1])]).unwrap();
+        cache.put("a", vec![batch(&[9, 9])]).unwrap();
+        let got = cache.get("a").unwrap().unwrap();
+        assert_eq!(first_col_i64(&got), vec![9, 9]);
+    }
+
+    #[test]
+    fn over_the_memory_budget_spills_to_disk_but_stays_readable() {
+        // A 1-byte memory budget forces every entry to spill; the disk budget is
+        // generous so nothing is evicted.
+        let cache = CellResultCache::new(temp_dir(), 1, BIG);
+        cache.put("a", vec![batch(&[1, 2])]).unwrap();
+        cache.put("b", vec![text_batch(&["x", "y"])]).unwrap();
+        assert!(cache.is_on_disk("a"));
+        assert!(cache.is_on_disk("b"));
+        // Both still return their original contents, read back from IPC.
+        assert_eq!(first_col_i64(&cache.get("a").unwrap().unwrap()), vec![1, 2]);
+        assert!(cache.contains("b"));
+    }
+
+    #[test]
+    fn over_the_total_budget_evicts_least_recently_used() {
+        // A 1-byte total budget keeps only the most-recent entry alive.
+        let cache = CellResultCache::new(temp_dir(), 1, 1);
+        cache.put("a", vec![batch(&[1])]).unwrap();
+        cache.put("b", vec![batch(&[2])]).unwrap();
+        assert!(!cache.contains("a"), "coldest entry should be evicted");
+        assert!(cache.contains("b"), "newest entry is always kept");
+        assert!(cache.get("a").unwrap().is_none());
+    }
+
+    #[test]
+    fn get_marks_an_entry_recently_used_so_it_survives_eviction() {
+        // Budget holds exactly two equal-sized entries; no memory spill.
+        let unit = CellResultCache::batches_bytes(&[batch(&[1])]);
+        let cache = CellResultCache::new(temp_dir(), BIG, unit * 2);
+        cache.put("a", vec![batch(&[1])]).unwrap();
+        cache.put("b", vec![batch(&[2])]).unwrap();
+        // Read "a" so it becomes most-recently-used; "b" is now the coldest.
+        let _ = cache.get("a").unwrap();
+        cache.put("c", vec![batch(&[3])]).unwrap();
+        // Inserting "c" overflows to three entries; the LRU victim is "b", not "a".
+        assert!(cache.contains("a"), "recently-read entry survives");
+        assert!(cache.contains("c"), "newest entry survives");
+        assert!(!cache.contains("b"), "coldest entry is evicted");
+    }
+}

--- a/crates/arris-engines/src/canvas/mod.rs
+++ b/crates/arris-engines/src/canvas/mod.rs
@@ -1,0 +1,9 @@
+mod constants;
+mod errors;
+mod impl_canvas_engine;
+mod impl_cell_result_cache;
+
+pub use constants::{CELL_CACHE_MEMORY_BUDGET, CELL_CACHE_TOTAL_BUDGET};
+pub use errors::CanvasError;
+pub use impl_canvas_engine::CanvasEngine;
+pub use impl_cell_result_cache::CellResultCache;

--- a/crates/arris-engines/src/canvas/mod.rs
+++ b/crates/arris-engines/src/canvas/mod.rs
@@ -2,8 +2,10 @@ mod constants;
 mod errors;
 mod impl_canvas_engine;
 mod impl_cell_result_cache;
+mod types;
 
 pub use constants::{CELL_CACHE_MEMORY_BUDGET, CELL_CACHE_TOTAL_BUDGET};
 pub use errors::CanvasError;
 pub use impl_canvas_engine::CanvasEngine;
 pub use impl_cell_result_cache::CellResultCache;
+pub use types::{CanvasCellRun, CanvasCellSpec};

--- a/crates/arris-engines/src/canvas/types.rs
+++ b/crates/arris-engines/src/canvas/types.rs
@@ -1,0 +1,45 @@
+use serde::{Deserialize, Serialize};
+
+use crate::QueryResult;
+
+/// One query cell on a board, as sent from the frontend for a chained run. The
+/// engine builds the dependency graph from each cell's `sql` (its `FROM`/`JOIN`
+/// references that match another cell's sanitized `title`).
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CanvasCellSpec {
+    pub id: String,
+    pub title: String,
+    pub sql: String,
+    pub connection_id: Option<String>,
+}
+
+/// The outcome of running one cell during a chained run: either its result or the
+/// error that stopped it (a failed upstream blocks its descendants).
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CanvasCellRun {
+    pub id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result: Option<QueryResult>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+impl CanvasCellRun {
+    pub fn ok(id: String, result: QueryResult) -> Self {
+        Self {
+            id,
+            result: Some(result),
+            error: None,
+        }
+    }
+
+    pub fn failed(id: String, error: String) -> Self {
+        Self {
+            id,
+            result: None,
+            error: Some(error),
+        }
+    }
+}

--- a/crates/arris-engines/src/federation/impl_federated_table_provider.rs
+++ b/crates/arris-engines/src/federation/impl_federated_table_provider.rs
@@ -225,7 +225,7 @@ impl FederatedExec {
         DataType::Utf8
     }
 
-    fn query_result_to_record_batch(
+    pub(crate) fn query_result_to_record_batch(
         result: &QueryResult,
         schema: &SchemaRef,
     ) -> Result<RecordBatch, String> {

--- a/crates/arris-engines/src/federation/impl_federation_engine.rs
+++ b/crates/arris-engines/src/federation/impl_federation_engine.rs
@@ -582,6 +582,39 @@ impl FederationEngine {
         }
     }
 
+    /// Convert a `QueryResult` into a single Arrow `RecordBatch` plus its schema,
+    /// reusing the same type inference the federation scan path uses. Shared with
+    /// the canvas cell cache, which stores a prior cell's result as Arrow so a
+    /// later cell can read it back through a `MemTable`.
+    pub(crate) fn query_result_to_batch(
+        result: &QueryResult,
+    ) -> Result<(datafusion::arrow::datatypes::SchemaRef, RecordBatch), String> {
+        let schema = FederatedExec::infer_schema_from_result(result);
+        let batch = FederatedExec::query_result_to_record_batch(result, &schema)?;
+        Ok((schema, batch))
+    }
+
+    /// Flatten Arrow `RecordBatch`es back into a `QueryResult` (column specs from
+    /// the batch schema, rows from each batch). The inverse of
+    /// `query_result_to_batch`; shared with the canvas engine so a chained cell
+    /// returns the same shape as any other query.
+    pub(crate) fn batches_to_query_result(batches: &[RecordBatch], elapsed: f64) -> QueryResult {
+        let columns = batches
+            .first()
+            .map(Self::schema_to_column_specs)
+            .unwrap_or_default();
+        let mut rows = Vec::new();
+        for batch in batches {
+            Self::append_batch_rows(batch, &mut rows);
+        }
+        QueryResult {
+            columns,
+            rows,
+            elapsed,
+            ..Default::default()
+        }
+    }
+
     fn parse_federated_refs(sql: &str) -> Vec<FederationRef> {
         let chars: Vec<char> = sql.chars().collect();
         let mut out = Vec::new();

--- a/crates/arris-engines/src/lib.rs
+++ b/crates/arris-engines/src/lib.rs
@@ -22,7 +22,7 @@ pub trait Engine: Send + Sync {
 }
 
 pub use agent::AgentEngine;
-pub use canvas::{CanvasEngine, CanvasError, CellResultCache};
+pub use canvas::{CanvasCellRun, CanvasCellSpec, CanvasEngine, CanvasError, CellResultCache};
 pub use connection::{ConnectionEngine, ScopedConnection};
 pub use dbt::DbtEngine;
 pub use federation::FederationEngine;

--- a/crates/arris-engines/src/lib.rs
+++ b/crates/arris-engines/src/lib.rs
@@ -2,6 +2,7 @@ pub mod drivers;
 pub mod persistence;
 
 pub mod agent;
+pub mod canvas;
 pub mod connection;
 pub mod editor;
 pub mod dbt;
@@ -21,6 +22,7 @@ pub trait Engine: Send + Sync {
 }
 
 pub use agent::AgentEngine;
+pub use canvas::{CanvasEngine, CanvasError, CellResultCache};
 pub use connection::{ConnectionEngine, ScopedConnection};
 pub use dbt::DbtEngine;
 pub use federation::FederationEngine;

--- a/docs/src/pages/ai/canvas.astro
+++ b/docs/src/pages/ai/canvas.astro
@@ -78,7 +78,11 @@ import DocTable from "../../components/docs/DocTable/DocTable.astro";
           connection, the same engine the editor uses. The query object shows no rows itself: the
           first time you run it, Arris drops a preview <strong>table</strong> beside it (joined with an
           arrow) so the rows show without any extra step. Bind a chart to it instead if you want a
-          visualization rather than a grid.
+          visualization rather than a grid. A query can also read <strong>another query's result</strong>
+          by its title: write <code>FROM &lt;other cell title&gt;</code> and that cell becomes an
+          in-memory table. Running a query auto-runs the upstream cells it reads first, and a
+          dependency arrow is drawn between them. (Joining a live database table and another cell's
+          result in the same query is not supported yet; pull the live data into its own cell first.)
         </td>
       </tr>
       <tr>

--- a/frontend/src/domains/canvas/components/CanvasAgentChat/hooks.test.ts
+++ b/frontend/src/domains/canvas/components/CanvasAgentChat/hooks.test.ts
@@ -17,12 +17,14 @@ vi.mock("./ipc", () => ({
 }));
 
 vi.mock("../../ipc", () => ({
-  runCanvasQueryIPC: vi.fn().mockResolvedValue({ columns: [], rows: [], elapsed: 0 }),
+  runCanvasCellIPC: vi
+    .fn()
+    .mockResolvedValue([{ id: "q1", result: { columns: [], rows: [], elapsed: 0 } }]),
 }));
 
 import { useConnectionsStore } from "@domains/connection/hooks";
 import { useTabsStore } from "@shell/hooks/tabsStore";
-import { runCanvasQueryIPC } from "../../ipc";
+import { runCanvasCellIPC } from "../../ipc";
 import { useCanvasStore } from "../../hooks";
 import { makeComponent } from "../../utils";
 import { sendCanvasAgentIPC } from "./ipc";
@@ -180,7 +182,7 @@ describe("useCanvasAgentChat", () => {
 
     const board = useCanvasStore.getState().boards[TAB];
     expect(board.doc.components).toHaveLength(3);
-    expect(vi.mocked(runCanvasQueryIPC)).toHaveBeenCalledWith("conn-1", expect.any(String));
+    expect(vi.mocked(runCanvasCellIPC)).toHaveBeenCalledWith(TAB, "q1", expect.any(Array));
     expect(result.current.streaming).toBe(false);
     expect(result.current.entries.at(-1)?.text).toMatch(/Added 3 objects/);
   });

--- a/frontend/src/domains/canvas/components/CanvasView/components/QueryNode/index.test.tsx
+++ b/frontend/src/domains/canvas/components/CanvasView/components/QueryNode/index.test.tsx
@@ -63,10 +63,10 @@ describe("QueryNode", () => {
     expect(view!.state.doc.toString()).toBe("select 42");
   });
 
-  it("Run surfaces an error when the object has no connection", async () => {
-    seed(makeComponent({ kind: "query", id: "q", sql: "select 1", connectionId: null }));
+  it("Run surfaces an error for an empty query (without hitting the backend)", async () => {
+    seed(makeComponent({ kind: "query", id: "q", sql: "   ", connectionId: "c" }));
     renderNode("q");
     fireEvent.click(screen.getByRole("button", { name: "Run" }));
-    expect(await screen.findByText(/Pick a connection/)).toBeTruthy();
+    expect(await screen.findByText(/empty/i)).toBeTruthy();
   });
 });

--- a/frontend/src/domains/canvas/hooks/store.test.ts
+++ b/frontend/src/domains/canvas/hooks/store.test.ts
@@ -1,10 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("../ipc", () => ({ runCanvasQueryIPC: vi.fn() }));
+vi.mock("../ipc", () => ({ runCanvasCellIPC: vi.fn() }));
 
 import type { AgentCanvasSpec } from "../types";
 import { makeComponent } from "../utils";
-import { runCanvasQueryIPC } from "../ipc";
+import { runCanvasCellIPC } from "../ipc";
 import { useCanvasStore } from "./store";
 
 const TAB = "tab-1";
@@ -191,8 +191,10 @@ describe("useCanvasStore", () => {
     expect(get().boards[TAB].doc.components[0].locked).toBe(true);
   });
 
-  it("runQueryComponent stores the result on success", async () => {
-    vi.mocked(runCanvasQueryIPC).mockResolvedValue({ columns: [], rows: [], elapsed: 1 });
+  it("runQueryComponent applies each executed cell's result", async () => {
+    vi.mocked(runCanvasCellIPC).mockResolvedValue([
+      { id: "q1", result: { columns: [], rows: [], elapsed: 1 } },
+    ]);
     get().ensureBoard(TAB, "");
     get().addComponent(
       TAB,
@@ -200,22 +202,61 @@ describe("useCanvasStore", () => {
     );
     await get().runQueryComponent(TAB, "q1");
     expect(get().boards[TAB].runs.q1.result).toBeDefined();
-    expect(get().boards[TAB].runs.q1.running).toBe(false);
+    expect(get().boards[TAB].runs.q1.running).toBeFalsy();
   });
 
-  it("runQueryComponent errors (without calling IPC) when no connection is set", async () => {
+  it("runQueryComponent auto-runs upstream cells and applies their results too", async () => {
+    // The user runs `query` (reads `abc`); the backend returns abc + query.
+    vi.mocked(runCanvasCellIPC).mockResolvedValue([
+      { id: "abc", result: { columns: [], rows: [], elapsed: 1 } },
+      { id: "query", result: { columns: [], rows: [], elapsed: 1 } },
+    ]);
     get().ensureBoard(TAB, "");
     get().addComponent(
       TAB,
-      makeComponent({ kind: "query", id: "q1", sql: "s", connectionId: null }),
+      makeComponent({ kind: "query", id: "abc", title: "abc", sql: "SELECT 1", connectionId: "conn" }),
+    );
+    get().addComponent(
+      TAB,
+      makeComponent({ kind: "query", id: "query", title: "query", sql: "SELECT * FROM abc" }),
+    );
+    await get().runQueryComponent(TAB, "query");
+    expect(get().boards[TAB].runs.abc.result).toBeDefined();
+    expect(get().boards[TAB].runs.query.result).toBeDefined();
+    // The dependency arrow abc -> query is auto-derived from the SQL.
+    expect(get().boards[TAB].doc.edges).toEqual(
+      expect.arrayContaining([expect.objectContaining({ source: "abc", target: "query" })]),
+    );
+  });
+
+  it("runQueryComponent surfaces a per-cell backend error", async () => {
+    vi.mocked(runCanvasCellIPC).mockResolvedValue([
+      { id: "q1", error: "pick a connection for this query cell" },
+    ]);
+    get().ensureBoard(TAB, "");
+    get().addComponent(
+      TAB,
+      makeComponent({ kind: "query", id: "q1", sql: "select 1", connectionId: null }),
     );
     await get().runQueryComponent(TAB, "q1");
     expect(get().boards[TAB].runs.q1.error).toBeTruthy();
-    expect(runCanvasQueryIPC).not.toHaveBeenCalled();
+  });
+
+  it("runQueryComponent errors (without calling IPC) on an empty query", async () => {
+    get().ensureBoard(TAB, "");
+    get().addComponent(
+      TAB,
+      makeComponent({ kind: "query", id: "q1", sql: "   ", connectionId: "conn" }),
+    );
+    await get().runQueryComponent(TAB, "q1");
+    expect(get().boards[TAB].runs.q1.error).toBeTruthy();
+    expect(runCanvasCellIPC).not.toHaveBeenCalled();
   });
 
   it("runQueryComponent auto-adds a preview table + arrow bound to the query", async () => {
-    vi.mocked(runCanvasQueryIPC).mockResolvedValue({ columns: [], rows: [], elapsed: 1 });
+    vi.mocked(runCanvasCellIPC).mockResolvedValue([
+      { id: "q1", result: { columns: [], rows: [], elapsed: 1 } },
+    ]);
     get().ensureBoard(TAB, "");
     get().addComponent(
       TAB,
@@ -232,7 +273,9 @@ describe("useCanvasStore", () => {
   });
 
   it("a second run does not pile on a duplicate preview table", async () => {
-    vi.mocked(runCanvasQueryIPC).mockResolvedValue({ columns: [], rows: [], elapsed: 1 });
+    vi.mocked(runCanvasCellIPC).mockResolvedValue([
+      { id: "q1", result: { columns: [], rows: [], elapsed: 1 } },
+    ]);
     get().ensureBoard(TAB, "");
     get().addComponent(
       TAB,

--- a/frontend/src/domains/canvas/hooks/store.ts
+++ b/frontend/src/domains/canvas/hooks/store.ts
@@ -6,12 +6,20 @@ import type {
   CanvasDoc,
   CanvasEdge,
   CanvasViewport,
+  QueryComponent,
   QueryRunState,
   ReorderOp,
 } from "../types";
 import { DEFAULT_SIZE, LAYOUT_GAP } from "../constants";
-import { genId, makeComponent, makeEdge, parseDoc, planAgentChanges } from "../utils";
-import { runCanvasQueryIPC } from "../ipc";
+import {
+  deriveDataEdges,
+  genId,
+  makeComponent,
+  makeEdge,
+  parseDoc,
+  planAgentChanges,
+} from "../utils";
+import { runCanvasCellIPC } from "../ipc";
 
 interface BoardState {
   doc: CanvasDoc;
@@ -337,22 +345,37 @@ const useCanvasStore = create<CanvasStore>((set, get) => ({
   runQueryComponent: async (tabId, id) => {
     const board = get().boards[tabId];
     const comp = board?.doc.components.find((c) => c.id === id);
-    if (!comp || comp.kind !== "query") return;
-    if (!comp.connectionId) {
-      get().setRun(tabId, id, { error: "Pick a connection for this query object." });
-      return;
-    }
+    if (!board || !comp || comp.kind !== "query") return;
     if (!comp.sql.trim()) {
       get().setRun(tabId, id, { error: "This query object is empty." });
       return;
     }
+    // Snapshot every query cell so the backend can resolve title references and
+    // auto-run this cell's upstream dependencies before the target.
+    const cells = board.doc.components
+      .filter((c): c is QueryComponent => c.kind === "query")
+      .map((c) => ({
+        id: c.id,
+        title: c.title ?? "",
+        sql: c.sql,
+        connectionId: c.connectionId,
+      }));
     get().setRun(tabId, id, { running: true });
     try {
-      const result = await runCanvasQueryIPC(comp.connectionId, comp.sql);
-      get().setRun(tabId, id, { running: false, result });
-      // First successful run auto-adds a preview table (with an arrow) bound to
-      // this query, so the rows show without the user creating one by hand.
-      set((s) => ({ boards: withDoc(s.boards, tabId, (doc) => withPreviewTable(doc, id)) }));
+      const runs = await runCanvasCellIPC(tabId, id, cells);
+      // Apply each executed cell's outcome (target + its upstream dependencies).
+      for (const r of runs) {
+        get().setRun(tabId, r.id, r.error ? { error: r.error } : { result: r.result });
+      }
+      const targetOk = runs.some((r) => r.id === id && r.result);
+      // The cell the user ran gets a preview table on first success; the
+      // query-to-query arrows are re-derived from the current SQL references.
+      set((s) => ({
+        boards: withDoc(s.boards, tabId, (doc) => {
+          const next = targetOk ? withPreviewTable(doc, id) : doc;
+          return { ...next, edges: deriveDataEdges(next.components, next.edges) };
+        }),
+      }));
     } catch (e) {
       get().setRun(tabId, id, { running: false, error: errToString(e) });
     }

--- a/frontend/src/domains/canvas/ipc.ts
+++ b/frontend/src/domains/canvas/ipc.ts
@@ -1,26 +1,35 @@
 import { invoke } from "@tauri-apps/api/core";
-import type { QueryLanguage, QueryResult, QueryValue } from "@shared";
+import type { QueryResult } from "@shared";
 
-/// Row cap pulled for a board query object. Charts buffer the whole result, so a
-/// bound keeps a careless `SELECT *` from dragging the board down; `has_more`
-/// on the result signals truncation.
-const CANVAS_QUERY_PAGE_SIZE = 1000;
-
-/// Run a query object's SQL against its connection and return the first page of
-/// rows. Reuses the same `cmd_run_query` command the editor/results grid use.
-function runCanvasQueryIPC(
-  connectionId: string,
-  sql: string,
-  language?: QueryLanguage,
-): Promise<QueryResult> {
-  return invoke("cmd_run_query", {
-    connectionId,
-    sql,
-    params: [] as QueryValue[],
-    language,
-    pageSize: CANVAS_QUERY_PAGE_SIZE,
-    page: 0,
-  });
+/// One query cell sent to the backend for a chained run. The backend builds the
+/// dependency graph from each cell's `sql` (a `FROM`/`JOIN` reference to another
+/// cell's sanitized title is a dependency).
+interface CanvasCellSpec {
+  id: string;
+  title: string;
+  sql: string;
+  connectionId: string | null;
 }
 
-export { runCanvasQueryIPC };
+/// The outcome of one executed cell: its result, or the error that stopped it.
+interface CanvasCellRun {
+  id: string;
+  result?: QueryResult;
+  error?: string;
+}
+
+/// Run a canvas query cell, auto-running its upstream cells first. `cells` is the
+/// board's full set of query cells (so the backend can resolve title references);
+/// `targetId` is the cell the user clicked Run on. Returns one entry per executed
+/// cell (the target and its transitive dependencies), so the board can refresh
+/// every affected grid in one round-trip.
+function runCanvasCellIPC(
+  boardId: string,
+  targetId: string,
+  cells: CanvasCellSpec[],
+): Promise<CanvasCellRun[]> {
+  return invoke("cmd_run_canvas_cell", { boardId, targetId, cells });
+}
+
+export { runCanvasCellIPC };
+export type { CanvasCellRun, CanvasCellSpec };

--- a/frontend/src/domains/canvas/utils/dependencies.test.ts
+++ b/frontend/src/domains/canvas/utils/dependencies.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+
+import { makeComponent } from "./factory";
+import { deriveDataEdges, sanitizeCellTitle } from "./dependencies";
+
+describe("sanitizeCellTitle", () => {
+  it("matches the backend identifier rules", () => {
+    expect(sanitizeCellTitle("Monthly Sales")).toBe("monthly_sales");
+    expect(sanitizeCellTitle("  spaced  ")).toBe("spaced");
+    expect(sanitizeCellTitle("2024 totals")).toBe("_2024_totals");
+    expect(sanitizeCellTitle("a--b__c")).toBe("a_b_c");
+    expect(sanitizeCellTitle("!!!")).toBe("cell");
+  });
+});
+
+describe("deriveDataEdges", () => {
+  it("draws an arrow from a referenced cell to the cell that reads it", () => {
+    const abc = makeComponent({ kind: "query", id: "abc", title: "abc", sql: "SELECT 1" });
+    const query = makeComponent({
+      kind: "query",
+      id: "query",
+      title: "Query",
+      sql: "SELECT * FROM abc",
+    });
+    const edges = deriveDataEdges([abc, query], []);
+    expect(edges).toEqual([
+      expect.objectContaining({ source: "abc", target: "query" }),
+    ]);
+  });
+
+  it("leaves a query-to-table binding edge untouched", () => {
+    const q = makeComponent({ kind: "query", id: "q", title: "q", sql: "SELECT 1" });
+    const table = makeComponent({ kind: "table", id: "t", sourceQueryId: "q" });
+    const binding = { id: "bind", source: "q", target: "t" };
+    const edges = deriveDataEdges([q, table], [binding]);
+    expect(edges).toContainEqual(binding);
+  });
+
+  it("drops a stale query-to-query edge whose reference is gone", () => {
+    const a = makeComponent({ kind: "query", id: "a", title: "a", sql: "SELECT 1" });
+    // b no longer references a, but a stale arrow a->b still exists.
+    const b = makeComponent({ kind: "query", id: "b", title: "b", sql: "SELECT 2" });
+    const stale = { id: "old", source: "a", target: "b" };
+    const edges = deriveDataEdges([a, b], [stale]);
+    expect(edges).toHaveLength(0);
+  });
+
+  it("reuses the existing edge id when a dependency persists", () => {
+    const a = makeComponent({ kind: "query", id: "a", title: "a", sql: "SELECT 1" });
+    const b = makeComponent({ kind: "query", id: "b", title: "b", sql: "SELECT * FROM a" });
+    const existing = { id: "keep", source: "a", target: "b" };
+    const edges = deriveDataEdges([a, b], [existing]);
+    expect(edges).toEqual([existing]);
+  });
+});

--- a/frontend/src/domains/canvas/utils/dependencies.ts
+++ b/frontend/src/domains/canvas/utils/dependencies.ts
@@ -1,0 +1,90 @@
+import type { CanvasComponent, CanvasEdge, QueryComponent } from "../types";
+import { makeEdge } from "./factory";
+
+/// Turn a cell title into the SQL-safe identifier a downstream cell references.
+/// MUST match the backend `CanvasEngine::sanitize_title`: lowercased, every run of
+/// non-alphanumerics collapsed to one underscore, trimmed, digit-prefixed.
+function sanitizeCellTitle(title: string): string {
+  let out = "";
+  let prevUnderscore = false;
+  for (const ch of title) {
+    if (/[A-Za-z0-9]/.test(ch)) {
+      out += ch.toLowerCase();
+      prevUnderscore = false;
+    } else if (!prevUnderscore) {
+      out += "_";
+      prevUnderscore = true;
+    }
+  }
+  const trimmed = out.replace(/^_+|_+$/g, "");
+  if (trimmed === "") return "cell";
+  if (/^[0-9]/.test(trimmed)) return `_${trimmed}`;
+  return trimmed;
+}
+
+/// The table names referenced after `FROM`/`JOIN`, lowercased to their leading
+/// identifier. Mirrors the backend `CanvasEngine::table_refs` so the arrows the
+/// UI draws match the dependencies the engine actually runs.
+function tableRefs(sql: string): string[] {
+  const tokens = sql.split(/[\s,()]+/).filter(Boolean);
+  const out: string[] = [];
+  for (let i = 0; i < tokens.length; i += 1) {
+    const upper = tokens[i].toUpperCase();
+    if ((upper === "FROM" || upper === "JOIN") && i + 1 < tokens.length) {
+      const match = tokens[i + 1].match(/^[A-Za-z0-9_]+/);
+      const ident = match ? match[0].toLowerCase() : "";
+      if (ident && !out.includes(ident)) out.push(ident);
+    }
+  }
+  return out;
+}
+
+/// Recompute the query-to-query dependency arrows from each query cell's SQL,
+/// leaving every other edge (a query's binding to a table/chart, or a manual
+/// relationship arrow) untouched. An edge whose endpoints are both query objects
+/// is "data-dependency managed": we drop the stale ones and add one per current
+/// title reference, reusing the existing edge id when a dependency persists so the
+/// arrow doesn't flicker.
+function deriveDataEdges(
+  components: CanvasComponent[],
+  edges: CanvasEdge[],
+): CanvasEdge[] {
+  const queries = components.filter((c): c is QueryComponent => c.kind === "query");
+  const isQuery = (id: string) => queries.some((q) => q.id === id);
+
+  // Sanitized title -> cell id. Last cell wins on a title collision.
+  const titleToId = new Map<string, string>();
+  for (const q of queries) {
+    titleToId.set(sanitizeCellTitle(q.title ?? ""), q.id);
+  }
+
+  // Desired query->query edges, deduped by source/target.
+  const desired = new Map<string, { source: string; target: string }>();
+  for (const q of queries) {
+    for (const ref of tableRefs(q.sql)) {
+      const sourceId = titleToId.get(ref);
+      if (sourceId && sourceId !== q.id) {
+        desired.set(`${sourceId}->${q.id}`, { source: sourceId, target: q.id });
+      }
+    }
+  }
+
+  // Keep every edge that is NOT an auto-managed query->query edge.
+  const keptOthers = edges.filter((e) => !(isQuery(e.source) && isQuery(e.target)));
+  // Reuse existing ids for dependencies that still hold.
+  const existingById = new Map(
+    edges
+      .filter((e) => isQuery(e.source) && isQuery(e.target))
+      .map((e) => [`${e.source}->${e.target}`, e.id]),
+  );
+
+  const dependencyEdges: CanvasEdge[] = [];
+  for (const [key, { source, target }] of desired) {
+    const id = existingById.get(key);
+    dependencyEdges.push(id ? { id, source, target } : makeEdge(source, target));
+  }
+
+  return [...keptOthers, ...dependencyEdges];
+}
+
+export { deriveDataEdges, sanitizeCellTitle };

--- a/frontend/src/domains/canvas/utils/index.ts
+++ b/frontend/src/domains/canvas/utils/index.ts
@@ -2,6 +2,7 @@ export { parseAgentCanvas, planAgentChanges } from "./agentSpec";
 export type { BoardChanges, ComponentUpdate } from "./agentSpec";
 export { describeBoard } from "./boardContext";
 export { sanitizeChartSpec } from "./chartSpec";
+export { deriveDataEdges, sanitizeCellTitle } from "./dependencies";
 export { genId, makeComponent, makeEdge } from "./factory";
 export type { ComponentInput } from "./factory";
 export { autoLayout, contentBottom } from "./layout";

--- a/src-tauri/src/commands/canvas.rs
+++ b/src-tauri/src/commands/canvas.rs
@@ -1,0 +1,121 @@
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+
+use arris_engines::{
+    AppEnvironment, CanvasCellRun, CanvasCellSpec, CanvasEngine, IpcError, QueryValue,
+};
+use tauri::State;
+use uuid::Uuid;
+
+use crate::helpers::ipc_err;
+
+/// Run a canvas query cell, auto-running its upstream cells first.
+///
+/// The board's query cells are sent as `cells`; the engine plans the run order
+/// from each cell's SQL (a `FROM`/`JOIN` reference to another cell's sanitized
+/// title is a dependency). Cells are then executed in dependency order:
+/// - a cell with no cell dependencies runs against its own connection (the
+///   normal single-database path) and its result is cached as Arrow;
+/// - a cell that reads only other cells runs in DataFusion, with each referenced
+///   cell registered as an in-memory table;
+/// - a cell that mixes a live table with a cell reference is rejected for now.
+///
+/// Every executed cell's result (or error) is returned so the board can refresh
+/// each grid. A failed cell blocks its descendants.
+#[tauri::command]
+pub async fn cmd_run_canvas_cell(
+    env: State<'_, Arc<AppEnvironment>>,
+    board_id: String,
+    target_id: String,
+    cells: Vec<CanvasCellSpec>,
+) -> Result<Vec<CanvasCellRun>, IpcError> {
+    let order = CanvasEngine::plan(&cells, &target_id).map_err(ipc_err)?;
+
+    let by_id: HashMap<&str, &CanvasCellSpec> =
+        cells.iter().map(|c| (c.id.as_str(), c)).collect();
+    let title_to_id: HashMap<String, String> = cells
+        .iter()
+        .map(|c| (CanvasEngine::sanitize_title(&c.title), c.id.clone()))
+        .collect();
+
+    let proj = env.project.read().await;
+    let mut failed: HashSet<String> = HashSet::new();
+    let mut runs: Vec<CanvasCellRun> = Vec::new();
+
+    for id in order {
+        let cell = match by_id.get(id.as_str()) {
+            Some(c) => *c,
+            None => continue,
+        };
+        let refs = CanvasEngine::table_refs(&cell.sql);
+        // A reference is a dependency when it matches ANOTHER cell's title.
+        let dep_ids: Vec<String> = refs
+            .iter()
+            .filter_map(|r| title_to_id.get(r))
+            .filter(|did| *did != &id)
+            .cloned()
+            .collect();
+        let has_live_ref = refs.iter().any(|r| !title_to_id.contains_key(r));
+
+        if dep_ids.iter().any(|did| failed.contains(did)) {
+            failed.insert(id.clone());
+            runs.push(CanvasCellRun::failed(
+                id,
+                "blocked: an upstream cell failed".to_string(),
+            ));
+            continue;
+        }
+
+        let outcome: Result<arris_engines::QueryResult, String> = if dep_ids.is_empty() {
+            // Normal single-connection run (covers a cell that only reads live
+            // tables). The result is cached below so downstream cells can read it.
+            match cell.connection_id.as_deref() {
+                None => Err("pick a connection for this query cell".to_string()),
+                Some(conn) => match Uuid::parse_str(conn) {
+                    Err(_) => Err("invalid connection id".to_string()),
+                    Ok(uuid) => env
+                        .query
+                        .run_query(
+                            uuid,
+                            &env.connection,
+                            proj.as_ref(),
+                            cell.sql.clone(),
+                            Vec::<QueryValue>::new(),
+                            None,
+                            None,
+                            None,
+                            None,
+                        )
+                        .await
+                        .map_err(|e| IpcError::from(e).message),
+                },
+            }
+        } else if has_live_ref {
+            Err("a cell that joins a live table with another cell's result is not \
+                 supported yet; put the live data in its own cell first"
+                .to_string())
+        } else {
+            env.canvas
+                .run_cell(&board_id, &cell.title, &cell.sql)
+                .await
+                .map_err(|e| e.to_string())
+        };
+
+        match outcome {
+            Ok(result) => {
+                // Chained cells cache themselves inside run_cell; cache the
+                // normal-path cells here so they can feed downstream.
+                if dep_ids.is_empty() {
+                    let _ = env.canvas.cache_result(&board_id, &cell.title, &result);
+                }
+                runs.push(CanvasCellRun::ok(id, result));
+            }
+            Err(message) => {
+                failed.insert(id.clone());
+                runs.push(CanvasCellRun::failed(id, message));
+            }
+        }
+    }
+
+    Ok(runs)
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,4 +1,5 @@
 mod agent;
+mod canvas;
 mod connection;
 mod dbt;
 mod federation;
@@ -13,6 +14,7 @@ mod sqlmesh;
 mod terminal;
 
 pub use agent::*;
+pub use canvas::*;
 pub use connection::*;
 pub use dbt::*;
 pub use federation::*;

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -156,6 +156,7 @@ fn main() {
             cmd_run_query,
             cmd_cancel_query,
             cmd_run_federation_query,
+            cmd_run_canvas_cell,
             cmd_explain_query,
             cmd_primary_key,
             cmd_object_definition,


### PR DESCRIPTION
## What does this PR do?

Let's one canvas cell consume another's results.

Included
- DataFusion MemTable + result cache.
- DAG plan + cmd_run_canvas_cell.
- Route runs through cmd_run_canvas_cell.

## Checklist

- [ ] I opened an issue first for non-trivial changes, or this is a small fix.
- [x] Tests added/updated for my change.
- [x] **I license my contribution under the MIT License**, per [CONTRIBUTING.md](../CONTRIBUTING.md). I confirm this is my original work, or that I have the right to submit it.
