### PR TITLE
[Fix] Resolve agent CLI path resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -244,6 +244,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
+ "which",
 ]
 
 [[package]]
@@ -8379,7 +8380,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
@@ -9355,6 +9356,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "which"
+version = "8.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48d7cd18d4acb58fb3cdfe9ea54e6cd96a4e7d4cc45c56338b236e82dad47248"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/crates/arris-engines/Cargo.toml
+++ b/crates/arris-engines/Cargo.toml
@@ -61,6 +61,9 @@ datafusion = "52.2"
 futures = "0.3"
 regex-lite = "0.1"
 dirs = "6"
+# resolve agent CLIs (`claude`, `codex`) to an absolute path over an augmented
+# search set, so a GUI-launched app with a minimal PATH still finds them.
+which = "8.0"
 nucleo = "0.5"
 notify = "8.2"
 notify-debouncer-full = "0.7"

--- a/crates/arris-engines/src/agent/constants.rs
+++ b/crates/arris-engines/src/agent/constants.rs
@@ -3,3 +3,25 @@
 /// Cap on the schema DDL inlined into the codex prompt, to keep large databases
 /// from blowing the model's context window. Excess is truncated with a marker.
 pub(super) const SCHEMA_PROMPT_MAX_BYTES: usize = 60_000;
+
+/// Command run in the user's login+interactive shell to capture their real
+/// environment when a GUI launch's process `PATH` is the minimal launchd set.
+/// Wrapped in [`SHELL_ENV_MARKER`] so noise printed by the user's rc files is
+/// discarded. `env` is used (not `echo $PATH`) because it prints `PATH`
+/// colon-separated regardless of the shell dialect: fish stores `$PATH` as a
+/// list, so echoing it would come back space-separated and unparseable.
+pub(super) const SHELL_PATH_PROBE: &str =
+    "printf '%s' '__ARRIS_ENV__'; env; printf '%s' '__ARRIS_ENV__'";
+
+/// Delimiter bracketing the `env` dump in [`SHELL_PATH_PROBE`] output.
+pub(super) const SHELL_ENV_MARKER: &str = "__ARRIS_ENV__";
+
+/// Line prefix of the `PATH` entry in the shell's `env` dump.
+pub(super) const PATH_ENV_PREFIX: &str = "PATH=";
+
+/// Shell used to run [`SHELL_PATH_PROBE`] when `$SHELL` is unset.
+pub(super) const FALLBACK_LOGIN_SHELL: &str = "/bin/sh";
+
+/// Flags making the shell source the user's login and interactive profiles
+/// (where `PATH` is exported) before running the probe command.
+pub(super) const LOGIN_SHELL_FLAGS: &str = "-ilc";

--- a/crates/arris-engines/src/agent/impl_agent_engine.rs
+++ b/crates/arris-engines/src/agent/impl_agent_engine.rs
@@ -18,6 +18,7 @@ use tokio::sync::{mpsc, oneshot};
 
 use super::constants::SCHEMA_PROMPT_MAX_BYTES;
 use super::errors::AgentError;
+use super::impl_cli_resolver::CliResolver;
 use super::types::{AgentEvent, AgentProfile, AgentProvider};
 use crate::{DatabaseKind, Engine, SchemaNode, SchemaNodeKind};
 
