### PR TITLE
Bump anyhow to 1.0.103 to clear RUSTSEC-2026-0190

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,9 +122,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "ar_archive_writer"
@@ -185,7 +185,7 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "arris-engines"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-trait",


### PR DESCRIPTION
## What does this PR do?

Bump `anyhow` to `1.0.103` to clear `RUSTSEC-2026-0190`

Also bump a previously missing crate version to 0.7.0 first

## Checklist

- [ ] I opened an issue first for non-trivial changes, or this is a small fix.
- [ ] Tests added/updated for my change.
- [ ] **I license my contribution under the MIT License**, per [CONTRIBUTING.md](../CONTRIBUTING.md). I confirm this is my original work, or that I have the right to submit it.
