### PR TITLE
[Feature] Improve terminal rendering

### DIFF
--- a/frontend/src/domains/editor/components/EditorPane/index.tsx
+++ b/frontend/src/domains/editor/components/EditorPane/index.tsx
@@ -1950,7 +1950,7 @@ function PaneGroupView({ groupId }: { groupId: string }) {
       />
       {groupTabs.filter(t => t.tabType === "terminal").map(t => (
         <div key={t.id} className={`mdbc-tab-content${t.id === activeId ? "" : " hidden"}`}>
-          <TerminalView />
+          <TerminalView tabId={t.id} />
         </div>
       ))}
       <EditorTabRouter

--- a/frontend/src/domains/terminal/components/TerminalView/constants.ts
+++ b/frontend/src/domains/terminal/components/TerminalView/constants.ts
@@ -1,5 +1,8 @@
 const DEFAULT_COLS = 80;
 const DEFAULT_ROWS = 24;
+// The persistent per-tab element xterm is opened into; it travels between pane
+// hosts on split/move so the session is never re-created.
+const TERMINAL_CONTAINER_CLASS = "mdbc-terminal-session";
 // 1.0 keeps box-drawing glyphs touching between rows; >1 leaves vertical gaps.
 const DEFAULT_LINE_HEIGHT = 1.0;
 const DEFAULT_LETTER_SPACING = 0;
@@ -12,4 +15,5 @@ export {
   DEFAULT_LINE_HEIGHT,
   DEFAULT_LETTER_SPACING,
   DEFAULT_TERMINAL_FONT,
+  TERMINAL_CONTAINER_CLASS,
 };

--- a/frontend/src/domains/terminal/components/TerminalView/constants.ts
+++ b/frontend/src/domains/terminal/components/TerminalView/constants.ts
@@ -3,6 +3,9 @@ const DEFAULT_ROWS = 24;
 // The persistent per-tab element xterm is opened into; it travels between pane
 // hosts on split/move so the session is never re-created.
 const TERMINAL_CONTAINER_CLASS = "mdbc-terminal-session";
+// Wait for a separator drag to settle before reflowing the grid. Refitting on
+// every frame resizes (and so clears) the WebGL canvas, which reads as blinking.
+const RESIZE_DEBOUNCE_MS = 100;
 // 1.0 keeps box-drawing glyphs touching between rows; >1 leaves vertical gaps.
 const DEFAULT_LINE_HEIGHT = 1.0;
 const DEFAULT_LETTER_SPACING = 0;
@@ -15,5 +18,6 @@ export {
   DEFAULT_LINE_HEIGHT,
   DEFAULT_LETTER_SPACING,
   DEFAULT_TERMINAL_FONT,
+  RESIZE_DEBOUNCE_MS,
   TERMINAL_CONTAINER_CLASS,
 };

--- a/frontend/src/domains/terminal/components/TerminalView/hooks.ts
+++ b/frontend/src/domains/terminal/components/TerminalView/hooks.ts
@@ -43,8 +43,7 @@ function useTerminalView(tabId: string): TerminalViewModel {
     host.appendChild(session.container);
     session.terminal.focus();
 
-    // Reflow only once the drag settles: refitting mid-drag resizes (and clears)
-    // the WebGL canvas every frame, which the user sees as the terminal blinking.
+    // Debounced so the grid reflows only once the drag settles (see the constant).
     let debounceId = 0;
     const scheduleFit = () => {
       if (debounceId) clearTimeout(debounceId);

--- a/frontend/src/domains/terminal/components/TerminalView/hooks.ts
+++ b/frontend/src/domains/terminal/components/TerminalView/hooks.ts
@@ -3,6 +3,7 @@ import { useSettingsStore } from "@shared/settings";
 import { useProjectStore } from "@shell/hooks/projectStore";
 import { useTabsStore } from "@shell/hooks/tabsStore";
 import { zoomDirectionFromWheel, zoomTerminal } from "@shell/utils";
+import { RESIZE_DEBOUNCE_MS } from "./constants";
 import type { TerminalSession, TerminalViewModel } from "./types";
 import {
   acquireTerminalSession,
@@ -42,15 +43,15 @@ function useTerminalView(tabId: string): TerminalViewModel {
     host.appendChild(session.container);
     session.terminal.focus();
 
-    // Coalesce the burst of ResizeObserver callbacks a separator drag produces
-    // into one fit per frame so the grid tracks the drag without thrashing.
-    let rafId = 0;
+    // Reflow only once the drag settles: refitting mid-drag resizes (and clears)
+    // the WebGL canvas every frame, which the user sees as the terminal blinking.
+    let debounceId = 0;
     const scheduleFit = () => {
-      if (rafId) return;
-      rafId = requestAnimationFrame(() => {
-        rafId = 0;
+      if (debounceId) clearTimeout(debounceId);
+      debounceId = window.setTimeout(() => {
+        debounceId = 0;
         fitTerminalSession(session);
-      });
+      }, RESIZE_DEBOUNCE_MS);
     };
     const observer = new ResizeObserver(scheduleFit);
     observer.observe(host);
@@ -58,7 +59,7 @@ function useTerminalView(tabId: string): TerminalViewModel {
 
     return () => {
       observer.disconnect();
-      if (rafId) cancelAnimationFrame(rafId);
+      if (debounceId) clearTimeout(debounceId);
       session.container.parentNode?.removeChild(session.container);
       sessionRef.current = null;
       if (!isTerminalTabOpen(tabId)) destroyTerminalSession(tabId);

--- a/frontend/src/domains/terminal/components/TerminalView/hooks.ts
+++ b/frontend/src/domains/terminal/components/TerminalView/hooks.ts
@@ -1,34 +1,27 @@
 import { useEffect, useRef, useState } from "react";
-import { Terminal } from "@xterm/xterm";
-import { FitAddon } from "@xterm/addon-fit";
-import { spawn } from "tauri-pty/dist/index.es.js";
 import { useSettingsStore } from "@shared/settings";
 import { useProjectStore } from "@shell/hooks/projectStore";
+import { useTabsStore } from "@shell/hooks/tabsStore";
 import { zoomDirectionFromWheel, zoomTerminal } from "@shell/utils";
-import { terminalListShellsIPC } from "./ipc";
-import type {
-  TerminalRefs,
-  PtyData,
-  TerminalViewModel,
-} from "./types";
+import type { TerminalSession, TerminalViewModel } from "./types";
 import {
-  decodePtyData,
+  acquireTerminalSession,
+  destroyTerminalSession,
+  fitTerminalSession,
   loadTerminalFonts,
-  loadWebglRenderer,
-  ptySpawnOptions,
-  resizePty,
-  resolveTerminalShell,
-  terminalErrorMessage,
   terminalOptions,
 } from "./utils";
 
-function useTerminalView(): TerminalViewModel {
+// A pane split/move keeps the tab in the store and only re-parents its React
+// subtree; a real close removes it. So on unmount we keep the session unless the
+// tab is gone, which is what preserves the scrollback across split/move.
+function isTerminalTabOpen(tabId: string): boolean {
+  return useTabsStore.getState().tabs.some((tab) => tab.id === tabId);
+}
+
+function useTerminalView(tabId: string): TerminalViewModel {
   const hostRef = useRef<HTMLDivElement>(null);
-  const terminalRef = useRef<Terminal | null>(null);
-  const ptyRef = useRef<TerminalRefs["ptyRef"]["current"]>(null);
-  const disposablesRef = useRef<TerminalRefs["disposablesRef"]["current"]>([]);
-  const resizeObserverRef = useRef<ResizeObserver | null>(null);
-  const fitAddonRef = useRef<FitAddon | null>(null);
+  const sessionRef = useRef<TerminalSession | null>(null);
   const terminalShell = useSettingsStore((state) => state.terminalShell);
   const terminalFontSize = useSettingsStore((state) => state.terminalFontSize);
   const terminalFontFamily = useSettingsStore((state) => state.terminalFontFamily);
@@ -36,88 +29,58 @@ function useTerminalView(): TerminalViewModel {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    if (!hostRef.current) return undefined;
-    let disposed = false;
-    const decoder = new TextDecoder();
-    const options = terminalOptions(terminalFontSize, terminalFontFamily);
-    const terminal = new Terminal(options);
-    const fit = new FitAddon();
-    fitAddonRef.current = fit;
-    terminal.loadAddon(fit);
-    terminalRef.current = terminal;
-
-    const fitAndResize = () => {
-      try {
-        fit.fit();
-        resizePty(terminal, ptyRef.current);
-      } catch {
-        // Hidden panels can report zero dimensions during layout.
-      }
-    };
-
-    // Fonts load BEFORE open(): the cell grid is measured and the WebGL glyph
-    // atlas rasterized at open, and neither re-reads a font that loads later.
-    const opened = loadTerminalFonts(options.fontFamily, options.fontSize).then(() => {
-      if (disposed || !hostRef.current) return;
-      terminal.open(hostRef.current);
-      loadWebglRenderer(terminal);
-      terminal.focus();
-      resizeObserverRef.current = new ResizeObserver(fitAndResize);
-      resizeObserverRef.current.observe(hostRef.current);
-      fitAndResize();
+    const host = hostRef.current;
+    if (!host) return undefined;
+    const session = acquireTerminalSession(tabId, {
+      fontSize: terminalFontSize,
+      fontFamily: terminalFontFamily,
+      shell: terminalShell,
+      projectPath: activeProjectPath,
+      onError: setError,
     });
+    sessionRef.current = session;
+    host.appendChild(session.container);
+    session.terminal.focus();
 
-    Promise.all([opened, terminalListShellsIPC()])
-      .then(([, shells]) => {
-        if (disposed) return;
-        const shell = resolveTerminalShell(terminalShell, shells);
-        const pty = spawn(shell, [], ptySpawnOptions(terminal, activeProjectPath));
-        ptyRef.current = pty;
-        disposablesRef.current = [
-          pty.onData((data) => terminal.write(decodePtyData(data as PtyData, decoder))),
-          pty.onExit(({ exitCode }) => {
-            terminal.write(`\r\n[process exited ${exitCode}]\r\n`);
-          }),
-          terminal.onData((data) => pty.write(data)),
-        ];
-        fitAndResize();
-      })
-      .catch((loadError) => {
-        if (!disposed) setError(terminalErrorMessage(loadError));
+    // Coalesce the burst of ResizeObserver callbacks a separator drag produces
+    // into one fit per frame so the grid tracks the drag without thrashing.
+    let rafId = 0;
+    const scheduleFit = () => {
+      if (rafId) return;
+      rafId = requestAnimationFrame(() => {
+        rafId = 0;
+        fitTerminalSession(session);
       });
+    };
+    const observer = new ResizeObserver(scheduleFit);
+    observer.observe(host);
+    fitTerminalSession(session);
 
     return () => {
-      disposed = true;
-      cleanupTerminal({
-        terminalRef,
-        ptyRef,
-        disposablesRef,
-        resizeObserverRef,
-      });
+      observer.disconnect();
+      if (rafId) cancelAnimationFrame(rafId);
+      session.container.parentNode?.removeChild(session.container);
+      sessionRef.current = null;
+      if (!isTerminalTabOpen(tabId)) destroyTerminalSession(tabId);
     };
-    // Font size/family changes are applied live below; they must NOT recreate
-    // the terminal (which would respawn the pty and wipe the scrollback).
+    // The session captures shell/font/cwd at creation; only its tab identity
+    // decides which session this host attaches to.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [activeProjectPath, terminalShell]);
+  }, [tabId]);
 
-  // Apply font changes to the running terminal in place, then refit so the
-  // grid + pty match the new cell size. No teardown, no lost output.
+  // Apply font changes to the running terminal in place, then refit so the grid
+  // and pty match the new cell size. No teardown, no lost output.
   useEffect(() => {
-    const terminal = terminalRef.current;
-    if (!terminal) return;
+    const session = sessionRef.current;
+    if (!session) return;
     const { fontFamily, fontSize } = terminalOptions(terminalFontSize, terminalFontFamily);
     // Load the new font first so the re-measure and atlas rebuild triggered by
     // the option change see the real font.
     loadTerminalFonts(fontFamily, fontSize).then(() => {
-      if (terminalRef.current !== terminal) return;
-      terminal.options.fontFamily = fontFamily;
-      terminal.options.fontSize = fontSize;
-      try {
-        fitAddonRef.current?.fit();
-        resizePty(terminal, ptyRef.current);
-      } catch {
-        // Hidden panels can report zero dimensions during layout.
-      }
+      if (sessionRef.current !== session) return;
+      session.terminal.options.fontFamily = fontFamily;
+      session.terminal.options.fontSize = fontSize;
+      fitTerminalSession(session);
     });
   }, [terminalFontSize, terminalFontFamily]);
 
@@ -140,21 +103,6 @@ function useTerminalView(): TerminalViewModel {
     error,
     hostRef,
   };
-}
-
-function cleanupTerminal({
-  terminalRef,
-  ptyRef,
-  disposablesRef,
-  resizeObserverRef,
-}: TerminalRefs): void {
-  resizeObserverRef.current?.disconnect();
-  for (const disposable of disposablesRef.current) disposable.dispose();
-  disposablesRef.current = [];
-  ptyRef.current?.kill();
-  ptyRef.current = null;
-  terminalRef.current?.dispose();
-  terminalRef.current = null;
 }
 
 export {

--- a/frontend/src/domains/terminal/components/TerminalView/index.css
+++ b/frontend/src/domains/terminal/components/TerminalView/index.css
@@ -15,6 +15,11 @@
   height: 100%;
   min-height: 0;
 }
+/* The persistent per-tab element xterm is opened into. It sits between the host
+   and .xterm, so it must fill the host to keep the .xterm height:100% chain. */
+.mdbc-terminal-session {
+  height: 100%;
+}
 /* xterm paints the viewport's background black inline from its theme; the strip
    below the last full row would show through as a black bar. Force the editor
    background so leftover space blends with the terminal. */

--- a/frontend/src/domains/terminal/components/TerminalView/index.test.tsx
+++ b/frontend/src/domains/terminal/components/TerminalView/index.test.tsx
@@ -56,11 +56,13 @@ const mocks = vi.hoisted(() => {
   }
 
   class MockWebglAddon {
+    preserveDrawingBuffer: boolean;
     onContextLoss = vi.fn(() => ({ dispose: vi.fn() }));
     dispose = vi.fn();
 
-    constructor() {
+    constructor(preserveDrawingBuffer?: boolean) {
       if (state.webglThrows) throw new Error("webgl unavailable");
+      this.preserveDrawingBuffer = !!preserveDrawingBuffer;
       webglInstances.push(this);
     }
   }
@@ -162,6 +164,8 @@ describe("TerminalView", () => {
     expect(mocks.webglInstances).toHaveLength(1);
     expect(mocks.terminalInstances[0].loadAddon).toHaveBeenCalledWith(mocks.webglInstances[0]);
     expect(mocks.webglInstances[0].onContextLoss).toHaveBeenCalled();
+    // Preserve the drawing buffer so the canvas does not blank between composites.
+    expect(mocks.webglInstances[0].preserveDrawingBuffer).toBe(true);
   });
 
   it("falls back to the DOM renderer when WebGL is unavailable", async () => {

--- a/frontend/src/domains/terminal/components/TerminalView/index.test.tsx
+++ b/frontend/src/domains/terminal/components/TerminalView/index.test.tsx
@@ -296,9 +296,7 @@ describe("TerminalView", () => {
     vi.useFakeTimers();
     const before = mocks.pty.resize.mock.calls.length;
 
-    // A separator drag fires many observer ticks; refitting on each one resizes
-    // (and clears) the WebGL canvas every frame, which reads as blinking. They
-    // must collapse to a single fit once the drag settles.
+    // Many observer ticks during a drag must collapse to a single fit at the end.
     mocks.terminalInstances[0].cols = 90;
     triggerResize();
     triggerResize();

--- a/frontend/src/domains/terminal/components/TerminalView/index.test.tsx
+++ b/frontend/src/domains/terminal/components/TerminalView/index.test.tsx
@@ -3,14 +3,18 @@ import { act, render, waitFor } from "@testing-library/react";
 import { TerminalView } from "./index";
 import {
   decodePtyData,
+  resetTerminalSessions,
   resolveTerminalShell,
   terminalFontFamily,
   terminalOptions,
 } from "./utils";
 import { useSettingsStore } from "@shared/settings";
 import { useProjectStore } from "@shell/hooks/projectStore";
+import { useTabsStore } from "@shell/hooks/tabsStore";
 import { terminalListShellsIPC } from "./ipc";
 import { spawn } from "tauri-pty/dist/index.es.js";
+
+const TAB_ID = "t1";
 
 const mocks = vi.hoisted(() => {
   const terminalInstances: any[] = [];
@@ -72,13 +76,36 @@ vi.mock("./ipc", () => ({
   terminalListShellsIPC: vi.fn().mockResolvedValue(["/bin/zsh", "/bin/bash"]),
 }));
 
+// requestAnimationFrame is stubbed to queue callbacks so a test can prove that a
+// burst of ResizeObserver ticks coalesces into a single fit per flush.
+const rafCallbacks: FrameRequestCallback[] = [];
+const resizeObservers: { cb: ResizeObserverCallback; observe: any; disconnect: any }[] = [];
+
 class MockResizeObserver {
+  cb: ResizeObserverCallback;
   observe = vi.fn();
   disconnect = vi.fn();
+
+  constructor(cb: ResizeObserverCallback) {
+    this.cb = cb;
+    resizeObservers.push(this);
+  }
+}
+
+function triggerResize() {
+  resizeObservers.at(-1)?.cb([], {} as ResizeObserver);
+}
+
+function flushRaf() {
+  const queued = rafCallbacks.splice(0);
+  for (const cb of queued) cb(0);
 }
 
 describe("TerminalView", () => {
   beforeEach(() => {
+    resetTerminalSessions();
+    rafCallbacks.length = 0;
+    resizeObservers.length = 0;
     vi.clearAllMocks();
     mocks.terminalInstances.length = 0;
     mocks.webglInstances.length = 0;
@@ -86,9 +113,10 @@ describe("TerminalView", () => {
     mocks.state.webglThrows = false;
     vi.stubGlobal("ResizeObserver", MockResizeObserver);
     vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
-      cb(0);
-      return 1;
+      rafCallbacks.push(cb);
+      return rafCallbacks.length;
     });
+    vi.stubGlobal("cancelAnimationFrame", vi.fn());
     Object.defineProperty(document, "fonts", {
       configurable: true,
       value: {
@@ -100,6 +128,7 @@ describe("TerminalView", () => {
     });
     useSettingsStore.setState({ terminalShell: "" });
     useProjectStore.setState({ activeProjectPath: "/tmp/project", loading: false });
+    useTabsStore.setState({ tabs: [{ id: TAB_ID, tabType: "terminal" }] as never });
   });
 
   afterEach(() => {
@@ -129,7 +158,7 @@ describe("TerminalView", () => {
   });
 
   it("loads fonts before opening so the grid and atlas measure the real font", async () => {
-    render(<TerminalView />);
+    render(<TerminalView tabId={TAB_ID} />);
 
     await waitFor(() => expect(spawn).toHaveBeenCalled());
     expect(mocks.callOrder.indexOf("fonts")).toBeGreaterThanOrEqual(0);
@@ -137,7 +166,7 @@ describe("TerminalView", () => {
   });
 
   it("loads the WebGL renderer addon", async () => {
-    render(<TerminalView />);
+    render(<TerminalView tabId={TAB_ID} />);
 
     await waitFor(() => expect(spawn).toHaveBeenCalled());
     expect(mocks.webglInstances).toHaveLength(1);
@@ -148,7 +177,7 @@ describe("TerminalView", () => {
   it("falls back to the DOM renderer when WebGL is unavailable", async () => {
     mocks.state.webglThrows = true;
 
-    render(<TerminalView />);
+    render(<TerminalView tabId={TAB_ID} />);
 
     await waitFor(() => expect(spawn).toHaveBeenCalled());
     expect(mocks.webglInstances).toHaveLength(0);
@@ -158,7 +187,7 @@ describe("TerminalView", () => {
   it("loads the configured font up front so the grid measures the real font", async () => {
     useSettingsStore.setState({ terminalFontFamily: "JetBrains Mono", terminalFontSize: 13 });
 
-    render(<TerminalView />);
+    render(<TerminalView tabId={TAB_ID} />);
 
     await waitFor(() => expect(spawn).toHaveBeenCalled());
     await waitFor(() =>
@@ -174,7 +203,7 @@ describe("TerminalView", () => {
   it("does not use the editor font family preference", async () => {
     useSettingsStore.setState({ editorFontFamily: "Berkeley Mono", terminalFontFamily: null });
 
-    render(<TerminalView />);
+    render(<TerminalView tabId={TAB_ID} />);
 
     await waitFor(() => expect(spawn).toHaveBeenCalled());
     expect(mocks.terminalInstances[0].options.fontFamily).toBe(terminalFontFamily());
@@ -184,7 +213,7 @@ describe("TerminalView", () => {
   it("applies the terminal font size preference", async () => {
     useSettingsStore.setState({ terminalFontSize: 18 });
 
-    render(<TerminalView />);
+    render(<TerminalView tabId={TAB_ID} />);
 
     await waitFor(() => expect(spawn).toHaveBeenCalled());
     expect(mocks.terminalInstances[0].options.fontSize).toBe(18);
@@ -193,7 +222,7 @@ describe("TerminalView", () => {
   it("applies the terminal font family preference", async () => {
     useSettingsStore.setState({ terminalFontFamily: "Fira Code" });
 
-    render(<TerminalView />);
+    render(<TerminalView tabId={TAB_ID} />);
 
     await waitFor(() => expect(spawn).toHaveBeenCalled());
     expect(mocks.terminalInstances[0].options.fontFamily).toBe("Fira Code");
@@ -202,7 +231,7 @@ describe("TerminalView", () => {
   it("applies a font change to the existing terminal without respawning the pty", async () => {
     useSettingsStore.setState({ terminalFontSize: 13, terminalFontFamily: null });
 
-    render(<TerminalView />);
+    render(<TerminalView tabId={TAB_ID} />);
 
     await waitFor(() => expect(spawn).toHaveBeenCalled());
     expect(mocks.terminalInstances).toHaveLength(1);
@@ -223,8 +252,8 @@ describe("TerminalView", () => {
     expect(mocks.pty.kill).not.toHaveBeenCalled();
   });
 
-  it("spawns a pty in the active project and kills it on unmount", async () => {
-    const { unmount } = render(<TerminalView />);
+  it("spawns a pty in the active project", async () => {
+    render(<TerminalView tabId={TAB_ID} />);
 
     await waitFor(() => expect(spawn).toHaveBeenCalled());
     expect(terminalListShellsIPC).toHaveBeenCalled();
@@ -238,15 +267,71 @@ describe("TerminalView", () => {
     expect(mocks.terminalInstances[0].options.fontFamily).not.toContain("var(");
     expect(mocks.terminalInstances[0].options.letterSpacing).toBe(0);
     expect(mocks.terminalInstances[0].options.lineHeight).toBe(1.0);
+  });
+
+  it("keeps the pty alive and reuses the session across an unmount while the tab stays open", async () => {
+    // A pane split/move unmounts then remounts TerminalView; the tab stays in the
+    // store, so the session (pty + scrollback) must survive and be reattached.
+    const { unmount } = render(<TerminalView tabId={TAB_ID} />);
+    await waitFor(() => expect(spawn).toHaveBeenCalled());
+    const spawnCount = vi.mocked(spawn).mock.calls.length;
 
     unmount();
+    expect(mocks.pty.kill).not.toHaveBeenCalled();
+
+    render(<TerminalView tabId={TAB_ID} />);
+    // Reattached to the same session: no second Terminal, no second spawn.
+    expect(mocks.terminalInstances).toHaveLength(1);
+    expect(vi.mocked(spawn).mock.calls.length).toBe(spawnCount);
+  });
+
+  it("kills the pty when the terminal tab is closed", async () => {
+    const { unmount } = render(<TerminalView tabId={TAB_ID} />);
+    await waitFor(() => expect(spawn).toHaveBeenCalled());
+
+    // Closing the tab removes it from the store; the following unmount tears down.
+    act(() => useTabsStore.setState({ tabs: [] as never }));
+    unmount();
+
     expect(mocks.pty.kill).toHaveBeenCalled();
+  });
+
+  it("coalesces a burst of resize ticks into a single animation frame", async () => {
+    render(<TerminalView tabId={TAB_ID} />);
+    await waitFor(() => expect(spawn).toHaveBeenCalled());
+
+    // A separator drag fires many observer ticks per frame; they must schedule
+    // only one fit, otherwise the grid thrashes and flickers.
+    triggerResize();
+    triggerResize();
+    triggerResize();
+    expect(rafCallbacks).toHaveLength(1);
+  });
+
+  it("resizes the pty only when the cell grid actually changes", async () => {
+    render(<TerminalView tabId={TAB_ID} />);
+    await waitFor(() => expect(spawn).toHaveBeenCalled());
+    // The post-spawn sync sizes the pty once to the measured grid.
+    expect(mocks.pty.resize).toHaveBeenCalledTimes(1);
+    expect(mocks.pty.resize).toHaveBeenLastCalledWith(80, 24);
+
+    // A resize that does not cross a cell boundary sends no SIGWINCH.
+    triggerResize();
+    flushRaf();
+    expect(mocks.pty.resize).toHaveBeenCalledTimes(1);
+
+    // A real grid change forwards exactly one resize.
+    mocks.terminalInstances[0].cols = 100;
+    triggerResize();
+    flushRaf();
+    expect(mocks.pty.resize).toHaveBeenCalledTimes(2);
+    expect(mocks.pty.resize).toHaveBeenLastCalledWith(100, 24);
   });
 
   it("uses the persisted shell preference when present", async () => {
     useSettingsStore.setState({ terminalShell: "/usr/local/bin/fish" });
 
-    render(<TerminalView />);
+    render(<TerminalView tabId={TAB_ID} />);
 
     await waitFor(() => expect(spawn).toHaveBeenCalled());
     expect(spawn).toHaveBeenCalledWith(
@@ -257,7 +342,7 @@ describe("TerminalView", () => {
   });
 
   it("writes pty output when tauri returns number arrays", async () => {
-    render(<TerminalView />);
+    render(<TerminalView tabId={TAB_ID} />);
 
     await waitFor(() => expect(spawn).toHaveBeenCalled());
     mocks.pty.dataListener?.([36, 32]);
@@ -269,7 +354,7 @@ describe("TerminalView", () => {
     document.documentElement.style.setProperty("--m-bg-editor", "#1c1b24");
     document.documentElement.style.setProperty("--m-fg", "#f5f5f7");
 
-    render(<TerminalView />);
+    render(<TerminalView tabId={TAB_ID} />);
 
     await waitFor(() => expect(spawn).toHaveBeenCalled());
     const theme = mocks.terminalInstances[0].options.theme;
@@ -285,7 +370,7 @@ describe("TerminalView", () => {
     document.documentElement.style.removeProperty("--m-bg-editor");
     document.documentElement.style.removeProperty("--m-fg");
 
-    render(<TerminalView />);
+    render(<TerminalView tabId={TAB_ID} />);
 
     await waitFor(() => expect(spawn).toHaveBeenCalled());
     const theme = mocks.terminalInstances[0].options.theme;

--- a/frontend/src/domains/terminal/components/TerminalView/index.test.tsx
+++ b/frontend/src/domains/terminal/components/TerminalView/index.test.tsx
@@ -12,6 +12,7 @@ import { useSettingsStore } from "@shared/settings";
 import { useProjectStore } from "@shell/hooks/projectStore";
 import { useTabsStore } from "@shell/hooks/tabsStore";
 import { terminalListShellsIPC } from "./ipc";
+import { RESIZE_DEBOUNCE_MS } from "./constants";
 import { spawn } from "tauri-pty/dist/index.es.js";
 
 const TAB_ID = "t1";
@@ -76,9 +77,8 @@ vi.mock("./ipc", () => ({
   terminalListShellsIPC: vi.fn().mockResolvedValue(["/bin/zsh", "/bin/bash"]),
 }));
 
-// requestAnimationFrame is stubbed to queue callbacks so a test can prove that a
-// burst of ResizeObserver ticks coalesces into a single fit per flush.
-const rafCallbacks: FrameRequestCallback[] = [];
+// Captured so a test can drive the resize path and prove the debounce coalesces
+// a burst of ticks into a single fit.
 const resizeObservers: { cb: ResizeObserverCallback; observe: any; disconnect: any }[] = [];
 
 class MockResizeObserver {
@@ -96,15 +96,9 @@ function triggerResize() {
   resizeObservers.at(-1)?.cb([], {} as ResizeObserver);
 }
 
-function flushRaf() {
-  const queued = rafCallbacks.splice(0);
-  for (const cb of queued) cb(0);
-}
-
 describe("TerminalView", () => {
   beforeEach(() => {
     resetTerminalSessions();
-    rafCallbacks.length = 0;
     resizeObservers.length = 0;
     vi.clearAllMocks();
     mocks.terminalInstances.length = 0;
@@ -112,11 +106,6 @@ describe("TerminalView", () => {
     mocks.callOrder.length = 0;
     mocks.state.webglThrows = false;
     vi.stubGlobal("ResizeObserver", MockResizeObserver);
-    vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
-      rafCallbacks.push(cb);
-      return rafCallbacks.length;
-    });
-    vi.stubGlobal("cancelAnimationFrame", vi.fn());
     Object.defineProperty(document, "fonts", {
       configurable: true,
       value: {
@@ -132,6 +121,7 @@ describe("TerminalView", () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.unstubAllGlobals();
   });
 
@@ -296,16 +286,24 @@ describe("TerminalView", () => {
     expect(mocks.pty.kill).toHaveBeenCalled();
   });
 
-  it("coalesces a burst of resize ticks into a single animation frame", async () => {
+  it("debounces a burst of resize ticks into a single fit after the drag settles", async () => {
     render(<TerminalView tabId={TAB_ID} />);
     await waitFor(() => expect(spawn).toHaveBeenCalled());
+    vi.useFakeTimers();
+    const before = mocks.pty.resize.mock.calls.length;
 
-    // A separator drag fires many observer ticks per frame; they must schedule
-    // only one fit, otherwise the grid thrashes and flickers.
+    // A separator drag fires many observer ticks; refitting on each one resizes
+    // (and clears) the WebGL canvas every frame, which reads as blinking. They
+    // must collapse to a single fit once the drag settles.
+    mocks.terminalInstances[0].cols = 90;
     triggerResize();
     triggerResize();
     triggerResize();
-    expect(rafCallbacks).toHaveLength(1);
+    expect(mocks.pty.resize).toHaveBeenCalledTimes(before);
+
+    vi.advanceTimersByTime(RESIZE_DEBOUNCE_MS);
+    expect(mocks.pty.resize).toHaveBeenCalledTimes(before + 1);
+    vi.useRealTimers();
   });
 
   it("resizes the pty only when the cell grid actually changes", async () => {
@@ -314,18 +312,20 @@ describe("TerminalView", () => {
     // The post-spawn sync sizes the pty once to the measured grid.
     expect(mocks.pty.resize).toHaveBeenCalledTimes(1);
     expect(mocks.pty.resize).toHaveBeenLastCalledWith(80, 24);
+    vi.useFakeTimers();
 
-    // A resize that does not cross a cell boundary sends no SIGWINCH.
+    // A settled resize that does not cross a cell boundary sends no SIGWINCH.
     triggerResize();
-    flushRaf();
+    vi.advanceTimersByTime(RESIZE_DEBOUNCE_MS);
     expect(mocks.pty.resize).toHaveBeenCalledTimes(1);
 
     // A real grid change forwards exactly one resize.
     mocks.terminalInstances[0].cols = 100;
     triggerResize();
-    flushRaf();
+    vi.advanceTimersByTime(RESIZE_DEBOUNCE_MS);
     expect(mocks.pty.resize).toHaveBeenCalledTimes(2);
     expect(mocks.pty.resize).toHaveBeenLastCalledWith(100, 24);
+    vi.useRealTimers();
   });
 
   it("uses the persisted shell preference when present", async () => {

--- a/frontend/src/domains/terminal/components/TerminalView/index.tsx
+++ b/frontend/src/domains/terminal/components/TerminalView/index.tsx
@@ -1,10 +1,11 @@
 import type { RefObject } from "react";
 import "@xterm/xterm/css/xterm.css";
 import { useTerminalView } from "./hooks";
+import type { TerminalViewProps } from "./types";
 import "./index.css";
 
-function TerminalView() {
-  const { error, hostRef } = useTerminalView();
+function TerminalView({ tabId }: TerminalViewProps) {
+  const { error, hostRef } = useTerminalView(tabId);
 
   return (
     <div className="mdbc-terminal" data-testid="terminal-view">

--- a/frontend/src/domains/terminal/components/TerminalView/types.ts
+++ b/frontend/src/domains/terminal/components/TerminalView/types.ts
@@ -1,23 +1,47 @@
-import type { MutableRefObject, RefObject } from "react";
+import type { RefObject } from "react";
 import type { Terminal } from "@xterm/xterm";
+import type { FitAddon } from "@xterm/addon-fit";
 import type { IPty, IDisposable } from "tauri-pty/dist/types/index";
 
 type PtyData = Uint8Array | number[];
+
+interface TerminalViewProps {
+  tabId: string;
+}
 
 interface TerminalViewModel {
   error: string | null;
   hostRef: RefObject<HTMLDivElement | null>;
 }
 
-interface TerminalRefs {
-  terminalRef: MutableRefObject<Terminal | null>;
-  ptyRef: MutableRefObject<IPty | null>;
-  disposablesRef: MutableRefObject<IDisposable[]>;
-  resizeObserverRef: MutableRefObject<ResizeObserver | null>;
+// Inputs captured once when a session is first created; a running shell keeps
+// the cwd/shell it spawned with, so later changes do not respawn it.
+interface TerminalSessionConfig {
+  fontSize: number;
+  fontFamily: string | null;
+  shell: string;
+  projectPath: string | null | undefined;
+  onError: (message: string) => void;
+}
+
+// A live terminal owned outside React so it survives the unmount/remount that a
+// pane split or move triggers. `container` is the persistent element xterm is
+// opened into and that moves between pane hosts.
+interface TerminalSession {
+  terminal: Terminal;
+  fit: FitAddon;
+  container: HTMLDivElement;
+  pty: IPty | null;
+  disposables: IDisposable[];
+  lastCols: number;
+  lastRows: number;
+  disposed: boolean;
 }
 
 export type {
   PtyData,
-  TerminalRefs,
+  TerminalSession,
+  TerminalSessionConfig,
   TerminalViewModel,
+  TerminalViewProps,
 };

--- a/frontend/src/domains/terminal/components/TerminalView/types.ts
+++ b/frontend/src/domains/terminal/components/TerminalView/types.ts
@@ -24,9 +24,8 @@ interface TerminalSessionConfig {
   onError: (message: string) => void;
 }
 
-// A live terminal owned outside React so it survives the unmount/remount that a
-// pane split or move triggers. `container` is the persistent element xterm is
-// opened into and that moves between pane hosts.
+// A live terminal owned outside React so it survives the unmount/remount a pane
+// split or move triggers. `container` is the element xterm is opened into.
 interface TerminalSession {
   terminal: Terminal;
   fit: FitAddon;

--- a/frontend/src/domains/terminal/components/TerminalView/utils.ts
+++ b/frontend/src/domains/terminal/components/TerminalView/utils.ts
@@ -1,14 +1,21 @@
-import type { Terminal } from "@xterm/xterm";
+import { Terminal } from "@xterm/xterm";
+import { FitAddon } from "@xterm/addon-fit";
 import { WebglAddon } from "@xterm/addon-webgl";
-import type { IPty } from "tauri-pty/dist/types/index";
+import { spawn } from "tauri-pty/dist/index.es.js";
 import {
   DEFAULT_COLS,
   DEFAULT_ROWS,
   DEFAULT_LINE_HEIGHT,
   DEFAULT_LETTER_SPACING,
   DEFAULT_TERMINAL_FONT,
+  TERMINAL_CONTAINER_CLASS,
 } from "./constants";
-import type { PtyData } from "./types";
+import { terminalListShellsIPC } from "./ipc";
+import type {
+  PtyData,
+  TerminalSession,
+  TerminalSessionConfig,
+} from "./types";
 
 function normalizeShellPreference(shell: string): string {
   return shell.trim();
@@ -97,10 +104,6 @@ function ptySpawnOptions(
   };
 }
 
-function resizePty(terminal: Terminal, pty: IPty | null): void {
-  pty?.resize(terminal.cols || DEFAULT_COLS, terminal.rows || DEFAULT_ROWS);
-}
-
 function terminalErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
@@ -120,12 +123,119 @@ function loadTerminalFonts(fontFamily: string, fontSize: number): Promise<void> 
   ).then(() => undefined);
 }
 
+// Live terminals keyed by tab id, owned outside React so a pane split/move
+// (which unmounts and remounts TerminalView) never tears down the pty.
+const sessions = new Map<string, TerminalSession>();
+
+function createTerminalSession(
+  tabId: string,
+  config: TerminalSessionConfig,
+): TerminalSession {
+  const decoder = new TextDecoder();
+  const options = terminalOptions(config.fontSize, config.fontFamily);
+  const terminal = new Terminal(options);
+  const fit = new FitAddon();
+  terminal.loadAddon(fit);
+  const container = document.createElement("div");
+  container.className = TERMINAL_CONTAINER_CLASS;
+  const session: TerminalSession = {
+    terminal,
+    fit,
+    container,
+    pty: null,
+    disposables: [],
+    lastCols: 0,
+    lastRows: 0,
+    disposed: false,
+  };
+  sessions.set(tabId, session);
+
+  // Fonts load BEFORE open(): the cell grid is measured and the WebGL glyph
+  // atlas rasterized at open, and neither re-reads a font that loads later. The
+  // container is attached to a host by the caller before this microtask runs.
+  const opened = loadTerminalFonts(options.fontFamily, options.fontSize).then(() => {
+    if (session.disposed) return;
+    terminal.open(container);
+    loadWebglRenderer(terminal);
+  });
+
+  Promise.all([opened, terminalListShellsIPC()])
+    .then(([, shells]) => {
+      if (session.disposed) return;
+      const shell = resolveTerminalShell(config.shell, shells);
+      const pty = spawn(shell, [], ptySpawnOptions(terminal, config.projectPath));
+      session.pty = pty;
+      session.disposables = [
+        pty.onData((data) => terminal.write(decodePtyData(data as PtyData, decoder))),
+        pty.onExit(({ exitCode }) => {
+          terminal.write(`\r\n[process exited ${exitCode}]\r\n`);
+        }),
+        terminal.onData((data) => pty.write(data)),
+      ];
+      // Sync the pty to the grid measured during the async open, now that it exists.
+      fitTerminalSession(session);
+    })
+    .catch((loadError) => {
+      if (!session.disposed) config.onError(terminalErrorMessage(loadError));
+    });
+
+  return session;
+}
+
+function acquireTerminalSession(
+  tabId: string,
+  config: TerminalSessionConfig,
+): TerminalSession {
+  return sessions.get(tabId) ?? createTerminalSession(tabId, config);
+}
+
+// Refit the grid, then resize the pty ONLY when the cell count actually changed.
+// A separator drag fires many sub-cell resizes; sending SIGWINCH on each one
+// makes full-screen TUIs redraw every frame, which is the visible flicker.
+function fitTerminalSession(session: TerminalSession): void {
+  try {
+    session.fit.fit();
+    // Until the pty exists it is sized from the spawn options, so a pre-spawn
+    // fit must not claim the current dims as already-applied.
+    if (!session.pty) return;
+    const { cols, rows } = session.terminal;
+    if (cols === session.lastCols && rows === session.lastRows) return;
+    session.lastCols = cols;
+    session.lastRows = rows;
+    session.pty.resize(cols || DEFAULT_COLS, rows || DEFAULT_ROWS);
+  } catch {
+    // Hidden panels can report zero dimensions during layout.
+  }
+}
+
+function destroyTerminalSession(tabId: string): void {
+  const session = sessions.get(tabId);
+  if (!session) return;
+  session.disposed = true;
+  for (const disposable of session.disposables) disposable.dispose();
+  session.disposables = [];
+  session.pty?.kill();
+  session.pty = null;
+  session.terminal.dispose();
+  session.container.remove();
+  sessions.delete(tabId);
+}
+
+// Test-only: tear down every session so module-level state does not leak
+// between test cases.
+function resetTerminalSessions(): void {
+  for (const tabId of [...sessions.keys()]) destroyTerminalSession(tabId);
+}
+
 export {
+  acquireTerminalSession,
   decodePtyData,
+  destroyTerminalSession,
+  fitTerminalSession,
   loadTerminalFonts,
   loadWebglRenderer,
   ptySpawnOptions,
-  resizePty,
+  resetTerminalSessions,
   resolveTerminalShell,
   terminalErrorMessage,
   terminalFontFamily,

--- a/frontend/src/domains/terminal/components/TerminalView/utils.ts
+++ b/frontend/src/domains/terminal/components/TerminalView/utils.ts
@@ -153,9 +153,7 @@ function createTerminalSession(
   };
   sessions.set(tabId, session);
 
-  // Fonts load BEFORE open(): the cell grid is measured and the WebGL glyph
-  // atlas rasterized at open, and neither re-reads a font that loads later. The
-  // container is attached to a host by the caller before this microtask runs.
+  // The caller attaches the container to a host before this microtask runs.
   const opened = loadTerminalFonts(options.fontFamily, options.fontSize).then(() => {
     if (session.disposed) return;
     terminal.open(container);
@@ -175,7 +173,6 @@ function createTerminalSession(
         }),
         terminal.onData((data) => pty.write(data)),
       ];
-      // Sync the pty to the grid measured during the async open, now that it exists.
       fitTerminalSession(session);
     })
     .catch((loadError) => {
@@ -192,9 +189,8 @@ function acquireTerminalSession(
   return sessions.get(tabId) ?? createTerminalSession(tabId, config);
 }
 
-// Refit the grid, then resize the pty ONLY when the cell count actually changed.
-// A separator drag fires many sub-cell resizes; sending SIGWINCH on each one
-// makes full-screen TUIs redraw every frame, which is the visible flicker.
+// Refit the grid, then resize the pty ONLY when the cell count changed, so a
+// sub-cell drag does not spam SIGWINCH.
 function fitTerminalSession(session: TerminalSession): void {
   try {
     session.fit.fit();
@@ -224,10 +220,9 @@ function destroyTerminalSession(tabId: string): void {
   sessions.delete(tabId);
 }
 
-// Test-only: tear down every session so module-level state does not leak
-// between test cases.
+// Test-only: tear down every session so module state does not leak between tests.
 function resetTerminalSessions(): void {
-  for (const tabId of [...sessions.keys()]) destroyTerminalSession(tabId);
+  for (const tabId of sessions.keys()) destroyTerminalSession(tabId);
 }
 
 export {

--- a/frontend/src/domains/terminal/components/TerminalView/utils.ts
+++ b/frontend/src/domains/terminal/components/TerminalView/utils.ts
@@ -80,7 +80,10 @@ function terminalOptions(fontSize: number, fontFamily?: string | null) {
 // each glyph inside its exact cell, so the grid can never overflow.
 function loadWebglRenderer(terminal: Terminal): void {
   try {
-    const webgl = new WebglAddon();
+    // preserveDrawingBuffer keeps the last frame in the canvas between composites.
+    // Without it WebKit shows a cleared (blank) buffer while the pane relayouts
+    // during a separator drag, which reads as the terminal text blinking.
+    const webgl = new WebglAddon(true);
     webgl.onContextLoss(() => webgl.dispose());
     terminal.loadAddon(webgl);
   } catch {


### PR DESCRIPTION
## What does this PR do?

Improve terminal rendering: no reset on pane move, no flicker on resize

Changes:
- Persist terminals across pane moves.
- Debounce the refit. The grid reflows only once the drag settles (`RESIZE_DEBOUNCE_MS`), instead of every frame.
- Preserve the WebGL drawing buffer. `WebglAddon(preserveDrawingBuffer: true)` keeps the last frame in the canvas between composites, so WebKit no longer shows blank frames during the pane relayout.

## Checklist

- [ ] I opened an issue first for non-trivial changes, or this is a small fix.
- [x] Tests added/updated for my change.
- [x] **I license my contribution under the MIT License**, per [CONTRIBUTING.md](../CONTRIBUTING.md). I confirm this is my original work, or that I have the right to submit it.