@@ -63,8 +64,11 @@ impl AgentEngine {
         let cwd = Self::working_dir()?;
         let cli = provider.cli();
         let binary = cli.binary();
+        // Resolve to an absolute path over the user's real PATH: a GUI launch
+        // inherits a minimal PATH that omits where the CLI is installed.
+        let program = CliResolver::resolve(binary).ok_or(AgentError::CliNotFound(provider))?;
 
-        let mut cmd = Command::new(binary);
+        let mut cmd = Command::new(&program);
         cmd.current_dir(&cwd);
         cli.configure(&mut cmd, &prompt, resume_session.as_deref());
         // The CLI may drain stdin for extra input; an inherited GUI stdin never

--- a/crates/arris-engines/src/agent/impl_cli_resolver.rs
+++ b/crates/arris-engines/src/agent/impl_cli_resolver.rs
@@ -1,0 +1,102 @@
+//! Resolve an agent CLI (`claude`, `codex`) to an absolute path. A GUI-launched
+//! app inherits launchd's minimal `PATH`, so a bare-name spawn misses CLIs in
+//! Homebrew/npm/version-manager bins; fall back to the login shell's real `PATH`
+//! instead of hardcoding install dirs.
+
+use std::ffi::OsString;
+use std::path::PathBuf;
+use std::sync::OnceLock;
+
+use super::constants::{
+    FALLBACK_LOGIN_SHELL, LOGIN_SHELL_FLAGS, PATH_ENV_PREFIX, SHELL_ENV_MARKER, SHELL_PATH_PROBE,
+};
+
+/// Login-shell `PATH`, probed once; `None` when unobtainable (no shell / non-unix).
+static LOGIN_SHELL_PATH: OnceLock<Option<OsString>> = OnceLock::new();
+
+pub(crate) struct CliResolver;
+
+impl CliResolver {
+    /// Resolve `binary` to an absolute path, or `None` if installed nowhere on
+    /// the process or login-shell `PATH`.
+    pub(crate) fn resolve(binary: &str) -> Option<PathBuf> {
+        // Process PATH: correct for a terminal launch and for Windows GUI apps.
+        if let Ok(path) = which::which(binary) {
+            return Some(path);
+        }
+        let search = Self::login_shell_path().clone()?;
+        // cwd only matters for a name with a path separator; CLIs are bare names.
+        let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("/"));
+        which::which_in(binary, Some(search), cwd).ok()
+    }
+
+    fn login_shell_path() -> &'static Option<OsString> {
+        LOGIN_SHELL_PATH.get_or_init(Self::probe_login_shell_path)
+    }
+
+    /// Read `PATH` from the login+interactive shell's `env` so user profiles are sourced.
+    #[cfg(unix)]
+    fn probe_login_shell_path() -> Option<OsString> {
+        use std::process::{Command, Stdio};
+
+        let shell = std::env::var("SHELL").unwrap_or_else(|_| FALLBACK_LOGIN_SHELL.to_string());
+        let output = Command::new(shell)
+            .arg(LOGIN_SHELL_FLAGS)
+            .arg(SHELL_PATH_PROBE)
+            .stdin(Stdio::null()) // don't block if an rc file reads stdin
+            .output()
+            .ok()?;
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        Self::parse_env_path(&stdout)
+    }
+
+    #[cfg(not(unix))]
+    fn probe_login_shell_path() -> Option<OsString> {
+        None
+    }
+
+    /// Pull the `PATH` line out of the marker-bracketed `env` dump, ignoring rc noise.
+    fn parse_env_path(stdout: &str) -> Option<OsString> {
+        let start = stdout.find(SHELL_ENV_MARKER)? + SHELL_ENV_MARKER.len();
+        let rest = &stdout[start..];
+        let end = rest.find(SHELL_ENV_MARKER).unwrap_or(rest.len());
+        rest[..end]
+            .lines()
+            .find_map(|line| line.strip_prefix(PATH_ENV_PREFIX))
+            .map(OsString::from)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_env_path_extracts_path_between_markers() {
+        // rc noise before the marker, then the `env` dump.
+        let stdout = "welcome to my shell\n\
+             __ARRIS_ENV__SHELL=/bin/zsh\n\
+             HOME=/Users/x\n\
+             PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin\n\
+             TERM=xterm__ARRIS_ENV__";
+        let path = CliResolver::parse_env_path(stdout).expect("PATH parsed");
+        assert_eq!(
+            path,
+            OsString::from("/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin")
+        );
+    }
+
+    #[test]
+    fn parse_env_path_is_none_without_markers_or_path() {
+        assert!(CliResolver::parse_env_path("no markers here PATH=/bin").is_none());
+        assert!(CliResolver::parse_env_path("__ARRIS_ENV__HOME=/x\n__ARRIS_ENV__").is_none());
+    }
+
+    #[test]
+    fn resolves_a_standard_unix_binary_to_an_absolute_path() {
+        // `sh` is on the process PATH, so the fast which() branch returns it.
+        let path = CliResolver::resolve("sh").expect("sh resolves");
+        assert!(path.is_absolute());
+        assert!(path.ends_with("sh"));
+    }
+}

--- a/crates/arris-engines/src/agent/mod.rs
+++ b/crates/arris-engines/src/agent/mod.rs
@@ -1,6 +1,7 @@
 mod constants;
 mod errors;
 mod impl_agent_engine;
+mod impl_cli_resolver;
 mod providers;
 mod types;
 

--- a/crates/arris-engines/src/agent/providers/mod.rs
+++ b/crates/arris-engines/src/agent/providers/mod.rs
@@ -9,6 +9,7 @@ mod codex;
 
 use tokio::process::Command;
 
+use super::impl_cli_resolver::CliResolver;
 use super::types::{AgentEvent, AgentProvider};
 use claude::ClaudeProvider;
 use codex::CodexProvider;
@@ -44,9 +45,14 @@ impl AgentProvider {
         }
     }
 
-    /// Whether this provider's CLI is available on PATH (`<binary> --version`).
+    /// Whether this provider's CLI is installed (`<binary> --version` exits 0),
+    /// resolved over the user's real PATH so a GUI launch's minimal PATH does not
+    /// report an installed CLI as missing.
     pub async fn check(self) -> bool {
-        Command::new(self.cli().binary())
+        let Some(program) = CliResolver::resolve(self.cli().binary()) else {
+            return false;
+        };
+        Command::new(program)
             .arg("--version")
             .output()
             .await

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -241,6 +241,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
+ "which",
 ]
 
 [[package]]
@@ -11854,6 +11855,15 @@ dependencies = [
  "thiserror 2.0.18",
  "windows 0.61.3",
  "windows-core 0.61.2",
+]
+
+[[package]]
+name = "which"
+version = "8.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48d7cd18d4acb58fb3cdfe9ea54e6cd96a4e7d4cc45c56338b236e82dad47248"
+dependencies = [
+ "libc",
 ]
 
 [[package]]


### PR DESCRIPTION
## What does this PR do?

Canvas agent panel errored "Claude CLI not found" though `claude` works in a terminal. The launched app inherits `launchd`'s minimal `PATH`, which omits Homebrew/npm/per-user bins.

Changes:
- New CliResolver resolves the CLI to an absolute path before spawning
- No hardcoded install dirs, so any package/version manager works. Wired into `AgentEngine::send` and `AgentProvider::check`.

## Checklist

- [ ] I opened an issue first for non-trivial changes, or this is a small fix.
- [ ] Tests added/updated for my change.
- [ ] **I license my contribution under the MIT License**, per [CONTRIBUTING.md](../CONTRIBUTING.md). I confirm this is my original work, or that I have the right to submit it.
