### PR TITLE
[Fix] Mixpanel: use PaginationStrategy::None so paged queries are not wrapped

### DIFF
--- a/crates/arris-engines/src/drivers/mixpanel/driver.rs
+++ b/crates/arris-engines/src/drivers/mixpanel/driver.rs
@@ -186,6 +186,12 @@ impl DatabaseDriver for MixpanelDriver {
         })
     }
 
+    fn pagination_strategy(&self) -> crate::PaginationStrategy {
+        // The driver buffers the full export result and applies LIMIT itself;
+        // the Mixpanel SQL subset cannot parse a wrapped subquery.
+        crate::PaginationStrategy::None
+    }
+
     async fn supports_explain(&self, _mode: ExplainMode) -> bool {
         false
     }
@@ -329,5 +335,11 @@ mod tests {
     async fn driver_starts_disconnected() {
         let d = MixpanelDriver::new();
         assert!(!d.is_connected().await);
+    }
+
+    #[test]
+    fn pagination_strategy_is_none() {
+        let d = MixpanelDriver::new();
+        assert_eq!(d.pagination_strategy(), crate::PaginationStrategy::None);
     }
 }


### PR DESCRIPTION
## What does this PR do?

To fix a query error when using Mixpanel as connection:
<img width="543" height="183" alt="image" src="https://github.com/user-attachments/assets/0de07a1f-cbdd-4b27-8398-0e3a1392e294" />

`MixpanelDriver` did not override `pagination_strategy()`, so it inherited the default `PaginationStrategy::SubqueryOffset`. When the console runs a paginated SELECT, the query engine wraps the user SQL in a pagination subquery:

`SELECT * FROM (SELECT * FROM events LIMIT 100) AS _p LIMIT 501 OFFSET 0`

The Mixpanel driver's SQL-subset parser only accepts a plain table in the FROM clause; a derived table hits the TableFactor::Table mismatch in get_table_name and surfaces as `Missing FROM clause`.

## Checklist

- [ ] I opened an issue first for non-trivial changes, or this is a small fix.
- [X] Tests added/updated for my change.
- [X] **I license my contribution under the MIT License**, per [CONTRIBUTING.md](../CONTRIBUTING.md). I confirm this is my original work, or that I have the right to submit it.
