### PR TITLE
[Feature] Mixpanel driver enhancement

### DIFF
--- a/crates/arris-engines/src/drivers/mixpanel/api.rs
+++ b/crates/arris-engines/src/drivers/mixpanel/api.rs
@@ -19,11 +19,19 @@ pub(super) struct Inner {
 pub(super) async fn execute_export(
     inner: &Inner,
     parsed_query: &sql_parser::MixpanelQuery,
+    api_limit: Option<usize>,
 ) -> Result<Vec<BTreeMap<String, QueryValue>>> {
     let mut url = format!(
         "{EXPORT_BASE_URL}?project_id={}&from_date={}&to_date={}",
         inner.project_id, parsed_query.from_date, parsed_query.to_date,
     );
+
+    // The export endpoint caps returned events with `limit`, so push the query's
+    // LIMIT down to Mixpanel rather than downloading the full history and slicing
+    // in memory. Only safe when no ORDER BY / aggregation reorders the result.
+    if let Some(limit) = api_limit {
+        url.push_str(&format!("&limit={limit}"));
+    }
 
     if !parsed_query.event_filter.is_empty() {
         let json_array = serde_json::to_string(&parsed_query.event_filter)

--- a/crates/arris-engines/src/drivers/mixpanel/api.rs
+++ b/crates/arris-engines/src/drivers/mixpanel/api.rs
@@ -3,8 +3,8 @@ use std::collections::BTreeMap;
 use crate::{DriverError, QueryValue};
 use crate::drivers::errors::Result;
 
-use super::driver::{
-    EXPORT_BASE_URL, MAX_PROPERTY_FETCHES, QUERY_API_BASE, SCHEMAS_API_BASE,
+use super::constants::{
+    EXPORT_BASE_URL, MAX_PROPERTY_FETCHES, QUERY_API_BASE, SCHEMA_SAMPLE_LIMIT, SCHEMAS_API_BASE,
 };
 use super::query;
 use super::sql_parser;
@@ -195,6 +195,72 @@ async fn fetch_event_properties_top(
     obj.keys().map(|k| (k.clone(), String::new())).collect()
 }
 
+fn json_type_label(value: &serde_json::Value) -> &'static str {
+    match value {
+        serde_json::Value::String(_) => "string",
+        serde_json::Value::Number(_) => "number",
+        serde_json::Value::Bool(_) => "boolean",
+        serde_json::Value::Array(_) | serde_json::Value::Object(_) => "object",
+        serde_json::Value::Null => "",
+    }
+}
+
+// Read a bounded sample of recent raw events and collect each property key,
+// inferring its type from the first non-null value seen. This backfills columns
+// when the Query API metadata endpoints return nothing for the service account.
+async fn sample_event_properties(inner: &Inner) -> BTreeMap<String, BTreeMap<String, String>> {
+    let url = format!(
+        "{EXPORT_BASE_URL}?project_id={}&from_date={}&to_date={}&limit={}",
+        inner.project_id,
+        sql_parser::schema_sample_from_date(),
+        sql_parser::default_to_date(),
+        SCHEMA_SAMPLE_LIMIT,
+    );
+    let Ok(resp) = inner
+        .client
+        .get(&url)
+        .basic_auth(&inner.username, Some(&inner.password))
+        .header("Accept", "text/plain")
+        .timeout(std::time::Duration::from_secs(60))
+        .send()
+        .await
+    else {
+        return BTreeMap::new();
+    };
+    if resp.status().as_u16() != 200 {
+        return BTreeMap::new();
+    }
+    let Ok(text) = resp.text().await else {
+        return BTreeMap::new();
+    };
+
+    let mut result: BTreeMap<String, BTreeMap<String, String>> = BTreeMap::new();
+    for line in text.lines() {
+        if line.is_empty() {
+            continue;
+        }
+        let Ok(obj) = serde_json::from_str::<serde_json::Value>(line) else {
+            continue;
+        };
+        let event = obj
+            .get("event")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .to_owned();
+        let entry = result.entry(event).or_default();
+        if let Some(props) = obj.get("properties").and_then(|v| v.as_object()) {
+            for (key, value) in props {
+                let ty = json_type_label(value);
+                let slot = entry.entry(key.clone()).or_default();
+                if slot.is_empty() && !ty.is_empty() {
+                    *slot = ty.to_owned();
+                }
+            }
+        }
+    }
+    result
+}
+
 pub(super) async fn discover_events(inner: &Inner) -> BTreeMap<String, BTreeMap<String, String>> {
     let (event_names, lexicon) =
         tokio::join!(fetch_event_names(inner), fetch_lexicon_schemas(inner),);
@@ -222,6 +288,18 @@ pub(super) async fn discover_events(inner: &Inner) -> BTreeMap<String, BTreeMap<
 
     for name in &needs_properties[fetch_count..] {
         result.entry(name.clone()).or_default();
+    }
+
+    // Backfill columns from real event data for accounts whose metadata APIs are
+    // empty; keep existing typed entries, only fill gaps.
+    for (event, props) in sample_event_properties(inner).await {
+        let entry = result.entry(event).or_default();
+        for (key, ty) in props {
+            let slot = entry.entry(key).or_default();
+            if slot.is_empty() && !ty.is_empty() {
+                *slot = ty;
+            }
+        }
     }
 
     result

--- a/crates/arris-engines/src/drivers/mixpanel/constants.rs
+++ b/crates/arris-engines/src/drivers/mixpanel/constants.rs
@@ -1,0 +1,24 @@
+// Central constants for the Mixpanel driver module. Bounded to the module by the
+// private `mod constants;` declaration; referenced as `super::constants::*`.
+
+// Mixpanel HTTP API bases.
+pub const EXPORT_BASE_URL: &str = "https://data.mixpanel.com/api/2.0/export";
+pub const QUERY_API_BASE: &str = "https://mixpanel.com/api/query";
+pub const SCHEMAS_API_BASE: &str = "https://mixpanel.com/api/app/projects";
+
+// Schema-tree root.
+pub const MP_ROOT_NAME: &str = "Mixpanel";
+pub const MP_ROOT_PATH: &str = "mixpanel";
+
+// The single logical table every query targets (`FROM events`).
+pub const EVENTS_TABLE: &str = "events";
+
+// Discovery limits.
+pub const MAX_PROPERTY_FETCHES: usize = 50;
+pub const SCHEMA_SAMPLE_LIMIT: usize = 1000;
+pub const SCHEMA_SAMPLE_DAYS: i64 = 30;
+
+// The export endpoint requires an explicit from_date/to_date window and rejects
+// any from_date earlier than 2011-07-10 (HTTP 400). Anchoring to that floor
+// expresses "unlimited" unless a WHERE clause on `time` narrows the range.
+pub const EARLIEST_EXPORT_DATE: &str = "2011-07-10";

--- a/crates/arris-engines/src/drivers/mixpanel/driver.rs
+++ b/crates/arris-engines/src/drivers/mixpanel/driver.rs
@@ -114,17 +114,23 @@ impl DatabaseDriver for MixpanelDriver {
         let started = Instant::now();
         let parsed_query = sql_parser::parse(text)
             .map_err(|e| DriverError::QueryFailed(e.to_string()))?;
-        let mut all_rows = api::execute_export(inner, &parsed_query).await?;
-
-        if let Some(where_expr) = &parsed_query.where_expression {
-            all_rows.retain(|row| sql_parser::evaluate(where_expr, row));
-        }
-
         let has_agg = !parsed_query.group_by.is_empty()
             || parsed_query
                 .columns
                 .iter()
                 .any(|c| matches!(c, ColumnSelection::Aggregation(..)));
+
+        // Push LIMIT down to the export API when nothing downstream reorders or
+        // collapses the rows. ORDER BY and aggregation would make an API-side cut
+        // truncate the wrong events, so those buffer fully and get limited below.
+        let api_limit = parsed_query
+            .limit
+            .filter(|_| !has_agg && parsed_query.order_by.is_empty());
+        let mut all_rows = api::execute_export(inner, &parsed_query, api_limit).await?;
+
+        if let Some(where_expr) = &parsed_query.where_expression {
+            all_rows.retain(|row| sql_parser::evaluate(where_expr, row));
+        }
 
         if has_agg {
             all_rows = query::apply_aggregations(&all_rows, &parsed_query);
@@ -256,12 +262,11 @@ mod tests {
     use super::*;
 
     #[test]
-    fn build_schema_tree_produces_correct_tree() {
+    fn build_schema_tree_produces_single_events_table() {
         let mut events = BTreeMap::new();
 
         let mut signup_props = BTreeMap::new();
         signup_props.insert("$browser".to_owned(), "string".to_owned());
-        signup_props.insert("$city".to_owned(), "string".to_owned());
         signup_props.insert("plan".to_owned(), "string".to_owned());
         events.insert("Sign Up".to_owned(), signup_props);
 
@@ -277,58 +282,75 @@ mod tests {
         assert_eq!(root.kind, SchemaNodeKind::Database);
         assert_eq!(root.path, "mixpanel");
 
-        let event_nodes: Vec<&crate::SchemaNode> = root
+        // Exactly one table node, `events`.
+        assert_eq!(root.children.len(), 1);
+        let events_table = &root.children[0];
+        assert_eq!(events_table.name, "events");
+        assert_eq!(events_table.kind, SchemaNodeKind::Table);
+        assert_eq!(events_table.path, "mixpanel.events");
+
+        // Columns = base columns + the union of every event's properties.
+        assert!(events_table
             .children
             .iter()
-            .filter(|c| c.kind == SchemaNodeKind::MixpanelEvent)
-            .collect();
-        assert_eq!(event_nodes.len(), 2);
-
-        let signup = event_nodes.iter().find(|e| e.name == "Sign Up").unwrap();
-        assert_eq!(signup.children.len(), 3);
-        let browser_col = signup.children.iter().find(|c| c.name == "$browser").unwrap();
-        assert_eq!(browser_col.kind, SchemaNodeKind::Column);
-        assert_eq!(browser_col.detail.as_deref(), Some("string"));
-
-        let purchase = event_nodes.iter().find(|e| e.name == "Purchase").unwrap();
-        assert_eq!(purchase.children.len(), 2);
-        let amount_col = purchase.children.iter().find(|c| c.name == "amount").unwrap();
-        assert_eq!(amount_col.detail.as_deref(), Some("number"));
-
-        let global_props: Vec<&crate::SchemaNode> = root
+            .all(|c| c.kind == SchemaNodeKind::Column));
+        let col_names: Vec<&str> = events_table
             .children
             .iter()
-            .filter(|c| c.kind == SchemaNodeKind::MixpanelEventProperty)
+            .map(|c| c.name.as_str())
             .collect();
-        assert_eq!(global_props.len(), 4);
-        let browser_prop = global_props.iter().find(|p| p.name == "$browser").unwrap();
-        assert_eq!(browser_prop.path, "mixpanel.properties.$browser");
+        for expected in ["event", "time", "distinct_id", "$browser", "plan", "amount"] {
+            assert!(col_names.contains(&expected), "missing column {expected}");
+        }
+        // {$browser, plan, amount} ∪ {event, time, distinct_id} = 6 columns.
+        assert_eq!(events_table.children.len(), 6);
+
+        let browser = events_table
+            .children
+            .iter()
+            .find(|c| c.name == "$browser")
+            .unwrap();
+        assert_eq!(browser.detail.as_deref(), Some("string"));
+        assert_eq!(browser.path, "mixpanel.events.$browser");
+        let amount = events_table
+            .children
+            .iter()
+            .find(|c| c.name == "amount")
+            .unwrap();
+        assert_eq!(amount.detail.as_deref(), Some("number"));
     }
 
     #[test]
     fn build_schema_tree_handles_empty_input() {
         let tree = schema::build_schema_tree(&BTreeMap::new());
         assert_eq!(tree.len(), 1);
-        assert!(tree[0].children.is_empty());
+        let events_table = &tree[0].children[0];
+        assert_eq!(events_table.name, "events");
+        assert_eq!(events_table.kind, SchemaNodeKind::Table);
+        // Even with no discovered events, the base columns are present.
+        let col_names: Vec<&str> = events_table
+            .children
+            .iter()
+            .map(|c| c.name.as_str())
+            .collect();
+        assert_eq!(col_names, vec!["distinct_id", "event", "time"]);
     }
 
     #[test]
     fn build_schema_tree_omits_detail_for_empty_type() {
         let mut events = BTreeMap::new();
         let mut props = BTreeMap::new();
-        props.insert("$browser".to_owned(), String::new());
+        props.insert("custom_prop".to_owned(), String::new());
         events.insert("Click".to_owned(), props);
 
         let tree = schema::build_schema_tree(&events);
-        let root = &tree[0];
-        let click = root
+        let events_table = &tree[0].children[0];
+        let prop = events_table
             .children
             .iter()
-            .find(|c| c.kind == SchemaNodeKind::MixpanelEvent)
+            .find(|c| c.name == "custom_prop")
             .unwrap();
-        let browser = &click.children[0];
-        assert_eq!(browser.name, "$browser");
-        assert_eq!(browser.detail, None);
+        assert_eq!(prop.detail, None);
     }
 
     #[tokio::test]

--- a/crates/arris-engines/src/drivers/mixpanel/driver.rs
+++ b/crates/arris-engines/src/drivers/mixpanel/driver.rs
@@ -15,12 +15,7 @@ use super::schema;
 use super::sql_parser::{self, ColumnSelection};
 use crate::drivers::DatabaseDriver;
 
-pub(super) const EXPORT_BASE_URL: &str = "https://data.mixpanel.com/api/2.0/export";
-pub(super) const QUERY_API_BASE: &str = "https://mixpanel.com/api/query";
-pub(super) const SCHEMAS_API_BASE: &str = "https://mixpanel.com/api/app/projects";
-pub(super) const MP_ROOT_NAME: &str = "Mixpanel";
-pub(super) const MP_ROOT_PATH: &str = "mixpanel";
-pub(super) const MAX_PROPERTY_FETCHES: usize = 50;
+use super::constants::EXPORT_BASE_URL;
 
 pub struct MixpanelDriver {
     inner: Mutex<Option<api::Inner>>,

--- a/crates/arris-engines/src/drivers/mixpanel/mod.rs
+++ b/crates/arris-engines/src/drivers/mixpanel/mod.rs
@@ -1,4 +1,5 @@
 mod api;
+mod constants;
 mod driver;
 mod query;
 mod schema;

--- a/crates/arris-engines/src/drivers/mixpanel/schema.rs
+++ b/crates/arris-engines/src/drivers/mixpanel/schema.rs
@@ -4,52 +4,47 @@ use crate::{SchemaNode, SchemaNodeKind};
 
 use super::driver::{MP_ROOT_NAME, MP_ROOT_PATH};
 
-pub(super) fn build_schema_tree(discovered: &BTreeMap<String, BTreeMap<String, String>>) -> Vec<SchemaNode> {
-    let mut children: Vec<SchemaNode> = Vec::new();
-    let mut all_properties: BTreeMap<String, String> = BTreeMap::new();
+// Mixpanel exposes a single logical table, `events`, which every query targets
+// (`FROM events`). Each discovered event property becomes a column on it, and the
+// base columns event/time/distinct_id are always queryable.
+pub(super) const EVENTS_TABLE: &str = "events";
 
-    for (event_name, properties) in discovered {
-        let event_path = format!("{MP_ROOT_PATH}.events.{event_name}");
-        let mut prop_children: Vec<SchemaNode> = properties
-            .iter()
-            .map(|(prop_name, prop_type)| {
-                let mut node = SchemaNode::new(
-                    prop_name,
-                    SchemaNodeKind::Column,
-                    format!("{event_path}.{prop_name}"),
-                );
-                if !prop_type.is_empty() {
-                    node = node.with_detail(prop_type);
-                }
-                node
-            })
-            .collect();
-        prop_children.sort_by(|a, b| a.name.cmp(&b.name));
+pub(super) fn build_schema_tree(
+    discovered: &BTreeMap<String, BTreeMap<String, String>>,
+) -> Vec<SchemaNode> {
+    let table_path = format!("{MP_ROOT_PATH}.{EVENTS_TABLE}");
 
-        children.push(
-            SchemaNode::new(event_name, SchemaNodeKind::MixpanelEvent, event_path)
-                .with_children(prop_children),
-        );
-
-        for (k, v) in properties {
-            all_properties.entry(k.clone()).or_insert_with(|| v.clone());
+    // Union every event's properties into one column set. BTreeMap keeps the
+    // columns alphabetically ordered and de-duplicated across events.
+    let mut columns: BTreeMap<String, String> = BTreeMap::new();
+    for base in ["event", "time", "distinct_id"] {
+        columns.insert(base.to_owned(), String::new());
+    }
+    for properties in discovered.values() {
+        for (prop_name, prop_type) in properties {
+            columns
+                .entry(prop_name.clone())
+                .or_insert_with(|| prop_type.clone());
         }
     }
 
-    for (prop_name, prop_type) in &all_properties {
-        let mut node = SchemaNode::new(
-            prop_name,
-            SchemaNodeKind::MixpanelEventProperty,
-            format!("{MP_ROOT_PATH}.properties.{prop_name}"),
-        );
-        if !prop_type.is_empty() {
-            node = node.with_detail(prop_type);
-        }
-        children.push(node);
-    }
+    let column_nodes: Vec<SchemaNode> = columns
+        .iter()
+        .map(|(name, ty)| {
+            let mut node =
+                SchemaNode::new(name, SchemaNodeKind::Column, format!("{table_path}.{name}"));
+            if !ty.is_empty() {
+                node = node.with_detail(ty);
+            }
+            node
+        })
+        .collect();
 
-    children.sort_by(|a, b| a.name.cmp(&b.name));
+    let events_table = SchemaNode::new(EVENTS_TABLE, SchemaNodeKind::Table, table_path)
+        .with_children(column_nodes);
 
-    vec![SchemaNode::new(MP_ROOT_NAME, SchemaNodeKind::Database, MP_ROOT_PATH)
-        .with_children(children)]
+    vec![
+        SchemaNode::new(MP_ROOT_NAME, SchemaNodeKind::Database, MP_ROOT_PATH)
+            .with_children(vec![events_table]),
+    ]
 }

--- a/crates/arris-engines/src/drivers/mixpanel/schema.rs
+++ b/crates/arris-engines/src/drivers/mixpanel/schema.rs
@@ -2,13 +2,11 @@ use std::collections::BTreeMap;
 
 use crate::{SchemaNode, SchemaNodeKind};
 
-use super::driver::{MP_ROOT_NAME, MP_ROOT_PATH};
+use super::constants::{EVENTS_TABLE, MP_ROOT_NAME, MP_ROOT_PATH};
 
 // Mixpanel exposes a single logical table, `events`, which every query targets
 // (`FROM events`). Each discovered event property becomes a column on it, and the
 // base columns event/time/distinct_id are always queryable.
-pub(super) const EVENTS_TABLE: &str = "events";
-
 pub(super) fn build_schema_tree(
     discovered: &BTreeMap<String, BTreeMap<String, String>>,
 ) -> Vec<SchemaNode> {

--- a/crates/arris-engines/src/drivers/mixpanel/sql_parser.rs
+++ b/crates/arris-engines/src/drivers/mixpanel/sql_parser.rs
@@ -778,9 +778,14 @@ pub fn resolve_column_names(query: &MixpanelQuery) -> Vec<String> {
     }
 }
 
+// Mixpanel's raw-event export requires an explicit from_date/to_date window, so
+// "unlimited" is expressed as the earliest date any project could hold data. It
+// predates Mixpanel itself (founded 2009), so every event is captured unless the
+// query narrows the range with a WHERE clause on `time`.
+pub const EARLIEST_EXPORT_DATE: &str = "2008-01-01";
+
 pub fn default_from_date() -> String {
-    let d = Utc::now() - chrono::Duration::days(30);
-    d.format("%Y-%m-%d").to_string()
+    EARLIEST_EXPORT_DATE.to_string()
 }
 
 pub fn default_to_date() -> String {

--- a/crates/arris-engines/src/drivers/mixpanel/sql_parser.rs
+++ b/crates/arris-engines/src/drivers/mixpanel/sql_parser.rs
@@ -8,6 +8,7 @@ use sqlparser::ast::{
 };
 
 use crate::drivers::common::sql_parser::parse_sql_statement;
+use super::constants::{EARLIEST_EXPORT_DATE, SCHEMA_SAMPLE_DAYS};
 
 #[derive(Debug, Clone)]
 pub struct MixpanelQuery {
@@ -778,18 +779,20 @@ pub fn resolve_column_names(query: &MixpanelQuery) -> Vec<String> {
     }
 }
 
-// Mixpanel's raw-event export requires an explicit from_date/to_date window, so
-// "unlimited" is expressed as the earliest date any project could hold data. It
-// predates Mixpanel itself (founded 2009), so every event is captured unless the
-// query narrows the range with a WHERE clause on `time`.
-pub const EARLIEST_EXPORT_DATE: &str = "2008-01-01";
-
 pub fn default_from_date() -> String {
     EARLIEST_EXPORT_DATE.to_string()
 }
 
 pub fn default_to_date() -> String {
     Utc::now().format("%Y-%m-%d").to_string()
+}
+
+// Recent window sampled to discover event properties (columns) when Mixpanel's
+// metadata APIs return nothing for the service account. SCHEMA_SAMPLE_DAYS bounds
+// it so schema loads stay fast; the export `limit` caps how many events are read.
+pub fn schema_sample_from_date() -> String {
+    let d = Utc::now() - chrono::Duration::days(SCHEMA_SAMPLE_DAYS);
+    d.format("%Y-%m-%d").to_string()
 }
 
 #[cfg(test)]

--- a/crates/arris-engines/src/drivers/mixpanel/sql_parser/tests.rs
+++ b/crates/arris-engines/src/drivers/mixpanel/sql_parser/tests.rs
@@ -527,6 +527,16 @@ fn default_dates_format() {
     assert!(to.contains('-'));
 }
 
+#[test]
+fn default_from_date_is_unlimited() {
+    // No WHERE time filter -> the range starts at the earliest export date, not a
+    // rolling 30-day window, so the whole project history is queryable.
+    assert_eq!(default_from_date(), EARLIEST_EXPORT_DATE);
+    let q = parse("SELECT * FROM events").unwrap();
+    assert_eq!(q.from_date, EARLIEST_EXPORT_DATE);
+    assert_eq!(q.to_date, default_to_date());
+}
+
 // --- Strip Quotes ---
 
 #[test]

--- a/crates/arris-engines/src/drivers/mixpanel/sql_parser/tests.rs
+++ b/crates/arris-engines/src/drivers/mixpanel/sql_parser/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use super::super::constants::EARLIEST_EXPORT_DATE;
 use std::collections::BTreeMap;
 
 // --- Basic Parsing ---
@@ -525,6 +526,15 @@ fn default_dates_format() {
     assert_eq!(to.len(), 10);
     assert!(from.contains('-'));
     assert!(to.contains('-'));
+}
+
+#[test]
+fn schema_sample_window_is_valid_and_within_floor() {
+    let from = schema_sample_from_date();
+    assert_eq!(from.len(), 10);
+    assert!(from.contains('-'));
+    // The sampling window is recent, so it must never precede the export floor.
+    assert!(from.as_str() > EARLIEST_EXPORT_DATE);
 }
 
 #[test]

--- a/crates/arris-engines/src/drivers/types.rs
+++ b/crates/arris-engines/src/drivers/types.rs
@@ -274,8 +274,6 @@ pub enum SchemaNodeKind {
     Topic,
     ConsumerGroup,
     Group,
-    MixpanelEvent,
-    MixpanelEventProperty,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -796,8 +794,6 @@ mod tests {
         assert_eq!(serde_json::to_string(&SchemaNodeKind::ElasticsearchAlias).unwrap(), "\"elasticsearchAlias\"");
         assert_eq!(serde_json::to_string(&SchemaNodeKind::ElasticsearchIndexTemplate).unwrap(), "\"elasticsearchIndexTemplate\"");
         assert_eq!(serde_json::to_string(&SchemaNodeKind::ElasticsearchDataStream).unwrap(), "\"elasticsearchDataStream\"");
-        assert_eq!(serde_json::to_string(&SchemaNodeKind::MixpanelEvent).unwrap(), "\"mixpanelEvent\"");
-        assert_eq!(serde_json::to_string(&SchemaNodeKind::MixpanelEventProperty).unwrap(), "\"mixpanelEventProperty\"");
     }
 
     #[test]

--- a/docs/src/pages/supported-data-sources/mixpanel.astro
+++ b/docs/src/pages/supported-data-sources/mixpanel.astro
@@ -66,19 +66,11 @@ import DocTable from "../../components/docs/DocTable/DocTable.astro";
   <h2 id="schema">Schema browser</h2>
 
   <p>
-    Once connected, Arris fetches the project metadata and organizes it into groups.
+    Once connected, Arris fetches the project metadata and presents it as a single
+    <code>events</code> table. Its columns are the union of every event's properties,
+    plus the base columns <code>event</code>, <code>time</code>, and <code>distinct_id</code>.
+    Double-click the table to browse recent events.
   </p>
-
-  <p>
-    The schema tree displays the following object types, grouped by category:
-  </p>
-
-  <ul>
-    <li><strong>Events</strong> &mdash; tracked event types</li>
-    <li><strong>Event Properties</strong> &mdash; properties attached to events</li>
-  </ul>
-
-
 
   <h2 id="features">Supported SQL commands</h2>
 
@@ -92,7 +84,12 @@ import DocTable from "../../components/docs/DocTable/DocTable.astro";
     <tbody>
       <tr>
         <td class="font-medium text-fg"><code>SELECT</code></td>
-        <td>Query event data through the REST API, with aggregations.</td>
+        <td>
+          Query event data through the REST API, with aggregations. The full project
+          history is queried by default; narrow it with a <code>WHERE</code> filter on
+          <code>time</code>. A <code>LIMIT</code> is pushed down to the export API so
+          only the requested number of events is fetched.
+        </td>
       </tr>
     </tbody>
   </DocTable>

--- a/frontend/src/domains/connection/components/CombinedConnectionsTree/types.ts
+++ b/frontend/src/domains/connection/components/CombinedConnectionsTree/types.ts
@@ -74,9 +74,7 @@ type SchemaNodeKind =
   | "elasticsearchDataStream"
   | "topic"
   | "consumerGroup"
-  | "group"
-  | "mixpanelEvent"
-  | "mixpanelEventProperty";
+  | "group";
 
 interface SchemaNode {
   name: string;

--- a/frontend/src/domains/connection/components/utils/drivers/defaults.grouping.test.ts
+++ b/frontend/src/domains/connection/components/utils/drivers/defaults.grouping.test.ts
@@ -189,18 +189,10 @@ describe("groupSchemaChildren", () => {
     ]);
   });
 
-  it("groups Mixpanel events and event properties", () => {
-    const nodes = [
-      node("Sign Up", "mixpanelEvent"),
-      node("Purchase", "mixpanelEvent"),
-      node("$browser", "mixpanelEventProperty"),
-      node("$city", "mixpanelEventProperty"),
-    ];
+  it("groups Mixpanel into a single events table", () => {
+    const nodes = [node("events", "table")];
     const grouped = groupSchemaChildren(nodes, driverForKind("mixpanel").schemaGrouping);
-    expect(grouped.map((g) => g.name)).toEqual([
-      "Events (2)",
-      "Event Properties (2)",
-    ]);
+    expect(grouped.map((g) => g.name)).toEqual(["Tables (1)"]);
   });
 
   it("groups Oracle metadata object types", () => {

--- a/frontend/src/domains/connection/components/utils/drivers/mixpanel.ts
+++ b/frontend/src/domains/connection/components/utils/drivers/mixpanel.ts
@@ -2,23 +2,21 @@ import type { SchemaGrouping } from "./types";
 import { defaultTableRefFromNode, makeExtractSchemaNames, makeGroupSchemaTree } from "./defaults";
 import type { ConnectionDriver } from "./types";
 
-const schemaGrouping: SchemaGrouping = [
-  { label: "Events", kinds: ["mixpanelEvent"] },
-  { label: "Event Properties", kinds: ["mixpanelEventProperty"] },
-];
+// Mixpanel exposes a single `events` table; its event properties are the columns.
+const schemaGrouping: SchemaGrouping = [{ label: "Tables", kinds: ["table"] }];
 
 export const mixpanelDriver: ConnectionDriver = {
   kind: "mixpanel",
   schemaGrouping,
   defaultSchemas: [],
-  databaseActsAsSchema: true,
-  schemaTermLabel: "Databases",
-  tableOpenableKinds: new Set([]),
+  databaseActsAsSchema: false,
+  schemaTermLabel: "Schemas",
+  tableOpenableKinds: new Set(["table"]),
   editableKinds: new Set([]),
   hideDetailKinds: new Set(["database", "schema", "group"]),
   defaultPort: undefined,
   uriScheme: "mixpanel",
   tableRefFromNode: defaultTableRefFromNode,
-  extractSchemaNames: makeExtractSchemaNames(true),
-  groupSchemaTree: makeGroupSchemaTree(true, schemaGrouping),
+  extractSchemaNames: makeExtractSchemaNames(false),
+  groupSchemaTree: makeGroupSchemaTree(false, schemaGrouping),
 };

--- a/frontend/src/domains/connection/components/utils/drivers/registry.test.ts
+++ b/frontend/src/domains/connection/components/utils/drivers/registry.test.ts
@@ -122,8 +122,10 @@ describe("driver registry", () => {
     expect(d.tableOpenableKinds.has("elasticsearchDataStream")).toBe(true);
   });
 
-  it("mixpanel has no openable kinds", () => {
-    expect(driverForKind("mixpanel").tableOpenableKinds.size).toBe(0);
+  it("mixpanel opens the single events table", () => {
+    const openable = driverForKind("mixpanel").tableOpenableKinds;
+    expect(openable.size).toBe(1);
+    expect(openable.has("table")).toBe(true);
   });
 
   it("redshift shares postgres defaults", () => {

--- a/frontend/src/domains/results/components/ResultsTableView/types.ts
+++ b/frontend/src/domains/results/components/ResultsTableView/types.ts
@@ -124,9 +124,7 @@ type SchemaNodeKind =
   | "elasticsearchDataStream"
   | "topic"
   | "consumerGroup"
-  | "group"
-  | "mixpanelEvent"
-  | "mixpanelEventProperty";
+  | "group";
 
 interface SchemaNode {
   name: string;

--- a/frontend/src/shared/backendTypes.ts
+++ b/frontend/src/shared/backendTypes.ts
@@ -242,9 +242,7 @@ type SchemaNodeKind =
   | "elasticsearchDataStream"
   | "topic"
   | "consumerGroup"
-  | "group"
-  | "mixpanelEvent"
-  | "mixpanelEventProperty";
+  | "group";
 
 interface SchemaNode {
   name: string;


### PR DESCRIPTION
## What does this PR do?

Enhancements to the Mixpanel driver, plus a schema-discovery fix so columns show up properly.

| Items | Before | After |
|------|--------|-------|
| **Date range** | Implicit rolling 30-day window | Full project history by default (anchored at the export API floor, `2011-07-10`); narrow with a `WHERE` filter on `time` |
| **LIMIT** | Whole history downloaded, then sliced in memory | `LIMIT` pushed to the export API `limit` param, so only the requested events are fetched (skipped when `ORDER BY`/aggregation reorders rows, which still buffer + limit in memory) |
| **Schema browser** | `Events (N)` + `Event Properties (N)` folders | A single `events` table whose columns are the union of every event's properties + base `event`/`time`/`distinct_id`; double-click to browse |
| **Column discovery** | Relied on Query API metadata (empty for some service accounts → only base columns showed) | Falls back to sampling recent raw events (bounded window + export `limit`) and unions their property keys with inferred types |


## Checklist

- [ ] I opened an issue first for non-trivial changes, or this is a small fix.
- [x] Tests added/updated for my change.
- [x] **I license my contribution under the MIT License**, per [CONTRIBUTING.md](../CONTRIBUTING.md). I confirm this is my original work, or that I have the right to submit it.
