### PR TITLE
[Fix] Enhance editor keystroke performance

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "arris-frontend",
-  "version": "0.1.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "arris-frontend",
-      "version": "0.1.0",
+      "version": "0.8.0",
       "dependencies": {
         "@codemirror/autocomplete": "^6.18.0",
         "@codemirror/commands": "^6.7.1",

--- a/frontend/src/domains/editor/components/EditorPane/components/CsvTableView/hooks.ts
+++ b/frontend/src/domains/editor/components/EditorPane/components/CsvTableView/hooks.ts
@@ -119,8 +119,10 @@ function useCsvRawEditor(tab: EditorTab, fontSize: number) {
   const editorHandleRef = useRef<EditorHandle | null>(null);
   const updateTab = useTabsStore((s) => s.updateTab);
 
-  const onChangeRawText = useCallback((text: string) => updateTab(tab.id, { text }), [tab.id, updateTab]);
-  const onCursorChangeRaw = useCallback((cursor: number) => updateTab(tab.id, { cursor }), [tab.id, updateTab]);
+  const onEditRaw = useCallback(
+    (patch: { text?: string; cursor?: number }) => updateTab(tab.id, patch),
+    [tab.id, updateTab],
+  );
 
   useEffect(() => {
     if (!editorHostRef.current) return;
@@ -128,8 +130,7 @@ function useCsvRawEditor(tab: EditorTab, fontSize: number) {
       host: editorHostRef.current,
       initialDoc: tab.text,
       initialCursor: tab.cursor,
-      onChange: onChangeRawText,
-      onCursorChange: onCursorChangeRaw,
+      onEdit: onEditRaw,
       languageId: "text",
       fontSize,
       schema: {},
@@ -139,7 +140,7 @@ function useCsvRawEditor(tab: EditorTab, fontSize: number) {
       editorHandleRef.current = null;
       handle.destroy();
     };
-  }, [fontSize, onChangeRawText, onCursorChangeRaw, tab.cursor, tab.text]);
+  }, [fontSize, onEditRaw, tab.cursor, tab.text]);
 
   return { editorHostRef };
 }

--- a/frontend/src/domains/editor/components/EditorPane/index.test.tsx
+++ b/frontend/src/domains/editor/components/EditorPane/index.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { act, fireEvent, render, screen } from "@testing-library/react";
+import { Profiler } from "react";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, resolve } from "node:path";
@@ -1322,5 +1323,38 @@ describe("statement highlight box", () => {
       .map((m) => m[1]);
     expect(widths.length).toBeGreaterThanOrEqual(4);
     expect(new Set(widths)).toEqual(new Set(["1"]));
+  });
+});
+
+// Typing writes text/cursor/selection to the tabs store on every keystroke.
+// The pane subscribes with an equality fn that ignores those fields, so pure
+// typing churn must produce ZERO React commits in the editor pane; structural
+// changes (isRunning flip) must still re-render it.
+describe("keystroke re-render guard", () => {
+  it("ignores text/cursor/selection churn but re-renders on structural change", async () => {
+    let commits = 0;
+    render(
+      <Profiler id="editor-pane" onRender={() => { commits += 1; }}>
+        <EditorPane />
+      </Profiler>,
+    );
+    await act(async () => {});
+    const before = commits;
+
+    act(() => {
+      for (let i = 0; i < 5; i += 1) {
+        useTabsStore.getState().updateTab("t1", {
+          text: `select ${i}`,
+          cursor: i,
+          selection: { from: i, to: i },
+        });
+      }
+    });
+    expect(commits).toBe(before);
+
+    act(() => {
+      useTabsStore.getState().updateTab("t1", { isRunning: true });
+    });
+    expect(commits).toBeGreaterThan(before);
   });
 });

--- a/frontend/src/domains/editor/components/EditorPane/index.tsx
+++ b/frontend/src/domains/editor/components/EditorPane/index.tsx
@@ -76,7 +76,8 @@ import { EditorTabRouter } from "./components/EditorTabRouter";
 import type { MarkdownViewMode } from "../MarkdownPreview/types";
 import { dbtSlimDiffIPC } from "./components/SlimDiff/ipc";
 import type { DbtDiffRunConfig } from "./components/SlimDiff/types";
-import { buildPreviewSql, resolveRunRange, resolveRunSql, resolveTabConnectionId, runErrorMessage, NO_CONNECTION_MESSAGE } from "./utils";
+import { buildPreviewSql, resolveRunRange, resolveRunSql, resolveTabConnectionId, runErrorMessage, tabEqualIgnoringVolatile, tabsEqualIgnoringVolatile, NO_CONNECTION_MESSAGE } from "./utils";
+import { useStoreWithEqualityFn } from "zustand/traditional";
 
 import { Icon } from "@shared/ui/Icon";
 import {
@@ -145,11 +146,14 @@ function EditorPane() {
   const addTab = useTabsStore((s) => s.addTab);
   const selectedConnectionId = useConnectionsStore((s) => s.selectedId);
   const connections = useConnectionsStore((s) => s.connections);
-  const allTabs = useTabsStore((s) => s.tabs);
   const [draggingTabId, setDraggingTabId] = useState<string | null>(null);
-  const draggingTab = draggingTabId
-    ? allTabs.find((t) => t.id === draggingTabId) ?? null
-    : null;
+  // Stable null while no drag is active, and volatile-field churn (typing in
+  // some pane) never re-renders the whole editor root mid-drag.
+  const draggingTab = useStoreWithEqualityFn(
+    useTabsStore,
+    (s) => (draggingTabId ? s.tabs.find((t) => t.id === draggingTabId) ?? null : null),
+    tabEqualIgnoringVolatile,
+  );
   const dndSensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),
   );
