### PR TITLE
[Fix] Canvas chat scope

### DIFF
--- a/frontend/src/domains/canvas/components/CanvasView/index.test.tsx
+++ b/frontend/src/domains/canvas/components/CanvasView/index.test.tsx
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from "vitest";
+import { render } from "@testing-library/react";
+import type { EditorTab } from "@shell/types";
+
+// The agent chat owns per-canvas state. Spy on every mount so the test can prove
+// switching the active canvas remounts the panel (a fresh instance per tab id)
+// rather than reusing one instance that would carry the previous board's chat.
+const spy = vi.hoisted(() => ({ mounts: [] as string[] }));
+vi.mock("../CanvasAgentChat", async () => {
+  const React = await import("react");
+  return {
+    CanvasAgentChat: ({ tab }: { tab: { id: string } }) => {
+      // useState's initializer runs exactly once per mount.
+      React.useState(() => {
+        spy.mounts.push(tab.id);
+      });
+      return React.createElement("div", { "data-testid": "chat" }, tab.id);
+    },
+  };
+});
+
+// ReactFlow needs layout geometry jsdom lacks; the board itself is not under
+// test here, so stub the flow surface and the sibling panes down to nothing.
+vi.mock("reactflow", () => ({
+  __esModule: true,
+  default: () => null,
+  Background: () => null,
+  Controls: () => null,
+  applyNodeChanges: (_changes: unknown, nodes: unknown) => nodes,
+}));
+vi.mock("./components/CanvasToolbar", () => ({ CanvasToolbar: () => null }));
+vi.mock("./components/CanvasPropertiesPane", () => ({
+  CanvasPropertiesPane: () => null,
+}));
+
+import { CanvasView } from "./index";
+
+const makeTab = (id: string): EditorTab =>
+  ({ id, text: "", tabType: "canvas" }) as unknown as EditorTab;
+
+describe("CanvasView agent chat scoping", () => {
+  it("remounts the agent chat per canvas so a new board never inherits another board's chat", () => {
+    spy.mounts.length = 0;
+    const { rerender } = render(<CanvasView activeTab={makeTab("canvas-a")} />);
+    expect(spy.mounts).toEqual(["canvas-a"]);
+
+    // Switching to a different canvas (e.g. creating a new one) must give the
+    // chat panel a fresh instance keyed to the new tab id.
+    rerender(<CanvasView activeTab={makeTab("canvas-b")} />);
+    expect(spy.mounts).toEqual(["canvas-a", "canvas-b"]);
+  });
+});

--- a/frontend/src/domains/canvas/components/CanvasView/index.tsx
+++ b/frontend/src/domains/canvas/components/CanvasView/index.tsx
@@ -65,7 +65,10 @@ function CanvasView({ activeTab }: CanvasViewProps) {
     <div className="mdbc-canvas-view">
       <PanelGroup className="mdbc-canvas-panels" id="canvas-horizontal" direction="horizontal">
         <Panel id="canvas-agent" order={1} defaultSize={18} minSize={12} maxSize={40}>
-          <CanvasAgentChat tab={activeTab} />
+          {/* Key by tab id so each canvas gets its own chat instance: switching
+              to or creating a canvas remounts the panel with that board's chat
+              instead of carrying over the previous board's conversation. */}
+          <CanvasAgentChat key={activeTab.id} tab={activeTab} />
         </Panel>
         <PanelResizeHandle className="mdbc-canvas-pane-resizer" />
         <Panel id="canvas-board" order={2} minSize={30}>


### PR DESCRIPTION
## What does this PR do?

Make each canvas owns their chats by keying the panel by the active tab id in `CanvasView`

## Checklist

- [ ] I opened an issue first for non-trivial changes, or this is a small fix.
- [x] Tests added/updated for my change.
- [x] **I license my contribution under the MIT License**, per [CONTRIBUTING.md](../CONTRIBUTING.md). I confirm this is my original work, or that I have the right to submit it.