@@ -320,7 +324,16 @@ function SplitView({ split }: { split: PaneSplit }) {
 /// instance without tearing during cross-pane focus changes.
 function PaneGroupView({ groupId }: { groupId: string }) {
   const group = useTabsStore((s) => findLeaf(s.layout, groupId));
-  const allTabs = useTabsStore((s) => s.tabs);
+  // Ignore text/cursor/selection churn: typing writes those fields to the
+  // store on every keystroke, and re-rendering this (large) component per key
+  // was a dominant editor-latency cost. Everything render-visible here is
+  // structural; the few consumers of the live buffer subscribe narrowly below
+  // or read the store at invocation time (freshActiveTab).
+  const allTabs = useStoreWithEqualityFn(
+    useTabsStore,
+    (s) => s.tabs,
+    tabsEqualIgnoringVolatile,
+  );
   const isFocusedGroup = useTabsStore((s) => s.focusedPaneGroupId === groupId);
   const updateTab = useTabsStore((s) => s.updateTab);
   const focusTab = useTabsStore((s) => s.focusTab);
@@ -437,8 +450,17 @@ function PaneGroupView({ groupId }: { groupId: string }) {
 
   const activeId = group?.selectedTabId ?? null;
   const activeTab = groupTabs.find((t) => t.id === activeId) ?? null;
+  // The subscription above deliberately keeps text/cursor/selection stale in
+  // render; any handler needing the live buffer reads it at invocation time.
+  const freshActiveTab = () =>
+    useTabsStore.getState().tabs.find((t) => t.id === activeId) ?? null;
   const isMarkdown = activeTab?.kind === "markdown";
   const showRunBar = isMarkdown || isRunnableQueryKind(activeTab?.kind);
+  // Narrow live subscription: only a markdown tab needs its buffer text per
+  // keystroke (live preview); every other tab kind returns a stable "" here.
+  const markdownLiveText = useTabsStore((s) =>
+    isMarkdown && activeId ? s.tabs.find((t) => t.id === activeId)?.text ?? "" : "",
+  );
 
   // Status + start time of the active tab's most recent run, driving the
   // editor's per-statement run-status indicator (spinner / check / X).
@@ -536,21 +558,36 @@ function PaneGroupView({ groupId }: { groupId: string }) {
     };
   }, [isDbtModel, isSqlMeshModel, dbtNodes, sqlmeshModels]);
 
-  const liveModelSql = useMemo<Record<string, string>>(() => {
-    const pick = (name: string, filePath?: string) =>
-      (filePath ? allTabs.find((t) => t.filePath === filePath)?.text : undefined) ?? modelDiskSql[name];
-    const map: Record<string, string> = {};
-    const models = isDbtModel
-      ? dbtNodes.filter((n) => n.kind === "model")
-      : isSqlMeshModel
-        ? sqlmeshModels
-        : [];
-    for (const m of models) {
-      const sql = pick(m.name, m.filePath);
-      if (sql != null) map[m.name] = sql;
-    }
-    return map;
-  }, [isDbtModel, isSqlMeshModel, dbtNodes, sqlmeshModels, modelDiskSql, allTabs]);
+  // Subscribed with value equality (not identity): the map's content only
+  // changes when a model file's buffer or disk copy changes, so plain-console
+  // keystrokes neither re-render this component nor churn the identity chain
+  // (liveModelSql -> liveModelColumns -> updateCompletionSchema effect), which
+  // previously reconfigured the completion compartment on every keystroke.
+  const liveModelSql = useStoreWithEqualityFn(
+    useTabsStore,
+    (s): Record<string, string> => {
+      const pick = (name: string, filePath?: string) =>
+        (filePath ? s.tabs.find((t) => t.filePath === filePath)?.text : undefined) ?? modelDiskSql[name];
+      const map: Record<string, string> = {};
+      const models = isDbtModel
+        ? dbtNodes.filter((n) => n.kind === "model")
+        : isSqlMeshModel
+          ? sqlmeshModels
+          : [];
+      for (const m of models) {
+        const sql = pick(m.name, m.filePath);
+        if (sql != null) map[m.name] = sql;
+      }
+      return map;
+    },
+    (a, b) => {
+      if (a === b) return true;
+      const ka = Object.keys(a);
+      const kb = Object.keys(b);
+      if (ka.length !== kb.length) return false;
+      return ka.every((k) => a[k] === b[k]);
+    },
+  );
 
   // name → live `SELECT` output columns, parsed from `liveModelSql` when the
   // model SQL is confidently flat. Used to override stale scan columns in both
@@ -585,12 +622,18 @@ function PaneGroupView({ groupId }: { groupId: string }) {
       sqlmeshTests.some((t) => t.filePath === activeTab.filePath),
     [activeTab?.filePath, sqlmeshTests],
   );
+  // Narrow live subscription: only a sqlmesh test YAML needs text/cursor per
+  // keystroke (the toolbar's test-at-cursor label); every other tab kind
+  // returns stable primitives here and skips the re-render.
+  const smTestTabText = useTabsStore((s) =>
+    isSqlMeshTestFile && activeId ? s.tabs.find((t) => t.id === activeId)?.text ?? "" : "",
+  );
+  const smTestTabCursor = useTabsStore((s) =>
+    isSqlMeshTestFile && activeId ? s.tabs.find((t) => t.id === activeId)?.cursor ?? 0 : 0,
+  );
   const currentSqlMeshTestName = useMemo(
-    () =>
-      isSqlMeshTestFile && activeTab
-        ? sqlmeshTestNameAtCursor(activeTab.text, activeTab.cursor ?? 0)
-        : null,
-    [isSqlMeshTestFile, activeTab?.text, activeTab?.cursor],
+    () => (isSqlMeshTestFile ? sqlmeshTestNameAtCursor(smTestTabText, smTestTabCursor) : null),
+    [isSqlMeshTestFile, smTestTabText, smTestTabCursor],
   );
 
   function newTab() {
@@ -945,18 +988,20 @@ function PaneGroupView({ groupId }: { groupId: string }) {
   }, [activeTab?.id, activeTab?.isRunning, activeTab?.runRange, activeRunStatus, activeRunStartedAt]);
 
   function runActiveTab() {
-    const isFed = activeTab?.isFederation;
-    if (!activeTab) return;
+    // Live read: render-scope runTab has stale text/selection by design.
+    const runTab = freshActiveTab();
+    if (!runTab) return;
+    const isFed = runTab.isFederation;
     // A table tab renders its rows inline and never uses the shared bottom
     // Results pane, so its run must leave that pane exactly as the user left it:
     // no expanding it, no switching its Command Logs/Results mode.
-    const isTable = activeTab.tabType === "table";
-    const sql = resolveRunSql(activeTab);
+    const isTable = runTab.tabType === "table";
+    const sql = resolveRunSql(runTab);
     if (!sql) return;
     const runId = crypto.randomUUID();
     const queryId = crypto.randomUUID();
     const startedAt = Date.now();
-    appendRun(activeTab.id, {
+    appendRun(runTab.id, {
       id: runId,
       sqlSnapshot: sql,
       status: "pending",
@@ -965,22 +1010,22 @@ function PaneGroupView({ groupId }: { groupId: string }) {
     });
     if (!isTable) useSettingsStore.getState().showBottomPane();
     if (!isFed && (!tabConnectionId || !tabConnection)) {
-      updateTab(activeTab.id, { error: NO_CONNECTION_MESSAGE, isRunning: false });
-      patchRun(activeTab.id, runId, { status: "error", error: NO_CONNECTION_MESSAGE, endedAt: Date.now() });
+      updateTab(runTab.id, { error: NO_CONNECTION_MESSAGE, isRunning: false });
+      patchRun(runTab.id, runId, { status: "error", error: NO_CONNECTION_MESSAGE, endedAt: Date.now() });
       if (!isTable) setRequestedPaneMode("output");
       return;
     }
-    updateTab(activeTab.id, {
+    updateTab(runTab.id, {
       isRunning: true,
       queryId,
-      runRange: resolveRunRange(activeTab),
+      runRange: resolveRunRange(runTab),
       error: undefined,
       pane: "results",
     });
     const ps = useResultsTableStore.getState();
-    ps.resetPage(activeTab.id);
-    const pSize = ps.getPageSize(activeTab.id);
-    const queryLanguage = queryLanguageForEditorKind(activeTab.kind);
+    ps.resetPage(runTab.id);
+    const pSize = ps.getPageSize(runTab.id);
+    const queryLanguage = queryLanguageForEditorKind(runTab.kind);
     // In manual transaction mode every executed statement leaves uncommitted
     // work, so the connection becomes dirty (enabling Commit/Rollback) and the
     // statement is recorded for the transaction reference pane.
@@ -1000,14 +1045,14 @@ function PaneGroupView({ groupId }: { groupId: string }) {
       .then((result) => {
         if (isFed) useFederationProgressStore.getState().endRun();
         const isDml = result.rows_affected != null;
-        updateTab(activeTab.id, {
+        updateTab(runTab.id, {
           result: isDml ? undefined : result,
           isRunning: false,
           plan: undefined,
           error: undefined,
           pane: "results",
         });
-        patchRun(activeTab.id, runId, {
+        patchRun(runTab.id, runId, {
           status: "success",
           result,
           endedAt: Date.now(),
@@ -1020,7 +1065,7 @@ function PaneGroupView({ groupId }: { groupId: string }) {
           });
         }
         if (isDml) {
-          const allRuns = useRunHistoryStore.getState().runsByTab[activeTab.id] ?? [];
+          const allRuns = useRunHistoryStore.getState().runsByTab[runTab.id] ?? [];
           const lastSelect = [...allRuns].reverse().find(
             (r) => r.id !== runId && !/^\s*(INSERT|UPDATE|DELETE)\b/i.test(r.sqlSnapshot),
           );
@@ -1033,8 +1078,8 @@ function PaneGroupView({ groupId }: { groupId: string }) {
       .catch((e) => {
         if (isFed) useFederationProgressStore.getState().endRun();
         const msg = runErrorMessage(e);
-        updateTab(activeTab.id, { error: msg, isRunning: false });
-        patchRun(activeTab.id, runId, {
+        updateTab(runTab.id, { error: msg, isRunning: false });
+        patchRun(runTab.id, runId, {
           status: "error",
           error: msg,
           endedAt: Date.now(),
@@ -1052,11 +1097,13 @@ function PaneGroupView({ groupId }: { groupId: string }) {
   }
 
   function saveActiveTab() {
+    // Live read: render-scope activeTab has stale text by design.
+    const saveTab = freshActiveTab();
     // Media tabs are read-only binary previews; their `text` is empty, so
     // writing it back would truncate the image/asset on disk.
-    if (!activeTab?.filePath || activeTab.tabType === "media") return;
-    const filePath = activeTab.filePath;
-    writeTextFileIPC(filePath, activeTab.text)
+    if (!saveTab?.filePath || saveTab.tabType === "media") return;
+    const filePath = saveTab.filePath;
+    writeTextFileIPC(filePath, saveTab.text)
       .then(async () => {
         let repo = gitRepoPath;
         if (!repo) {
@@ -1079,11 +1126,13 @@ function PaneGroupView({ groupId }: { groupId: string }) {
     saveActiveTabRef.current = saveActiveTab;
   });
 
-  const autosaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   useEffect(() => {
     // Notebooks autosave themselves from the notebook store (tab.text is stale
     // for them), so skip them here. Media tabs are read-only binary previews:
     // their empty `text` would truncate the image/asset on disk.
+    // Text changes are observed via a store subscription instead of a render
+    // dependency so typing does not have to re-render this component to arm
+    // the autosave debounce.
     if (
       !autosave ||
       !activeTab?.filePath ||
@@ -1092,25 +1141,32 @@ function PaneGroupView({ groupId }: { groupId: string }) {
     )
       return;
     const filePath = activeTab.filePath;
-    const text = activeTab.text;
-    if (autosaveTimerRef.current) clearTimeout(autosaveTimerRef.current);
-    autosaveTimerRef.current = setTimeout(() => {
-      writeTextFileIPC(filePath, text)
-        .then(async () => {
-          await useGitStore.getState().refreshFileStatuses().catch(() => {});
-          const repo = gitRepoPath ?? useFilesStore.getState().rootPath;
-          if (repo) {
-            gitFileDiffHunksIPC(repo, filePath)
-              .then(setDiffHunks)
-              .catch(() => setDiffHunks([]));
-          }
-        })
-        .catch((e) => console.error("Autosave failed", e));
-    }, 500);
+    const tabId = activeTab.id;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const unsubscribe = useTabsStore.subscribe((state, prev) => {
+      const next = state.tabs.find((t) => t.id === tabId);
+      const before = prev.tabs.find((t) => t.id === tabId);
+      if (!next || !before || next.text === before.text) return;
+      if (timer) clearTimeout(timer);
+      timer = setTimeout(() => {
+        writeTextFileIPC(filePath, next.text)
+          .then(async () => {
+            await useGitStore.getState().refreshFileStatuses().catch(() => {});
+            const repo = gitRepoPath ?? useFilesStore.getState().rootPath;
+            if (repo) {
+              gitFileDiffHunksIPC(repo, filePath)
+                .then(setDiffHunks)
+                .catch(() => setDiffHunks([]));
+            }
+          })
+          .catch((e) => console.error("Autosave failed", e));
+      }, 500);
+    });
     return () => {
-      if (autosaveTimerRef.current) clearTimeout(autosaveTimerRef.current);
+      if (timer) clearTimeout(timer);
+      unsubscribe();
     };
-  }, [autosave, activeTab?.text, activeTab?.filePath]);
+  }, [autosave, activeTab?.id, activeTab?.filePath, activeTab?.tabType, gitRepoPath]);
 
 
   function handleSplit(tabId: string, direction: SplitDirection) {
@@ -1138,12 +1194,19 @@ function PaneGroupView({ groupId }: { groupId: string }) {
   // Prefer the right-click position (so right-clicking near a star offers the
   // action without first moving the caret), but fall back to the caret when the
   // click isn't on/near a star, preserving keyboard-placed-caret expansion.
-  const starExpansion = useMemo(() => {
-    if (!activeTab) return null;
+  // Computed ON DEMAND (menu open / command dispatch), never per render: the
+  // detection scans the whole document, and running it on every keystroke was
+  // pure waste while the context menu stayed closed.
+  const computeStarExpansion = (clickPos: number | null) => {
+    const tab = freshActiveTab();
+    if (!tab) return null;
     const fromClick =
-      ctxStarPos != null ? expandStarAtCursor(activeTab.text, ctxStarPos, starSchema) : null;
-    return fromClick ?? expandStarAtCursor(activeTab.text, activeTab.cursor ?? 0, starSchema);
-  }, [activeTab?.text, activeTab?.cursor, ctxStarPos, starSchema]);
+      clickPos != null ? expandStarAtCursor(tab.text, clickPos, starSchema) : null;
+    return fromClick ?? expandStarAtCursor(tab.text, tab.cursor ?? 0, starSchema);
+  };
+  // Menu open/close is a state change, so this render-scope value exists
+  // exactly while the editor context menu is visible.
+  const starExpansion = editorMenu.state ? computeStarExpansion(ctxStarPos) : null;
 
   function onEditorContextMenu(e: ReactMouseEvent) {
     const pos = editorHandleRef.current?.posAtCoords(e.clientX, e.clientY);
@@ -1166,15 +1229,16 @@ function PaneGroupView({ groupId }: { groupId: string }) {
   }
 
   function pinFocusedQuery() {
-    if (!activeTab || !activeTab.text?.trim()) return;
-    const sql = resolveRunSql(activeTab);
+    const pinTab = freshActiveTab();
+    if (!pinTab || !pinTab.text?.trim()) return;
+    const sql = resolveRunSql(pinTab);
     if (!sql) return;
-    const conn = connections.find((c) => c.id === activeTab.connectionId);
+    const conn = connections.find((c) => c.id === pinTab.connectionId);
     const pinnedQueriesStore = usePinnedQueriesStore.getState();
     pinnedQueriesStore.addQuery({
       name: "Untitled query",
       text: sql,
-      connectionId: activeTab.connectionId,
+      connectionId: pinTab.connectionId,
       kind: conn?.kind ?? "sql",
     });
     pinnedQueriesStore.openPane();
@@ -1185,11 +1249,14 @@ function PaneGroupView({ groupId }: { groupId: string }) {
   }
 
   function expandFocusedStar() {
-    if (!starExpansion) return;
+    // Menu path reuses the render-scope detection (right-click position);
+    // the keyboard command path detects at the caret on demand.
+    const expansion = starExpansion ?? computeStarExpansion(null);
+    if (!expansion) return;
     editorHandleRef.current?.replaceRange(
-      starExpansion.from,
-      starExpansion.to,
-      starExpansion.replacement,
+      expansion.from,
+      expansion.to,
+      expansion.replacement,
     );
   }
 
@@ -1464,8 +1531,9 @@ function PaneGroupView({ groupId }: { groupId: string }) {
     try {
       // dbt compiles the model from disk, so flush the editor buffer first;
       // otherwise the diff reflects the last-saved file, not the latest edit.
-      if (activeTab.filePath) {
-        await writeTextFileIPC(activeTab.filePath, activeTab.text);
+      const diffTab = freshActiveTab();
+      if (diffTab?.filePath) {
+        await writeTextFileIPC(diffTab.filePath, diffTab.text);
       }
       const result = await dbtSlimDiffIPC({
         connectionId: tabConnectionId,
@@ -1686,10 +1754,11 @@ function PaneGroupView({ groupId }: { groupId: string }) {
   }
 
   function handleSmTestAtCursor() {
-    if (!activeTab?.filePath) return;
-    const name = sqlmeshTestNameAtCursor(activeTab.text, activeTab.cursor ?? 0);
-    const target = name ? `${activeTab.filePath}::${name}` : activeTab.filePath;
-    void handleSmTestTarget(target, name ?? activeTab.title);
+    const testTab = freshActiveTab();
+    if (!testTab?.filePath) return;
+    const name = sqlmeshTestNameAtCursor(testTab.text, testTab.cursor ?? 0);
+    const target = name ? `${testTab.filePath}::${name}` : testTab.filePath;
+    void handleSmTestTarget(target, name ?? testTab.title);
   }
 
   function handleSmTestFile() {
@@ -1827,7 +1896,10 @@ function PaneGroupView({ groupId }: { groupId: string }) {
         run: () => { setSmPrimaryAction("preview"); handleSmPreview(); },
         isEnabled: () => sqlMeshModelReady && !isSqlMeshPythonModel,
       },
-      expandStar: { run: () => expandFocusedStar(), isEnabled: () => !!starExpansion },
+      expandStar: {
+        run: () => expandFocusedStar(),
+        isEnabled: () => !!(starExpansion ?? computeStarExpansion(null)),
+      },
       pinQuery: { run: () => pinFocusedQuery(), isEnabled: () => activeTab?.tabType === "console" },
       openEditorContextMenu: { run: () => openEditorMenuAtCaret(), isEnabled: () => !!activeTab },
       switchMongoSqlMode: { run: () => switchMongoQueryMode("mongodb"), isEnabled: () => isMongoTab },
@@ -1974,7 +2046,7 @@ function PaneGroupView({ groupId }: { groupId: string }) {
           showRunBar,
           markdownView,
           onSetMarkdownView: setMarkdownView,
-          markdownSource: activeTab?.text ?? "",
+          markdownSource: markdownLiveText,
         }}
       />
     </div>

--- a/frontend/src/domains/editor/components/EditorPane/index.tsx
+++ b/frontend/src/domains/editor/components/EditorPane/index.tsx
@@ -793,16 +793,18 @@ function PaneGroupView({ groupId }: { groupId: string }) {
       host: editorHostRef.current,
       initialDoc: activeTab.text,
       initialCursor: activeTab.cursor,
-      onChange: (text) => {
-        updateTab(activeTab.id, { text });
+      // One patch per editor update: a keystroke changes doc AND selection, so
+      // separate callbacks meant three store writes (and three re-render waves
+      // through every tab subscriber) per key. Single write instead.
+      onEdit: (patch) => {
+        updateTab(activeTab.id, patch);
+        if (patch.text === undefined) return;
         if (currentDbtNode) {
           markCompiledStale(currentDbtNode.name);
           markDocsStale();
         }
         if (currentSqlMeshModel) markRenderedStale(currentSqlMeshModel.name);
       },
-      onCursorChange: (cursor) => updateTab(activeTab.id, { cursor }),
-      onSelectionChange: (selection) => updateTab(activeTab.id, { selection }),
       languageId: activeTab.kind,
       fileName: activeTab.filePath,
       connectionKind: tabConnection?.kind,

--- a/frontend/src/domains/editor/components/EditorPane/utils.test.ts
+++ b/frontend/src/domains/editor/components/EditorPane/utils.test.ts
@@ -18,6 +18,7 @@ import { cancelQueryIPC, explainQueryIPC, runQueryIPC, writeTextFileIPC } from "
 import { leavesOf } from "@shell/utils/paneTree";
 import { useNotebookStore } from "@domains/notebook/hooks";
 import { useTabsStore } from "@shell/hooks/tabsStore";
+import type { EditorTab } from "@shell/types";
 import { parseNotebook } from "@domains/notebook";
 import { useSettingsStore } from "@shared/settings";
 import { useDbtStore } from "@domains/dbt/hooks";
@@ -34,6 +35,8 @@ import {
   runErrorMessage,
   saveActiveFile,
   stopActiveQuery,
+  tabEqualIgnoringVolatile,
+  tabsEqualIgnoringVolatile,
 } from "./utils";
 
 function reset() {
@@ -515,5 +518,58 @@ describe("resolveRunRange", () => {
     const cursor = cli.indexOf("HGETALL") + 3;
     const tab = { text: cli, kind: "rediscli", cursor } as any;
     expect(resolveRunRange(tab)).toEqual({ from: 9, to: cli.length });
+  });
+});
+
+// The pane group's tabs subscription ignores per-keystroke fields so typing
+// does not re-render the editor chrome; structural fields still count.
+describe("tabEqualIgnoringVolatile", () => {
+  const base = { id: "t1", title: "Q", text: "select 1", kind: "sql", cursor: 0 } as EditorTab;
+
+  it("treats text/cursor/selection churn as equal", () => {
+    expect(
+      tabEqualIgnoringVolatile(base, {
+        ...base,
+        text: "select 12345",
+        cursor: 12,
+        selection: { from: 3, to: 8 },
+      }),
+    ).toBe(true);
+  });
+
+  it("detects structural changes", () => {
+    expect(tabEqualIgnoringVolatile(base, { ...base, isRunning: true })).toBe(false);
+    expect(tabEqualIgnoringVolatile(base, { ...base, title: "renamed" })).toBe(false);
+    expect(tabEqualIgnoringVolatile(base, { ...base, error: "boom" })).toBe(false);
+  });
+
+  it("handles null/undefined operands", () => {
+    expect(tabEqualIgnoringVolatile(null, null)).toBe(true);
+    expect(tabEqualIgnoringVolatile(base, null)).toBe(false);
+    expect(tabEqualIgnoringVolatile(undefined, base)).toBe(false);
+  });
+
+  it("detects a field present on only one side", () => {
+    expect(tabEqualIgnoringVolatile(base, { ...base, filePath: "/a.sql" })).toBe(false);
+  });
+});
+
+describe("tabsEqualIgnoringVolatile", () => {
+  const base = { id: "t1", title: "Q", text: "select 1", kind: "sql", cursor: 0 } as EditorTab;
+
+  it("equal when only volatile fields changed on some tab", () => {
+    const a = [base, { ...base, id: "t2" }];
+    const b = [{ ...base, text: "x", cursor: 1 }, { ...base, id: "t2" }];
+    expect(tabsEqualIgnoringVolatile(a, b)).toBe(true);
+  });
+
+  it("unequal on length change or structural change", () => {
+    const a = [base];
+    expect(tabsEqualIgnoringVolatile(a, [])).toBe(false);
+    expect(
+      tabsEqualIgnoringVolatile(a, [
+        { ...base, result: { columns: [], rows: [], elapsed: 0 } } as EditorTab,
+      ]),
+    ).toBe(false);
   });
 });

--- a/frontend/src/domains/editor/components/EditorPane/utils.ts
+++ b/frontend/src/domains/editor/components/EditorPane/utils.ts
@@ -327,6 +327,36 @@ function exportActiveResults(format: ExportFormat): boolean {
   return true;
 }
 
+// Tab fields rewritten on (nearly) every keystroke. Subscriptions that only
+// need structural tab state (id/kind/title/result/isRunning/...) compare with
+// these ignored so typing does not re-render the whole pane group; handlers
+// that need the live buffer read it from the store at invocation time.
+const VOLATILE_TAB_FIELDS = new Set(["text", "cursor", "selection"]);
+
+function tabEqualIgnoringVolatile(
+  a: EditorTab | null | undefined,
+  b: EditorTab | null | undefined,
+): boolean {
+  if (a === b) return true;
+  if (!a || !b) return false;
+  const ra = a as unknown as Record<string, unknown>;
+  const rb = b as unknown as Record<string, unknown>;
+  for (const k of new Set([...Object.keys(ra), ...Object.keys(rb)])) {
+    if (VOLATILE_TAB_FIELDS.has(k)) continue;
+    if (ra[k] !== rb[k]) return false;
+  }
+  return true;
+}
+
+function tabsEqualIgnoringVolatile(a: EditorTab[], b: EditorTab[]): boolean {
+  if (a === b) return true;
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (!tabEqualIgnoringVolatile(a[i], b[i])) return false;
+  }
+  return true;
+}
+
 export type { RunMode };
 export {
   NO_CONNECTION_MESSAGE,
@@ -342,4 +372,6 @@ export {
   stopActiveQuery,
   saveActiveFile,
   exportActiveResults,
+  tabEqualIgnoringVolatile,
+  tabsEqualIgnoringVolatile,
 };

--- a/frontend/src/domains/editor/utils/autocomplete/context/clauseDetection.ts
+++ b/frontend/src/domains/editor/utils/autocomplete/context/clauseDetection.ts
@@ -1,5 +1,6 @@
 import { syntaxTree } from "@codemirror/language";
 import type { EditorState } from "@codemirror/state";
+import { docString } from "../../docText";
 
 type SqlClause =
   | "from"
@@ -33,7 +34,7 @@ function collectKeywords(
   to: number,
 ): KeywordHit[] {
   const tree = syntaxTree(state);
-  const doc = state.doc.toString();
+  const doc = docString(state.doc);
   const kws: KeywordHit[] = [];
   tree.iterate({
     from,
@@ -86,7 +87,7 @@ function findStatementRange(
   pos: number,
 ): { from: number; to: number } {
   const tree = syntaxTree(state);
-  const doc = state.doc.toString();
+  const doc = docString(state.doc);
   let stmtFrom = 0;
   let stmtTo = state.doc.length;
   let found = false;
@@ -108,7 +109,7 @@ function findStatementRange(
 
 function isPastAllStatements(state: EditorState, pos: number): boolean {
   const tree = syntaxTree(state);
-  const doc = state.doc.toString();
+  const doc = docString(state.doc);
   let maxTo = 0;
   let lastStmtHasSemicolon = false;
   tree.iterate({
@@ -138,7 +139,7 @@ function detectClauseFromTree(state: EditorState, pos: number): SqlClause | null
 
   if (isPastAllStatements(state, pos)) return "keyword";
 
-  const doc = state.doc.toString();
+  const doc = docString(state.doc);
   const { insideParens, parenFrom } = findParenContext(state, pos);
   const stmt = findStatementRange(state, pos);
 
@@ -195,7 +196,7 @@ function detectClauseRegex(text: string, pos: number): SqlClause {
 }
 
 function detectClause(state: EditorState, pos: number): SqlClause {
-  const doc = state.doc.toString();
+  const doc = docString(state.doc);
   // Jinja templating ({{ ... }} / {% ... %}) confuses the Lezer SQL parser, so
   // the syntax-tree clause detector misfires, e.g. reporting `keyword` in the
   // middle of a dbt model's column list, which suppresses column completions.

--- a/frontend/src/domains/editor/utils/autocomplete/data/functionSignatures.ts
+++ b/frontend/src/domains/editor/utils/autocomplete/data/functionSignatures.ts
@@ -1,6 +1,7 @@
 import { StateField, type Extension } from "@codemirror/state";
 import { showTooltip, type Tooltip } from "@codemirror/view";
 import type { DatabaseKind } from "@shared";
+import { docString } from "../../docText";
 
 interface FunctionSignature {
   name: string;
@@ -91,7 +92,7 @@ function paramHintTooltipExtension(kind?: DatabaseKind): Extension {
     update(value, tr) {
       if (!tr.docChanged && !tr.selection) return value;
       const pos = tr.state.selection.main.head;
-      const doc = tr.state.doc.toString();
+      const doc = docString(tr.state.doc);
       const ctx = findFunctionCallContext(doc, pos);
       if (!ctx) return null;
       const sig = signatures.get(ctx.funcName.toUpperCase());

--- a/frontend/src/domains/editor/utils/autocomplete/providers/dbtYaml.ts
+++ b/frontend/src/domains/editor/utils/autocomplete/providers/dbtYaml.ts
@@ -1,6 +1,7 @@
 import type { Completion, CompletionContext } from "@codemirror/autocomplete";
 
 import { CompletionProvider, type CompletionAnalysis } from "../core/provider";
+import { docString } from "../../docText";
 
 type DbtYamlFileType = "project" | "schema" | "packages" | "profiles";
 
@@ -552,7 +553,7 @@ class DbtYamlCompletionProvider extends CompletionProvider<DbtYamlSituation> {
   }
 
   protected analyze(cc: CompletionContext): CompletionAnalysis<DbtYamlSituation> | null {
-    const docText = cc.state.doc.toString();
+    const docText = docString(cc.state.doc);
     const line = cc.state.doc.lineAt(cc.pos);
     const lineNumber = line.number - 1;
 

--- a/frontend/src/domains/editor/utils/autocomplete/providers/sql/situation.ts
+++ b/frontend/src/domains/editor/utils/autocomplete/providers/sql/situation.ts
@@ -25,6 +25,7 @@ import {
 } from "./dbtRefs";
 import { buildSqlMeshFromJoinCompletions } from "./sqlmeshRefs";
 import type { SqlCompletionContext } from "./types";
+import { docString } from "../../../docText";
 
 interface QualifiedRef {
   qualifier: string;
@@ -62,7 +63,7 @@ function analyzeSqlSituation(
 ): CompletionAnalysis<SqlSituation> | null {
   const { opts, schema } = ctx;
   const word = cc.matchBefore(/[\w.$]+/);
-  const docText = cc.state.doc.toString();
+  const docText = docString(cc.state.doc);
   const qualified = qualifiedColumnContext(docText, cc.pos);
   const wordFrom = word?.from ?? cc.pos;
   const clause = detectClause(cc.state, wordFrom);

--- a/frontend/src/domains/editor/utils/autocomplete/providers/sqlmeshYaml.ts
+++ b/frontend/src/domains/editor/utils/autocomplete/providers/sqlmeshYaml.ts
@@ -3,6 +3,7 @@ import type { Completion, CompletionContext } from "@codemirror/autocomplete";
 import { CompletionProvider, type CompletionAnalysis } from "../core/provider";
 import { resolveSchemaPath, yamlPathAtCursor } from "./dbtYaml";
 import type { YamlSchemaNode } from "./dbtYaml";
+import { docString } from "../../docText";
 
 type SqlMeshYamlFileType = "config" | "test";
 
@@ -231,7 +232,7 @@ class SqlMeshYamlCompletionProvider extends CompletionProvider<SqlMeshYamlSituat
   }
 
   protected analyze(cc: CompletionContext): CompletionAnalysis<SqlMeshYamlSituation> | null {
-    const docText = cc.state.doc.toString();
+    const docText = docString(cc.state.doc);
     const line = cc.state.doc.lineAt(cc.pos);
     const lineNumber = line.number - 1;
 

--- a/frontend/src/domains/editor/utils/docText.test.ts
+++ b/frontend/src/domains/editor/utils/docText.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { Text } from "@codemirror/state";
+import { docString } from "./docText";
+
+describe("docString", () => {
+  it("returns the document text", () => {
+    const doc = Text.of(["SELECT 1;", "SELECT 2;"]);
+    expect(docString(doc)).toBe("SELECT 1;\nSELECT 2;");
+  });
+
+  it("returns the SAME string instance for repeated calls on one doc version", () => {
+    const doc = Text.of(["SELECT * FROM t"]);
+    const a = docString(doc);
+    const b = docString(doc);
+    expect(a).toBe(b);
+  });
+
+  it("recomputes for a new document version", () => {
+    const doc = Text.of(["SELECT 1"]);
+    const edited = doc.replace(7, 8, Text.of(["2"]));
+    expect(docString(doc)).toBe("SELECT 1");
+    expect(docString(edited)).toBe("SELECT 2");
+  });
+
+  it("handles the empty document", () => {
+    expect(docString(Text.empty)).toBe("");
+  });
+});

--- a/frontend/src/domains/editor/utils/docText.ts
+++ b/frontend/src/domains/editor/utils/docText.ts
@@ -1,0 +1,20 @@
+// Memoized `Text -> string` conversion. Several per-keystroke consumers
+// (statement highlight, autocomplete clause detection, param hints) each called
+// `state.doc.toString()` on the same document version, allocating a full copy
+// of the document apiece on every keystroke. `Text` is immutable, so one copy
+// per document version is enough; the WeakMap lets old versions be collected.
+
+import type { Text } from "@codemirror/state";
+
+const cache = new WeakMap<Text, string>();
+
+function docString(doc: Text): string {
+  let s = cache.get(doc);
+  if (s === undefined) {
+    s = doc.toString();
+    cache.set(doc, s);
+  }
+  return s;
+}
+
+export { docString };

--- a/frontend/src/domains/editor/utils/navigation/statementHighlight.test.ts
+++ b/frontend/src/domains/editor/utils/navigation/statementHighlight.test.ts
@@ -134,3 +134,50 @@ describe("findStatementAt", () => {
     expect(extracted).toBe("SELECT 2;");
   });
 });
+
+// Field-level behavior: decorations render, and a caret move INSIDE the
+// highlighted statement reuses the previous field value (no whole-document
+// boundary rescan per arrow key), while crossing into another statement
+// recomputes.
+describe("statementHighlightField", () => {
+  it("decorates the statement under the caret and reuses state within it", async () => {
+    const { EditorState } = await import("@codemirror/state");
+    const { statementHighlight, statementHighlightField } = await import("./statementHighlight");
+    const doc = "SELECT 1;\nSELECT 22;";
+    let state = EditorState.create({
+      doc,
+      selection: { anchor: 2 },
+      extensions: statementHighlight(),
+    });
+    const first = state.field(statementHighlightField);
+    expect(first.range).toEqual({ from: 0, to: 9 });
+
+    // Caret move within statement 1: same field value instance (skip path).
+    state = state.update({ selection: { anchor: 5 } }).state;
+    expect(state.field(statementHighlightField)).toBe(first);
+
+    // Caret move into statement 2: recomputed range.
+    state = state.update({ selection: { anchor: doc.indexOf("22") } }).state;
+    const second = state.field(statementHighlightField);
+    expect(second).not.toBe(first);
+    expect(second.range).toEqual({ from: 10, to: doc.length });
+  });
+
+  it("recomputes on document edits", async () => {
+    const { EditorState } = await import("@codemirror/state");
+    const { statementHighlight, statementHighlightField } = await import("./statementHighlight");
+    let state = EditorState.create({
+      doc: "SELECT 1",
+      selection: { anchor: 8 },
+      extensions: statementHighlight(),
+    });
+    const before = state.field(statementHighlightField);
+    state = state.update({
+      changes: { from: 8, to: 8, insert: "23" },
+      selection: { anchor: 10 },
+    }).state;
+    const after = state.field(statementHighlightField);
+    expect(after).not.toBe(before);
+    expect(after.range).toEqual({ from: 0, to: 10 });
+  });
+});

--- a/frontend/src/domains/editor/utils/navigation/statementHighlight.ts
+++ b/frontend/src/domains/editor/utils/navigation/statementHighlight.ts
@@ -1,12 +1,22 @@
 import { StateField, type EditorState, type Range } from "@codemirror/state";
 import { EditorView, Decoration, type DecorationSet } from "@codemirror/view";
+import { docString } from "../docText";
 import { findStatementAt } from "./statementSplit";
 
-function computeDecorations(state: EditorState): DecorationSet {
-  const doc = state.doc.toString();
+// Field value keeps the highlighted statement's range beside the decorations
+// so a pure caret move INSIDE the same statement (the common case while
+// navigating) can reuse the previous value instead of rescanning the whole
+// document for statement boundaries on every transaction.
+interface StatementHighlightState {
+  deco: DecorationSet;
+  range: { from: number; to: number } | null;
+}
+
+function computeState(state: EditorState): StatementHighlightState {
+  const doc = docString(state.doc);
   const pos = state.selection.main.head;
   const range = findStatementAt(doc, pos);
-  if (!range) return Decoration.none;
+  if (!range) return { deco: Decoration.none, range: null };
 
   const firstLine = state.doc.lineAt(range.from).number;
   const lastLine = state.doc.lineAt(
@@ -37,16 +47,22 @@ function computeDecorations(state: EditorState): DecorationSet {
     );
   }
 
-  return Decoration.set(decos, true);
+  return { deco: Decoration.set(decos, true), range };
 }
 
-const statementHighlightField = StateField.define<DecorationSet>({
-  create: computeDecorations,
-  update(decos, tr) {
-    if (tr.docChanged || tr.selection) return computeDecorations(tr.state);
-    return decos;
+const statementHighlightField = StateField.define<StatementHighlightState>({
+  create: computeState,
+  update(prev, tr) {
+    if (!tr.docChanged && !tr.selection) return prev;
+    // Caret moved but stayed inside the highlighted statement: the decoration
+    // set cannot change, so skip the whole-document boundary rescan.
+    if (!tr.docChanged && prev.range) {
+      const pos = tr.state.selection.main.head;
+      if (pos >= prev.range.from && pos <= prev.range.to) return prev;
+    }
+    return computeState(tr.state);
   },
-  provide: (f) => EditorView.decorations.from(f),
+  provide: (f) => EditorView.decorations.from(f, (v) => v.deco),
 });
 
 function statementHighlight() {
@@ -56,4 +72,5 @@ function statementHighlight() {
 export {
   findStatementAt,
   statementHighlight,
+  statementHighlightField,
 };

--- a/frontend/src/domains/editor/utils/ui/constants.ts
+++ b/frontend/src/domains/editor/utils/ui/constants.ts
@@ -1,0 +1,18 @@
+// Shared tuning constants for the editor's per-keystroke UI extensions.
+
+// How far back before the viewport semantic-highlight classification starts.
+// The role of a token depends on keywords to its LEFT (FROM/JOIN/WITH ... state
+// machine), so leaves are collected from a context window preceding the first
+// visible position. A window instead of the whole document keeps the
+// per-keystroke cost bounded by the viewport, not the file; statements larger
+// than the window may rarely misclassify their visible tail, which is
+// acceptable for a heuristic overlay.
+const SEMANTIC_CONTEXT_CHARS = 4000;
+
+// Parse budget per semantic-highlight rebuild. The window is viewport-sized,
+// so this is never hit in practice; it exists so a pathological single-line
+// document cannot stall the keystroke. An incomplete tree self-heals: the
+// plugin rebuilds when the background parser finishes (tree identity check).
+const SEMANTIC_PARSE_BUDGET_MS = 50;
+
+export { SEMANTIC_CONTEXT_CHARS, SEMANTIC_PARSE_BUDGET_MS };

--- a/frontend/src/domains/editor/utils/ui/setup.test.ts
+++ b/frontend/src/domains/editor/utils/ui/setup.test.ts
@@ -151,7 +151,7 @@ describe("mountEditor sql with schema", () => {
       initialDoc: "select  from users",
       languageId: "sql",
       schema: { users: [{ name: "id" }, { name: "name" }] },
-      onChange: () => {},
+      onEdit: () => {},
     });
     // Lang-sql attaches as a language layer; the editor mounts with caret
     // visible. The presence of the editor with the doc proves the SQL
@@ -169,8 +169,8 @@ describe("mountEditor schema drops", () => {
       initialDoc: "select  from users",
       initialCursor: 7,
       languageId: "sql",
-      onChange: (text) => {
-        latest = text;
+      onEdit: (patch) => {
+        latest = patch.text ?? latest;
       },
     });
     const content = host.querySelector(".cm-content") as HTMLElement;
@@ -223,8 +223,8 @@ describe("mountEditor schema drops", () => {
       initialDoc: "select  from users",
       initialCursor: 7,
       languageId: "sql",
-      onChange: (text) => {
-        latest = text;
+      onEdit: (patch) => {
+        latest = patch.text ?? latest;
       },
     });
 
@@ -280,5 +280,44 @@ describe("mountEditor live shortcut compartment", () => {
     // The old binding no longer triggers Run.
     ctrlKeydown(content, "Enter");
     expect(runs).toBe(2);
+  });
+});
+
+// A single keystroke changes the document AND moves the caret. The contract is
+// ONE onEdit invocation carrying text + cursor + selection together, so the
+// owner commits exactly one store write per keystroke (three separate
+// callbacks previously meant three writes and three re-render waves).
+describe("mountEditor onEdit coalescing", () => {
+  it("fires once per edit with text, cursor and selection in one patch", () => {
+    const patches: Array<{ text?: string; cursor?: number; selection?: { from: number; to: number } }> = [];
+    unmount = mountEditor({
+      host,
+      initialDoc: "select 1",
+      initialCursor: 8,
+      languageId: "sql",
+      onEdit: (patch) => patches.push(patch),
+    });
+
+    unmount.insertAtCursor("2");
+
+    expect(patches).toHaveLength(1);
+    expect(patches[0].text).toBe("select 12");
+    expect(patches[0].cursor).toBe(9);
+    expect(patches[0].selection).toEqual({ from: 9, to: 9 });
+  });
+
+  it("does not fire for transactions that touch neither doc nor selection", () => {
+    const patches: unknown[] = [];
+    const handle = mountEditor({
+      host,
+      initialDoc: "select 1",
+      languageId: "sql",
+      onEdit: (patch) => patches.push(patch),
+    });
+    unmount = handle;
+
+    handle.updateRunStatus({ kind: "success", from: 0, startedAt: 0 });
+
+    expect(patches).toHaveLength(0);
   });
 });

--- a/frontend/src/domains/editor/utils/ui/setup.ts
+++ b/frontend/src/domains/editor/utils/ui/setup.ts
@@ -60,11 +60,14 @@ interface MountOptions {
   host: HTMLElement;
   initialDoc: string;
   initialCursor?: number;
-  onChange?: (text: string) => void;
-  onCursorChange?: (cursor: number) => void;
-  /// Fired when the selection changes. `from`/`to` are equal for a collapsed
-  /// caret (no selection); a non-empty range means text is highlighted.
-  onSelectionChange?: (selection: { from: number; to: number }) => void;
+  /// Fired ONCE per editor update that changes the document and/or selection,
+  /// carrying every changed field together so the owner can commit a single
+  /// store write per keystroke (a keystroke changes doc AND selection; separate
+  /// callbacks meant separate writes and one subscriber re-render each).
+  /// `text` is present only when the document changed. `cursor`/`selection`
+  /// are present only when the selection changed; `selection.from`/`to` are
+  /// equal for a collapsed caret, a non-empty range means text is highlighted.
+  onEdit?: (patch: EditorEditPatch) => void;
   languageId: string;
   /// DatabaseKind of the tab's connection; picks the SQL dialect when `languageId === "sql"`.
   connectionKind?: DatabaseKind;
@@ -113,6 +116,12 @@ interface MountOptions {
   dbtMacros?: DbtMacroEntry[];
   sqlmeshModels?: SqlMeshModelEntry[];
   onDbtRefClick?: (reference: DbtReference) => void | Promise<void>;
+}
+
+interface EditorEditPatch {
+  text?: string;
+  cursor?: number;
+  selection?: { from: number; to: number };
 }
 
 interface CursorCoords {
@@ -340,14 +349,15 @@ function mountEditor(opts: MountOptions): EditorHandle {
         EditorState.readOnly.of(readOnly && !opts.formattable),
         EditorView.editable.of(!readOnly),
         EditorView.updateListener.of((u) => {
-          if (u.docChanged && opts.onChange) opts.onChange(docString(u.state.doc));
+          if (!opts.onEdit || (!u.docChanged && !u.selectionSet)) return;
+          const patch: EditorEditPatch = {};
+          if (u.docChanged) patch.text = docString(u.state.doc);
           if (u.selectionSet) {
             const main = u.state.selection.main;
-            if (opts.onCursorChange) opts.onCursorChange(main.head);
-            if (opts.onSelectionChange) {
-              opts.onSelectionChange({ from: main.from, to: main.to });
-            }
+            patch.cursor = main.head;
+            patch.selection = { from: main.from, to: main.to };
           }
+          opts.onEdit(patch);
         }),
         EditorView.domEventHandlers({
           dragover: (event) => {
@@ -678,5 +688,6 @@ export {
 
 export type {
   CursorCoords,
+  EditorEditPatch,
   EditorHandle,
 };

--- a/frontend/src/domains/editor/utils/ui/setup.ts
+++ b/frontend/src/domains/editor/utils/ui/setup.ts
@@ -35,6 +35,7 @@ import type { SqlSchemaDict } from "../autocomplete/sqlSchema";
 import { gitGutterExtension, type GitHunkActions } from "./gitGutter";
 import { editorSearchExtension, openEditorSearch } from "./search";
 import { statementHighlight } from "../navigation/statementHighlight";
+import { docString } from "../docText";
 import { runStatusExtension, setRunStatus, type RunStatus } from "./runStatus";
 import type { DbtSourceEntry, DbtModelEntry, DbtMacroEntry } from "../autocomplete/providers/sql/dbtRefs";
 import type { SqlMeshModelEntry } from "../autocomplete/providers/sql/sqlmeshRefs";
@@ -339,7 +340,7 @@ function mountEditor(opts: MountOptions): EditorHandle {
         EditorState.readOnly.of(readOnly && !opts.formattable),
         EditorView.editable.of(!readOnly),
         EditorView.updateListener.of((u) => {
-          if (u.docChanged && opts.onChange) opts.onChange(u.state.doc.toString());
+          if (u.docChanged && opts.onChange) opts.onChange(docString(u.state.doc));
           if (u.selectionSet) {
             const main = u.state.selection.main;
             if (opts.onCursorChange) opts.onCursorChange(main.head);

--- a/frontend/src/domains/editor/utils/ui/sqlSemanticHighlight.test.ts
+++ b/frontend/src/domains/editor/utils/ui/sqlSemanticHighlight.test.ts
@@ -8,7 +8,7 @@ import { editorLanguageExtensions } from "../dialects/registry";
 import {
   classifyLeaves,
   collectLeaves,
-  sqlSemanticField,
+  sqlSemanticPlugin,
   sqlSemanticHighlight,
   type Role,
 } from "./sqlSemanticHighlight";
@@ -173,6 +173,25 @@ describe("sql semantic highlight", () => {
   it("still colours a table-valued function after FROM as a function", () => {
     expect(roleOf("SELECT * FROM generate_series(1, 10)", "generate_series")).toBe("function");
   });
+
+  // Perf contract: leaf collection is windowed so a rebuild costs O(viewport),
+  // not O(document). Out-of-window statements must contribute no leaves.
+  it("collectLeaves respects the [from, to] window", () => {
+    const head = "SELECT aaa FROM t1;\n";
+    const tail = "SELECT zzz FROM t2;";
+    const doc = head + tail;
+    const state = EditorState.create({ doc, extensions: [sql({ dialect: StandardSQL })] });
+    const windowed = collectLeaves(state, head.length, doc.length);
+    const texts = windowed.map((l) => l.text);
+    expect(texts).toContain("zzz");
+    expect(texts).toContain("t2");
+    expect(texts).not.toContain("aaa");
+    expect(texts).not.toContain("t1");
+    // Default window still covers the whole document.
+    const all = collectLeaves(state).map((l) => l.text);
+    expect(all).toContain("aaa");
+    expect(all).toContain("zzz");
+  });
 });
 
 // End-to-end through a real EditorView with the same stack the editor mounts:
@@ -197,7 +216,7 @@ describe("sql semantic highlight (mounted view)", () => {
 
   it("produces role decorations in a configured view", () => {
     const view = mount("SELECT c.email FROM customers c");
-    const decos = view.state.field(sqlSemanticField);
+    const decos = view.plugin(sqlSemanticPlugin)!.decorations;
     const ranges: string[] = [];
     const iter = decos.iter();
     while (iter.value) {
@@ -207,6 +226,23 @@ describe("sql semantic highlight (mounted view)", () => {
     expect(ranges).toContain("customers"); // table
     expect(ranges).toContain("email"); // column
     expect(ranges).toContain("c"); // alias
+    view.destroy();
+  });
+
+  it("rebuilds decorations after an edit (docChanged path)", () => {
+    const view = mount("SELECT x FROM customers");
+    view.dispatch({
+      changes: { from: view.state.doc.length, to: view.state.doc.length, insert: " JOIN orders o ON 1=1" },
+    });
+    const decos = view.plugin(sqlSemanticPlugin)!.decorations;
+    const ranges: string[] = [];
+    const iter = decos.iter();
+    while (iter.value) {
+      ranges.push(view.state.doc.sliceString(iter.from, iter.to));
+      iter.next();
+    }
+    expect(ranges).toContain("orders"); // table added by the edit
+    expect(ranges).toContain("o"); // its alias
     view.destroy();
   });
 

--- a/frontend/src/domains/editor/utils/ui/sqlSemanticHighlight.ts
+++ b/frontend/src/domains/editor/utils/ui/sqlSemanticHighlight.ts
@@ -16,9 +16,16 @@
 
 import { ensureSyntaxTree, syntaxTree } from "@codemirror/language";
 import type { EditorState, Extension } from "@codemirror/state";
-import { Prec, RangeSetBuilder, StateField } from "@codemirror/state";
-import { Decoration, type DecorationSet, EditorView } from "@codemirror/view";
+import { Prec, RangeSetBuilder } from "@codemirror/state";
+import {
+  Decoration,
+  type DecorationSet,
+  type EditorView,
+  ViewPlugin,
+  type ViewUpdate,
+} from "@codemirror/view";
 import { findClosestKeyword } from "../linting/sqlLinter";
+import { SEMANTIC_CONTEXT_CHARS, SEMANTIC_PARSE_BUDGET_MS } from "./constants";
 
 type Role = "function" | "table" | "alias" | "column";
 
@@ -109,21 +116,22 @@ function prevNonSpaceChar(state: EditorState, pos: number): string {
   return m ? m[0] : "";
 }
 
-function collectLeaves(state: EditorState): Leaf[] {
-  const tree = ensureSyntaxTree(state, state.doc.length, 5000) ?? syntaxTree(state);
-  const cursor = tree.cursor();
+function collectLeaves(state: EditorState, from = 0, to = state.doc.length): Leaf[] {
+  const tree = ensureSyntaxTree(state, to, SEMANTIC_PARSE_BUDGET_MS) ?? syntaxTree(state);
   const leaves: Leaf[] = [];
-  // `cursor.next()` walks the whole tree in preorder (descending into children).
-  // Test for a leaf via `cursor.node.firstChild`, which does NOT move the cursor.
-  // (Using `cursor.firstChild()` as the test mutates position and silently skips
-  // the first child of every composite, e.g. the qualifier in `db.table`, leaving
-  // it uncoloured.)
-  do {
-    if (!cursor.node.firstChild) {
-      const text = state.doc.sliceString(cursor.from, cursor.to);
-      if (text.trim()) leaves.push({ name: cursor.name, from: cursor.from, to: cursor.to, text });
-    }
-  } while (cursor.next());
+  // `iterate` visits every node overlapping [from, to] in preorder. Test for a
+  // leaf via `n.node.firstChild` (does not move the iterator); descending into
+  // composites is what surfaces the qualifier segments of `db.table`.
+  tree.iterate({
+    from,
+    to,
+    enter: (n) => {
+      if (!n.node.firstChild) {
+        const text = state.doc.sliceString(n.from, n.to);
+        if (text.trim()) leaves.push({ name: n.name, from: n.from, to: n.to, text });
+      }
+    },
+  });
   return leaves;
 }
 
@@ -236,35 +244,60 @@ function classifyLeaves(state: EditorState, leaves: Leaf[]): RoleSpan[] {
   return spans;
 }
 
-function buildDecorations(state: EditorState): DecorationSet {
+// Decorate only what the user can see. Was previously a StateField that forced
+// a parse of the ENTIRE document (`ensureSyntaxTree(doc.length, 5000)`) and
+// walked the whole tree on every keystroke AND every caret move, synchronously
+// before paint, which made typing latency scale with document size. Now each
+// rebuild covers `view.visibleRanges` plus a fixed context window, so the cost
+// is O(viewport) regardless of how large the document grows.
+function buildDecorations(view: EditorView): DecorationSet {
+  const state = view.state;
   const caret = state.selection.main.head;
   const builder = new RangeSetBuilder<Decoration>();
-  for (const span of classifyLeaves(state, collectLeaves(state))) {
-    const typing =
-      isBeingTyped(caret, span.from, span.to) &&
-      isIncompleteKeyword(state.doc.sliceString(span.from, span.to));
-    builder.add(span.from, span.to, typing ? plainMark : roleMark(span.role));
+  // Ranges are processed in order; `emittedTo` guards against re-emitting a
+  // span when consecutive visible ranges share one context window.
+  let emittedTo = -1;
+  for (const range of view.visibleRanges) {
+    const winFrom = Math.max(0, range.from - SEMANTIC_CONTEXT_CHARS);
+    for (const span of classifyLeaves(state, collectLeaves(state, winFrom, range.to))) {
+      if (span.to <= range.from || span.from <= emittedTo) continue;
+      const typing =
+        isBeingTyped(caret, span.from, span.to) &&
+        isIncompleteKeyword(state.doc.sliceString(span.from, span.to));
+      builder.add(span.from, span.to, typing ? plainMark : roleMark(span.role));
+      emittedTo = span.to;
+    }
   }
   return builder.finish();
 }
 
-const sqlSemanticField = StateField.define<DecorationSet>({
-  create: (state) => buildDecorations(state),
-  update: (decorations, tr) => {
-    // Rebuild on edits, AND whenever the parse tree changes. lang-sql parses
-    // large docs incrementally in the background and dispatches non-doc-change
-    // transactions as the tree completes; without the tree-ref check those
-    // identifiers stay uncoloured until the next keystroke.
-    // `tr.selection` too: the token-under-caret stays plain, so the
-    // role colour must apply the moment the caret leaves it, even on a pure
-    // cursor move (arrow keys) with no doc edit.
-    if (tr.docChanged || tr.selection || syntaxTree(tr.state) !== syntaxTree(tr.startState)) {
-      return buildDecorations(tr.state);
+const sqlSemanticPlugin = ViewPlugin.fromClass(
+  class {
+    decorations: DecorationSet;
+
+    constructor(view: EditorView) {
+      this.decorations = buildDecorations(view);
     }
-    return decorations.map(tr.changes);
+
+    update(update: ViewUpdate) {
+      // Rebuild on edits, caret moves (the token-under-caret stays plain, so
+      // the role colour must apply the moment the caret leaves it), viewport
+      // scrolls, AND whenever the parse tree changes: lang-sql parses large
+      // docs incrementally in the background and flushes non-doc-change
+      // updates as the tree completes; without the tree-ref check those
+      // identifiers would stay uncoloured until the next keystroke.
+      if (
+        update.docChanged ||
+        update.selectionSet ||
+        update.viewportChanged ||
+        syntaxTree(update.state) !== syntaxTree(update.startState)
+      ) {
+        this.decorations = buildDecorations(update.view);
+      }
+    }
   },
-  provide: (f) => EditorView.decorations.from(f),
-});
+  { decorations: (v) => v.decorations },
+);
 
 function sqlSemanticHighlight(): Extension {
   // `Prec.highest` so the role decoration nests *inside* `syntaxHighlighting`'s
@@ -272,14 +305,14 @@ function sqlSemanticHighlight(): Extension {
   // token text. A child element's own `color` beats the inherited colour from a
   // parent span, so without this the flat `name` colour (on the inner highlight
   // span) wins and every identifier renders the same hue.
-  return Prec.highest(sqlSemanticField);
+  return Prec.highest(sqlSemanticPlugin);
 }
 
 export {
   buildDecorations,
   classifyLeaves,
   collectLeaves,
-  sqlSemanticField,
+  sqlSemanticPlugin,
   sqlSemanticHighlight,
 };
 export type { Role, RoleSpan };

--- a/frontend/src/domains/results/components/ResultsTableView/components/ResultsFooterBar/index.tsx
+++ b/frontend/src/domains/results/components/ResultsTableView/components/ResultsFooterBar/index.tsx
@@ -13,10 +13,21 @@ function ResultsFooterBar({ global: isGlobal = false }: { global?: boolean } = {
   // pane mode, so Command Logs ⇄ Results stays consistent across every tab.
   const globalRunTabId = useRunHistoryStore((s) => (isGlobal ? selectGlobalRun(s)?.tabId ?? null : null));
   const resolvedTabId = isGlobal ? globalRunTabId : activeId;
-  const tab = useTabsStore((state) => state.tabs.find((item) => item.id === resolvedTabId));
+  // Primitive selectors only: the tab OBJECT's identity changes on every
+  // keystroke (updateTab rebuilds it), and this footer is always mounted, so
+  // subscribing to the object re-rendered it per key. Existence and `pane`
+  // are stable primitives across text edits.
+  const tabExists = useTabsStore((state) =>
+    resolvedTabId != null && state.tabs.some((item) => item.id === resolvedTabId),
+  );
+  const tabPane = useTabsStore((state) =>
+    resolvedTabId != null
+      ? state.tabs.find((item) => item.id === resolvedTabId)?.pane
+      : undefined,
+  );
   const bottomPaneVisible = useSettingsStore((state) => state.bottomPaneVisible);
   const toggleBottomPane = useSettingsStore((state) => state.toggleBottomPaneVisible);
-  const tabId = tab?.id ?? null;
+  const tabId = tabExists ? resolvedTabId : null;
   const paneMode = useResultsTableStore((state) =>
     isGlobal ? state.globalMode : tabId ? state.modeByTab[tabId] ?? "results" : "results",
   );
@@ -64,7 +75,7 @@ function ResultsFooterBar({ global: isGlobal = false }: { global?: boolean } = {
         data-testid="footer-results-tab"
       >
         <Icon name="table" size={11} />
-        {tab?.pane === "plan" ? "Plan" : "Results"}
+        {tabPane === "plan" ? "Plan" : "Results"}
       </button>
     </div>
   );

--- a/frontend/src/domains/results/components/ResultsTableView/components/ResultsToolbar/index.tsx
+++ b/frontend/src/domains/results/components/ResultsTableView/components/ResultsToolbar/index.tsx
@@ -43,7 +43,7 @@ function ResultsToolbar({
   showRowDetailPane,
   stagedCount,
   tabIsTable,
-  tabText,
+  tabHasText,
   toggleDag,
   toggleRowDetailPane,
   uploadBusy,
@@ -112,7 +112,7 @@ function ResultsToolbar({
             label="Pin query"
             variant="ghost"
             onClick={onClickPinQuery}
-            disabled={!hasResult || !tabText?.trim()}
+            disabled={!hasResult || !tabHasText}
             data-testid="results-pin-btn"
           />
         </Tooltip>

--- a/frontend/src/domains/results/components/ResultsTableView/index.css
+++ b/frontend/src/domains/results/components/ResultsTableView/index.css
@@ -561,6 +561,16 @@
   min-width: 0;
   overflow: auto;
   background: var(--m-bg-editor);
+  /* Layout isolation for the results grid. The table below uses auto layout
+     with width:max-content, so the browser re-measures every rendered cell
+     whenever any document reflow reaches it. CodeMirror forces a reflow per
+     keystroke, which made typing stutter whenever a wide result set was on
+     screen. Overflow already clips the scroller's content, so layout/paint/
+     style containment is safe and lets the engine skip the table when outside
+     layout changes cannot affect its box. Size containment is deliberately
+     omitted: the scroller's flex sizing may still derive from content. Do not
+     remove without re-profiling typing with a wide result set loaded. */
+  contain: layout style paint;
 }
 .mdbc-results-table-scroll:focus,
 .mdbc-results-table-scroll:focus-visible {

--- a/frontend/src/domains/results/components/ResultsTableView/index.test.tsx
+++ b/frontend/src/domains/results/components/ResultsTableView/index.test.tsx
@@ -2,6 +2,7 @@ import { useResultsTableStore, useRunHistoryStore } from "../../hooks";
 import { usePinnedQueriesStore } from "@domains/pinnedQueries";
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { Profiler } from "react";
 
 vi.mock("@domains/pinnedQueries/components/PinnedQueriesPane/ipc", () => ({
   loadPinnedQueriesIPC: vi.fn().mockResolvedValue([]),
@@ -128,6 +129,32 @@ describe("ResultsTableView", () => {
     expect(screen.getByText("name")).toBeTruthy();
     expect(screen.getByText("alice")).toBeTruthy();
     expect(screen.getByText("NULL")).toBeTruthy();
+  });
+
+  it("does not re-render on tab text churn (keystrokes), but stays reactive to other tab fields", () => {
+    let commits = 0;
+    render(
+      <Profiler id="results" onRender={() => { commits += 1; }}>
+        <ResultsTableView />
+      </Profiler>,
+    );
+    const afterMount = commits;
+
+    // Editor keystrokes write { text } to the tab store; the results pane must
+    // NOT re-render for them.
+    act(() => {
+      useTabsStore.getState().updateTab("t1", { text: "select * from users where 1" });
+    });
+    act(() => {
+      useTabsStore.getState().updateTab("t1", { text: "select * from users where 1=1" });
+    });
+    expect(commits).toBe(afterMount);
+
+    // Positive control: a non-text tab change still re-renders the pane.
+    act(() => {
+      useTabsStore.getState().updateTab("t1", { isRunning: true });
+    });
+    expect(commits).toBeGreaterThan(afterMount);
   });
 
   it("does not borrow another run's result for a selected run that has none", () => {

--- a/frontend/src/domains/results/components/ResultsTableView/index.test.tsx
+++ b/frontend/src/domains/results/components/ResultsTableView/index.test.tsx
@@ -3,6 +3,7 @@ import { usePinnedQueriesStore } from "@domains/pinnedQueries";
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { Profiler } from "react";
+import { readFileSync } from "node:fs";
 
 vi.mock("@domains/pinnedQueries/components/PinnedQueriesPane/ipc", () => ({
   loadPinnedQueriesIPC: vi.fn().mockResolvedValue([]),
@@ -129,6 +130,16 @@ describe("ResultsTableView", () => {
     expect(screen.getByText("name")).toBeTruthy();
     expect(screen.getByText("alice")).toBeTruthy();
     expect(screen.getByText("NULL")).toBeTruthy();
+  });
+
+  it("keeps layout containment on the results grid scroller", () => {
+    // Perf guard: without `contain` on the scroller, the auto-layout
+    // (width:max-content) results table is re-measured by every document
+    // reflow, and CodeMirror reflows per keystroke. Typing stuttered whenever
+    // a wide result set was on screen.
+    const css = readFileSync("src/domains/results/components/ResultsTableView/index.css", "utf8");
+    const scrollerRule = css.match(/\.mdbc-results-table-scroll\s*\{[^}]*\}/)?.[0] ?? "";
+    expect(scrollerRule).toContain("contain: layout style paint;");
   });
 
   it("does not re-render on tab text churn (keystrokes), but stays reactive to other tab fields", () => {

--- a/frontend/src/domains/results/components/ResultsTableView/index.tsx
+++ b/frontend/src/domains/results/components/ResultsTableView/index.tsx
@@ -23,8 +23,10 @@ import {
   findVisibleMatches,
   stagedKeysForTab,
   tabEditCount,
+  tabEqualIgnoringText,
   visibleRowsForResult,
 } from "./utils";
+import { useStoreWithEqualityFn } from "zustand/traditional";
 import { ResultsDataTable } from "./components/ResultsDataTable";
 import type { SelectedCell } from "./types";
 import { ResultsToolbar } from "./components/ResultsToolbar";
@@ -50,7 +52,18 @@ function ResultsTableView({ tabId: tabIdProp, global: isGlobal = false }: { tabI
   const activeId = useTabsStore((s) => s.activeId);
   const globalRunTabId = useRunHistoryStore((s) => (isGlobal ? selectGlobalRun(s)?.tabId ?? null : null));
   const resolvedTabId = isGlobal ? globalRunTabId : tabIdProp ?? activeId;
-  const tab = useTabsStore((s) => s.tabs.find((t) => t.id === resolvedTabId));
+  // Subscribe to the tab but ignore `text`-only churn: the editor writes
+  // `{ text }` per keystroke and re-rendering the whole results pane (grid,
+  // toolbar, detail pane) for it is what makes typing stutter. Live text is
+  // read via `tabHasText` / `tabTextLive` below where it actually matters.
+  const tab = useStoreWithEqualityFn(
+    useTabsStore,
+    (s) => s.tabs.find((t) => t.id === resolvedTabId),
+    tabEqualIgnoringText,
+  );
+  const tabHasText = useTabsStore(
+    (s) => !!s.tabs.find((t) => t.id === resolvedTabId)?.text.trim(),
+  );
   const showRowDetailPane = useSettingsStore((s) => s.showRowDetailPane);
   const toggleRowDetailPane = useSettingsStore(
     (s) => s.toggleRowDetailPane,
@@ -120,7 +133,12 @@ function ResultsTableView({ tabId: tabIdProp, global: isGlobal = false }: { tabI
     ? (_tabId, mode) => setGlobalMode(mode)
     : setModeByTab;
   const openChartEditor = useChartEditorStore((s) => s.open);
-  const queryTextSql = activeRun?.sqlSnapshot ?? tab?.text ?? "";
+  // Track live tab text only while the query-text popover is open; while it is
+  // closed the selector returns null so keystrokes don't invalidate it.
+  const tabTextLive = useTabsStore((s) =>
+    showQueryText ? s.tabs.find((t) => t.id === resolvedTabId)?.text ?? null : null,
+  );
+  const queryTextSql = activeRun?.sqlSnapshot ?? tabTextLive ?? "";
   const queryRunning = !!tab?.isRunning || activeRun?.status === "pending";
   const fedDag = useFederationProgressStore((s) => s.dag);
   const showDag = useFederationProgressStore((s) => s.showDag);
@@ -443,7 +461,7 @@ function ResultsTableView({ tabId: tabIdProp, global: isGlobal = false }: { tabI
       showRowDetailPane={showRowDetailPane}
       stagedCount={stagedCount}
       tabIsTable={isTableTab}
-      tabText={tab.text}
+      tabHasText={tabHasText}
       toggleDag={toggleDag}
       toggleRowDetailPane={toggleRowDetailPane}
       uploadBusy={uploadBusy}

--- a/frontend/src/domains/results/components/ResultsTableView/types.ts
+++ b/frontend/src/domains/results/components/ResultsTableView/types.ts
@@ -203,7 +203,7 @@ interface ResultsToolbarProps {
   showRowDetailPane: boolean;
   stagedCount: number;
   tabIsTable: boolean;
-  tabText: string | undefined;
+  tabHasText: boolean;
   toggleDag: () => void;
   toggleRowDetailPane: () => void;
   uploadBusy: boolean;

--- a/frontend/src/domains/results/components/ResultsTableView/utils.test.ts
+++ b/frontend/src/domains/results/components/ResultsTableView/utils.test.ts
@@ -5,8 +5,10 @@ import {
   findVisibleMatches,
   resultToCsv,
   resultToJson,
+  tabEqualIgnoringText,
   typeChipMeta,
 } from "./utils";
+import type { EditorTab } from "@shell/types";
 import type { ColumnSpec, QueryValue, VisibleResultRow } from "./types";
 
 const columns: ColumnSpec[] = [
@@ -287,5 +289,36 @@ describe("copyTextForSelectedCell", () => {
     expect(
       copyTextForSelectedCell(visibleRows, cols, { row: 0, col: 9 }, noEdits, noStaged, "t1"),
     ).toBeNull();
+  });
+});
+
+describe("tabEqualIgnoringText", () => {
+  const base = {
+    id: "t1",
+    title: "Q",
+    text: "select 1",
+    kind: "sql",
+    cursor: 0,
+  } as EditorTab;
+
+  it("treats text-only changes as equal (keystroke churn)", () => {
+    expect(tabEqualIgnoringText(base, { ...base, text: "select 2" })).toBe(true);
+    expect(tabEqualIgnoringText(base, { ...base })).toBe(true);
+    expect(tabEqualIgnoringText(base, base)).toBe(true);
+    expect(tabEqualIgnoringText(undefined, undefined)).toBe(true);
+  });
+
+  it("detects changes on any non-text field", () => {
+    expect(tabEqualIgnoringText(base, { ...base, isRunning: true } as EditorTab)).toBe(false);
+    expect(tabEqualIgnoringText(base, { ...base, error: "boom" } as EditorTab)).toBe(false);
+    expect(tabEqualIgnoringText(base, { ...base, cursor: 5 })).toBe(false);
+    expect(tabEqualIgnoringText(base, undefined)).toBe(false);
+    expect(tabEqualIgnoringText(undefined, base)).toBe(false);
+  });
+
+  it("detects fields present on only one side", () => {
+    const withChart = { ...base, chart: { kind: "bar" } } as unknown as EditorTab;
+    expect(tabEqualIgnoringText(base, withChart)).toBe(false);
+    expect(tabEqualIgnoringText(withChart, base)).toBe(false);
   });
 });

--- a/frontend/src/domains/results/components/ResultsTableView/utils.tsx
+++ b/frontend/src/domains/results/components/ResultsTableView/utils.tsx
@@ -1,4 +1,5 @@
 import { type CellEdit, type PendingInsert } from "../../types";
+import type { EditorTab } from "@shell/types";
 import { save } from "@tauri-apps/plugin-dialog";
 import { writeTextFile } from "@tauri-apps/plugin-fs";
 import type {
@@ -306,6 +307,26 @@ async function exportResults(
   await writeTextFile(filePath, content);
 }
 
+// Equality guard for the results pane's tab subscription. Editor keystrokes
+// patch `tab.text` on every input, and the results pane must not re-render for
+// them; every other field change (result, isRunning, chart, error, ...) still
+// invalidates. Live text is read through dedicated selectors/handlers instead.
+function tabEqualIgnoringText(
+  a: EditorTab | undefined,
+  b: EditorTab | undefined,
+): boolean {
+  if (a === b) return true;
+  if (!a || !b) return false;
+  const left = a as unknown as Record<string, unknown>;
+  const right = b as unknown as Record<string, unknown>;
+  const keys = new Set([...Object.keys(left), ...Object.keys(right)]);
+  keys.delete("text");
+  for (const key of keys) {
+    if (left[key] !== right[key]) return false;
+  }
+  return true;
+}
+
 export {
   buildBatchForTab,
   compareCell,
@@ -319,6 +340,7 @@ export {
   resultToJson,
   stagedKeysForTab,
   tabEditCount,
+  tabEqualIgnoringText,
   typeChipMeta,
   typeHintToKind,
   visibleRowsForResult,


### PR DESCRIPTION
## What does this PR do?

Typing in the query editor was sluggish on every keystroke, worse with a wide result set loaded. A single keystroke was doing work proportional to the whole document and the whole app. This branch cuts seven per-keystroke costs down to work proportional to what's visible and what actually changed. Pure perf, no behavior change.

Changes:

| # | Change | Effect |
|---|--------|--------|
| 1 | **Results grid: `contain: layout style paint`** on the scroll container | Browser no longer re-lays-out the whole `max-content` grid on each keystroke reflow. Fixes the "slow when results visible" case. |
| 2 | **Semantic highlighter -> viewport-scoped ViewPlugin** (was a whole-document parse + tree walk per key and per caret move) | Coloring cost is now constant, bounded by the viewport, not query length. |
| 3 | **Editor pane stops re-rendering per keystroke** (subscription ignores `text`/`cursor`/`selection`) | ~2000-line component + subtree no longer re-render per key; also stops the autocomplete config rebuild that fired every keystroke. |
| 4 | **Coalesce 3 editor callbacks into one `onEdit` patch** | One `updateTab` store write per keystroke instead of three notification waves. |
| 5 | **Statement-border highlight caches its range** | Caret moves inside the current statement skip the whole-document boundary rescan. |
| 6 | **Memoize `doc.toString()`** (`docText.ts`, WeakMap) | Up to 8 full-document string copies per keystroke -> 1, shared across highlighter + autocomplete + param hints. |
| 7 | **ResultsFooterBar reads primitives** instead of the tab object | Always-mounted footer no longer re-renders on the tab object's per-keystroke identity churn. |


## Checklist

- [ ] I opened an issue first for non-trivial changes, or this is a small fix.
- [x] Tests added/updated for my change.
- [x] **I license my contribution under the MIT License**, per [CONTRIBUTING.md](../CONTRIBUTING.md). I confirm this is my original work, or that I have the right to submit it.
