### PR TITLE
[Feature] Syntax highlighting + autocomplete for .gitignore and Makefile, an editor autosave-echo fix

### DIFF
--- a/frontend/src/domains/editor/components/EditorPane/index.tsx
+++ b/frontend/src/domains/editor/components/EditorPane/index.tsx
@@ -15,6 +15,7 @@ import {
 } from "@dnd-kit/core";
 import "./index.css";
 import { findLeaf, findLeafWithTab, planTabDrop } from "@shell/utils/paneTree";
+import { recordSelfWrite } from "@shell/utils/selfWrites";
 import { useEditorHandleStore } from "../../hooks/editorHandleStore";
 import { useTabsStore } from "@shell/hooks/tabsStore";
 import { useTransactionStore } from "../../hooks/transactionStore";
@@ -1149,7 +1150,10 @@ function PaneGroupView({ groupId }: { groupId: string }) {
       if (!next || !before || next.text === before.text) return;
       if (timer) clearTimeout(timer);
       timer = setTimeout(() => {
-        writeTextFileIPC(filePath, next.text)
+        // Mark the write so its watcher echo isn't mistaken for an external edit.
+        const content = next.text;
+        recordSelfWrite(filePath, content);
+        writeTextFileIPC(filePath, content)
           .then(async () => {
             await useGitStore.getState().refreshFileStatuses().catch(() => {});
             const repo = gitRepoPath ?? useFilesStore.getState().rootPath;

--- a/frontend/src/domains/editor/utils/autocomplete/providers/makefile.test.ts
+++ b/frontend/src/domains/editor/utils/autocomplete/providers/makefile.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import { EditorState } from "@codemirror/state";
+import { CompletionContext } from "@codemirror/autocomplete";
+
+import { MakefileCompletionProvider } from "./makefile";
+
+const source = new MakefileCompletionProvider().toSource();
+
+function makeCtx(doc: string, pos?: number, explicit = false): CompletionContext {
+  const state = EditorState.create({ doc });
+  return new CompletionContext(state, pos ?? doc.length, explicit);
+}
+
+function labels(doc: string, pos?: number, explicit = false): string[] {
+  const result = source(makeCtx(doc, pos, explicit));
+  return result ? result.options.map((o) => o.label) : [];
+}
+
+describe("MakefileCompletionProvider", () => {
+  it("suppresses the menu on a blank line unless explicitly triggered", () => {
+    expect(labels("")).toEqual([]);
+    expect(labels("", undefined, true)).toContain("ifeq");
+  });
+
+  it("offers directives and special targets while typing a line's first token", () => {
+    const got = labels("if");
+    expect(got).toContain("ifeq");
+    expect(got).toContain("ifdef");
+    expect(got).toContain(".PHONY");
+  });
+
+  it("anchors the directive completion at the token start", () => {
+    const result = source(makeCtx("ifn"));
+    expect(result?.from).toBe(0);
+  });
+
+  it("offers make functions inside $(", () => {
+    const got = labels("SRC := $(");
+    expect(got).toContain("wildcard");
+    expect(got).toContain("patsubst");
+    expect(got).toContain("foreach");
+  });
+
+  it("offers buffer-defined variables inside $(", () => {
+    const doc = "CC := gcc\nCFLAGS := -O2\nall:\n\t$(";
+    const got = labels(doc);
+    expect(got).toContain("CC");
+    expect(got).toContain("CFLAGS");
+  });
+
+  it("completes a partial function name after $(", () => {
+    const result = source(makeCtx("X := $(wild"));
+    expect(result?.options.map((o) => o.label)).toContain("wildcard");
+    // Anchors at the name start, right after `$(`.
+    expect(result?.from).toBe("X := $(".length);
+  });
+
+  it("does not offer directives in a recipe line", () => {
+    // Tab-indented recipe body: shell text, no directive menu.
+    expect(labels("all:\n\tif")).toEqual([]);
+  });
+
+  it("does not complete inside a prerequisite list", () => {
+    expect(labels("all: dep")).toEqual([]);
+  });
+});

--- a/frontend/src/domains/editor/utils/autocomplete/providers/makefile.ts
+++ b/frontend/src/domains/editor/utils/autocomplete/providers/makefile.ts
@@ -1,9 +1,6 @@
-// Autocomplete for GNU Makefiles (`makefile` language). Context-sensitive:
-//   - Inside `$(` / `${` : built-in make functions plus variables assigned
-//     anywhere in the buffer.
-//   - At the start of a non-recipe line: conditional/include directives and the
-//     built-in `.UPPER` special targets.
-// Everything else (prerequisite lists, recipe shell text) gets no completion.
+// Autocomplete for GNU Makefiles. Inside `$(`/`${`: make functions + buffer
+// variables. At a non-recipe line start: directives + `.UPPER` special targets.
+// Elsewhere (prerequisites, recipe shell text): nothing.
 
 import {
   type Completion,
@@ -19,7 +16,6 @@ import { CompletionProvider, type CompletionAnalysis } from "../core/provider";
 
 // Cursor sits right after `$(`/`${` with an optional partial function/var name.
 const VAR_OPEN_RE = /[$][({]([\w-]*)$/;
-// Leading whitespace of the current line.
 const LEADING_WS_RE = /^\s*/;
 // The line's first token is still being typed (directive / special target).
 const FIRST_TOKEN_RE = /^[-.\w]*$/;

--- a/frontend/src/domains/editor/utils/autocomplete/providers/makefile.ts
+++ b/frontend/src/domains/editor/utils/autocomplete/providers/makefile.ts
@@ -1,0 +1,95 @@
+// Autocomplete for GNU Makefiles (`makefile` language). Context-sensitive:
+//   - Inside `$(` / `${` : built-in make functions plus variables assigned
+//     anywhere in the buffer.
+//   - At the start of a non-recipe line: conditional/include directives and the
+//     built-in `.UPPER` special targets.
+// Everything else (prerequisite lists, recipe shell text) gets no completion.
+
+import {
+  type Completion,
+  type CompletionContext,
+} from "@codemirror/autocomplete";
+
+import {
+  MAKE_DIRECTIVES,
+  MAKE_FUNCTIONS,
+  MAKE_SPECIAL_TARGETS,
+} from "../../dialects/files/makefileLanguage";
+import { CompletionProvider, type CompletionAnalysis } from "../core/provider";
+
+// Cursor sits right after `$(`/`${` with an optional partial function/var name.
+const VAR_OPEN_RE = /[$][({]([\w-]*)$/;
+// Leading whitespace of the current line.
+const LEADING_WS_RE = /^\s*/;
+// The line's first token is still being typed (directive / special target).
+const FIRST_TOKEN_RE = /^[-.\w]*$/;
+// A variable definition: `NAME =` / `NAME :=` / `NAME += ...`.
+const ASSIGNMENT_RE = /^\s*([A-Za-z_]\w*)\s*(?:::=|:=|\+=|\?=|!=|=)/;
+
+type MakefileSituation =
+  | { kind: "function" }
+  | { kind: "directive" };
+
+function directiveOptions(): Completion[] {
+  return [
+    ...[...MAKE_DIRECTIVES].map((label): Completion => ({ label, type: "keyword", detail: "directive" })),
+    ...[...MAKE_SPECIAL_TARGETS].map((label): Completion => ({ label, type: "constant", detail: "special target" })),
+  ];
+}
+
+function functionOptions(): Completion[] {
+  return [...MAKE_FUNCTIONS].map((label): Completion => ({ label, type: "function", detail: "function" }));
+}
+
+// Variable names defined anywhere in the buffer, read live so freshly-typed
+// assignments are offered immediately.
+function variableOptions(cc: CompletionContext): Completion[] {
+  const names = new Set<string>();
+  for (let n = 1; n <= cc.state.doc.lines; n++) {
+    const match = ASSIGNMENT_RE.exec(cc.state.doc.line(n).text);
+    if (match) names.add(match[1]);
+  }
+  return [...names].sort().map((label): Completion => ({ label, type: "variable", detail: "variable" }));
+}
+
+class MakefileCompletionProvider extends CompletionProvider<MakefileSituation> {
+  protected analyze(cc: CompletionContext): CompletionAnalysis<MakefileSituation> | null {
+    const line = cc.state.doc.lineAt(cc.pos);
+    const before = cc.state.sliceDoc(line.from, cc.pos);
+
+    const varOpen = VAR_OPEN_RE.exec(before);
+    if (varOpen) {
+      const partial = varOpen[1];
+      return {
+        from: cc.pos - partial.length,
+        situation: { kind: "function" },
+        validFor: /^[\w-]*$/,
+      };
+    }
+
+    const lead = LEADING_WS_RE.exec(before)?.[0] ?? "";
+    const rest = before.slice(lead.length);
+    const isRecipe = before.startsWith("\t");
+    if (!isRecipe && FIRST_TOKEN_RE.test(rest)) {
+      // Don't pop the menu unasked on a blank line.
+      if (!rest && !cc.explicit) return null;
+      return {
+        from: cc.pos - rest.length,
+        situation: { kind: "directive" },
+        validFor: FIRST_TOKEN_RE,
+      };
+    }
+    return null;
+  }
+
+  protected suggest(situation: MakefileSituation, cc: CompletionContext): Completion[] {
+    if (situation.kind === "function") {
+      return [...functionOptions(), ...variableOptions(cc)];
+    }
+    return directiveOptions();
+  }
+}
+
+export {
+  MakefileCompletionProvider,
+};

--- a/frontend/src/domains/editor/utils/autocomplete/providers/makefile.ts
+++ b/frontend/src/domains/editor/utils/autocomplete/providers/makefile.ts
@@ -16,26 +16,23 @@ import { CompletionProvider, type CompletionAnalysis } from "../core/provider";
 
 // Cursor sits right after `$(`/`${` with an optional partial function/var name.
 const VAR_OPEN_RE = /[$][({]([\w-]*)$/;
-const LEADING_WS_RE = /^\s*/;
 // The line's first token is still being typed (directive / special target).
 const FIRST_TOKEN_RE = /^[-.\w]*$/;
 // A variable definition: `NAME =` / `NAME :=` / `NAME += ...`.
 const ASSIGNMENT_RE = /^\s*([A-Za-z_]\w*)\s*(?:::=|:=|\+=|\?=|!=|=)/;
+const NAME_PARTIAL_VALID = /^[\w-]*$/;
 
-type MakefileSituation =
-  | { kind: "function" }
-  | { kind: "directive" };
+type MakefileSituation = "function" | "directive";
 
-function directiveOptions(): Completion[] {
-  return [
-    ...[...MAKE_DIRECTIVES].map((label): Completion => ({ label, type: "keyword", detail: "directive" })),
-    ...[...MAKE_SPECIAL_TARGETS].map((label): Completion => ({ label, type: "constant", detail: "special target" })),
-  ];
-}
+const toCompletions = (labels: Iterable<string>, type: string, detail: string): Completion[] =>
+  [...labels].map((label) => ({ label, type, detail }));
 
-function functionOptions(): Completion[] {
-  return [...MAKE_FUNCTIONS].map((label): Completion => ({ label, type: "function", detail: "function" }));
-}
+// Static (independent of the cursor), so built once at module load.
+const DIRECTIVE_OPTIONS: Completion[] = [
+  ...toCompletions(MAKE_DIRECTIVES, "keyword", "directive"),
+  ...toCompletions(MAKE_SPECIAL_TARGETS, "constant", "special target"),
+];
+const FUNCTION_OPTIONS: Completion[] = toCompletions(MAKE_FUNCTIONS, "function", "function");
 
 // Variable names defined anywhere in the buffer, read live so freshly-typed
 // assignments are offered immediately.
@@ -45,7 +42,7 @@ function variableOptions(cc: CompletionContext): Completion[] {
     const match = ASSIGNMENT_RE.exec(cc.state.doc.line(n).text);
     if (match) names.add(match[1]);
   }
-  return [...names].sort().map((label): Completion => ({ label, type: "variable", detail: "variable" }));
+  return [...names].sort().map((label) => ({ label, type: "variable", detail: "variable" }));
 }
 
 class MakefileCompletionProvider extends CompletionProvider<MakefileSituation> {
@@ -56,33 +53,21 @@ class MakefileCompletionProvider extends CompletionProvider<MakefileSituation> {
     const varOpen = VAR_OPEN_RE.exec(before);
     if (varOpen) {
       const partial = varOpen[1];
-      return {
-        from: cc.pos - partial.length,
-        situation: { kind: "function" },
-        validFor: /^[\w-]*$/,
-      };
+      return { from: cc.pos - partial.length, situation: "function", validFor: NAME_PARTIAL_VALID };
     }
 
-    const lead = LEADING_WS_RE.exec(before)?.[0] ?? "";
-    const rest = before.slice(lead.length);
-    const isRecipe = before.startsWith("\t");
-    if (!isRecipe && FIRST_TOKEN_RE.test(rest)) {
-      // Don't pop the menu unasked on a blank line.
-      if (!rest && !cc.explicit) return null;
-      return {
-        from: cc.pos - rest.length,
-        situation: { kind: "directive" },
-        validFor: FIRST_TOKEN_RE,
-      };
+    const rest = before.replace(/^\s*/, "");
+    if (!before.startsWith("\t") && FIRST_TOKEN_RE.test(rest)) {
+      if (!rest && !cc.explicit) return null; // don't pop the menu unasked on a blank line
+      return { from: cc.pos - rest.length, situation: "directive", validFor: FIRST_TOKEN_RE };
     }
     return null;
   }
 
   protected suggest(situation: MakefileSituation, cc: CompletionContext): Completion[] {
-    if (situation.kind === "function") {
-      return [...functionOptions(), ...variableOptions(cc)];
-    }
-    return directiveOptions();
+    return situation === "function"
+      ? [...FUNCTION_OPTIONS, ...variableOptions(cc)]
+      : DIRECTIVE_OPTIONS;
   }
 }
 

--- a/frontend/src/domains/editor/utils/dialects/files/gitignore.ts
+++ b/frontend/src/domains/editor/utils/dialects/files/gitignore.ts
@@ -1,0 +1,19 @@
+import type { Extension } from "@codemirror/state";
+import { StreamLanguage } from "@codemirror/language";
+
+import { Dialect } from "../types";
+import { gitignore } from "./gitignoreLanguage";
+
+// `.gitignore`-style ignore files. Grammar only, no completion/linting.
+class GitignoreDialect extends Dialect {
+  readonly id = "gitignore";
+  protected override readonly languageIds = new Set(["gitignore"]);
+
+  language(): Extension[] {
+    return [StreamLanguage.define(gitignore)];
+  }
+}
+
+export {
+  GitignoreDialect,
+};

--- a/frontend/src/domains/editor/utils/dialects/files/gitignoreLanguage.test.ts
+++ b/frontend/src/domains/editor/utils/dialects/files/gitignoreLanguage.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import { StringStream } from "@codemirror/language";
+import { gitignore } from "./gitignoreLanguage";
+
+// Tokenize one line through the StreamParser, returning the non-whitespace tokens
+// with their highlight tag.
+function line(text: string): { text: string; tag: string | null }[] {
+  const state = gitignore.startState!(2);
+  const stream = new StringStream(text, 2, 2);
+  const out: { text: string; tag: string | null }[] = [];
+  while (!stream.eol()) {
+    const start = stream.pos;
+    const tag = gitignore.token!(stream, state);
+    if (stream.pos === start) stream.next();
+    const chunk = text.slice(start, stream.pos);
+    if (chunk.trim() !== "") out.push({ text: chunk, tag: tag ?? null });
+  }
+  return out;
+}
+
+describe("gitignore highlighter", () => {
+  it("treats a leading # as a comment", () => {
+    expect(line("# build artifacts")).toEqual([
+      { text: "# build artifacts", tag: "comment" },
+    ]);
+  });
+
+  it("highlights a leading ! negation, leaving the path plain", () => {
+    expect(line("!keep.log")).toEqual([
+      { text: "!", tag: "keyword" },
+      { text: "keep.log", tag: null },
+    ]);
+  });
+
+  it("highlights glob metacharacters", () => {
+    expect(line("*.tmp")).toEqual([
+      { text: "*", tag: "keyword" },
+      { text: ".tmp", tag: null },
+    ]);
+  });
+
+  it("highlights the recursive wildcard and character classes", () => {
+    expect(line("**/[Bb]uild")).toEqual([
+      { text: "**", tag: "keyword" },
+      { text: "/", tag: null },
+      { text: "[Bb]", tag: "keyword" },
+      { text: "uild", tag: null },
+    ]);
+  });
+
+  it("marks a trailing slash as a directory-only match", () => {
+    expect(line("build/")).toEqual([
+      { text: "build", tag: null },
+      { text: "/", tag: "operator" },
+    ]);
+  });
+
+  it("keeps an inner slash plain", () => {
+    expect(line("src/generated")).toEqual([
+      { text: "src", tag: null },
+      { text: "/", tag: null },
+      { text: "generated", tag: null },
+    ]);
+  });
+
+  it("does not treat a non-leading # as a comment", () => {
+    const tokens = line("file#1");
+    expect(tokens.every((t) => t.tag !== "comment")).toBe(true);
+  });
+});

--- a/frontend/src/domains/editor/utils/dialects/files/gitignoreLanguage.ts
+++ b/frontend/src/domains/editor/utils/dialects/files/gitignoreLanguage.ts
@@ -1,0 +1,46 @@
+// Syntax highlighting for `.gitignore`-style ignore files (also `.dockerignore`,
+// `.npmignore`, …). Line-oriented: a line whose first non-blank char is `#` is a
+// comment; a leading `!` negates the pattern; the rest is a glob where `*`, `**`,
+// `?`, and `[...]` classes are metacharacters and a trailing `/` marks a
+// directory-only match. Plain path text stays uncolored.
+
+import type { StreamParser } from "@codemirror/language";
+
+interface GitignoreState {
+  // Still at the first char of the line, where `#`/`!` have special meaning.
+  lineStart: boolean;
+}
+
+const gitignore: StreamParser<GitignoreState> = {
+  startState: () => ({ lineStart: true }),
+  token(stream, state) {
+    if (stream.sol()) state.lineStart = true;
+
+    if (state.lineStart && stream.peek() === "#") {
+      stream.skipToEnd();
+      return "comment";
+    }
+    if (state.lineStart && stream.peek() === "!") {
+      stream.next();
+      state.lineStart = false;
+      return "keyword"; // pattern negation
+    }
+    state.lineStart = false;
+
+    if (stream.match(/^\\./)) return null; // escaped metacharacter
+    if (stream.match(/^\*\*/)) return "keyword"; // recursive wildcard
+    if (stream.match(/^[*?]/)) return "keyword";
+    if (stream.match(/^\[[^\]]*\]/)) return "keyword"; // character class
+    if (stream.peek() === "/") {
+      stream.next();
+      return stream.eol() ? "operator" : null; // trailing slash = directory-only
+    }
+
+    if (!stream.match(/^[^*?[\\/#!]+/)) stream.next();
+    return null;
+  },
+};
+
+export {
+  gitignore,
+};

--- a/frontend/src/domains/editor/utils/dialects/files/gitignoreLanguage.ts
+++ b/frontend/src/domains/editor/utils/dialects/files/gitignoreLanguage.ts
@@ -1,8 +1,5 @@
 // Syntax highlighting for `.gitignore`-style ignore files (also `.dockerignore`,
-// `.npmignore`, …). Line-oriented: a line whose first non-blank char is `#` is a
-// comment; a leading `!` negates the pattern; the rest is a glob where `*`, `**`,
-// `?`, and `[...]` classes are metacharacters and a trailing `/` marks a
-// directory-only match. Plain path text stays uncolored.
+// `.npmignore`, ...): `#` comments, leading `!` negation, glob metacharacters.
 
 import type { StreamParser } from "@codemirror/language";
 

--- a/frontend/src/domains/editor/utils/dialects/files/makefile.ts
+++ b/frontend/src/domains/editor/utils/dialects/files/makefile.ts
@@ -1,16 +1,24 @@
 import type { Extension } from "@codemirror/state";
 import { StreamLanguage } from "@codemirror/language";
 
-import { Dialect } from "../types";
+import { MakefileCompletionProvider } from "../../autocomplete/providers/makefile";
+import { Dialect, type EditorDialectContext } from "../types";
 import { makefile } from "./makefileLanguage";
 
-// GNU Makefiles (`Makefile`, `*.mk`, …). Grammar only, no completion/linting.
+const DEFAULT_FONT_SIZE = 13;
+
+// GNU Makefiles (`Makefile`, `*.mk`, …). Grammar plus directive/function/variable
+// completion; not syntax-linted.
 class MakefileDialect extends Dialect {
   readonly id = "makefile";
   protected override readonly languageIds = new Set(["makefile"]);
 
   language(): Extension[] {
     return [StreamLanguage.define(makefile)];
+  }
+
+  override completion(context: EditorDialectContext): Extension[] {
+    return new MakefileCompletionProvider().extensions(context.fontSize ?? DEFAULT_FONT_SIZE);
   }
 }
 

--- a/frontend/src/domains/editor/utils/dialects/files/makefile.ts
+++ b/frontend/src/domains/editor/utils/dialects/files/makefile.ts
@@ -1,0 +1,19 @@
+import type { Extension } from "@codemirror/state";
+import { StreamLanguage } from "@codemirror/language";
+
+import { Dialect } from "../types";
+import { makefile } from "./makefileLanguage";
+
+// GNU Makefiles (`Makefile`, `*.mk`, …). Grammar only, no completion/linting.
+class MakefileDialect extends Dialect {
+  readonly id = "makefile";
+  protected override readonly languageIds = new Set(["makefile"]);
+
+  language(): Extension[] {
+    return [StreamLanguage.define(makefile)];
+  }
+}
+
+export {
+  MakefileDialect,
+};

--- a/frontend/src/domains/editor/utils/dialects/files/makefileLanguage.test.ts
+++ b/frontend/src/domains/editor/utils/dialects/files/makefileLanguage.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from "vitest";
+import { StringStream } from "@codemirror/language";
+import { makefile, MAKE_FUNCTIONS } from "./makefileLanguage";
+
+// Tokenize one line through the StreamParser, returning the non-whitespace tokens
+// with their highlight tag. State is threaded across lines so recipe detection
+// (leading tab) is exercised the same way CodeMirror drives the parser.
+function tokenize(lines: string[]): { text: string; tag: string | null }[][] {
+  const state = makefile.startState!(2);
+  return lines.map((line) => {
+    const stream = new StringStream(line, 2, 2);
+    const out: { text: string; tag: string | null }[] = [];
+    while (!stream.eol()) {
+      const start = stream.pos;
+      const tag = makefile.token!(stream, state);
+      if (stream.pos === start) stream.next();
+      const text = line.slice(start, stream.pos).trim();
+      if (text !== "") out.push({ text, tag: tag ?? null });
+    }
+    return out;
+  });
+}
+
+function line(text: string): { text: string; tag: string | null }[] {
+  return tokenize([text])[0];
+}
+
+describe("makefile highlighter", () => {
+  it("marks a target name as a definition", () => {
+    expect(line("build: deps")).toEqual([
+      { text: "build", tag: "def" },
+      { text: ":", tag: null },
+      { text: "deps", tag: null },
+    ]);
+  });
+
+  it("marks pattern-rule targets as definitions", () => {
+    expect(line("%.o: %.c")).toEqual([
+      { text: "%.o", tag: "def" },
+      { text: ":", tag: null },
+      { text: "%.c", tag: null },
+    ]);
+  });
+
+  it("highlights an assigned variable name and its operator", () => {
+    expect(line("CC := gcc")).toEqual([
+      { text: "CC", tag: "def" },
+      { text: ":=", tag: "operator" },
+      { text: "gcc", tag: null },
+    ]);
+  });
+
+  it("recognizes every make assignment operator", () => {
+    for (const op of ["=", ":=", "::=", "+=", "?=", "!="]) {
+      const tokens = line(`VAR ${op} value`);
+      expect(tokens.find((t) => t.text === op)).toEqual({ text: op, tag: "operator" });
+    }
+  });
+
+  it("highlights variable references and automatic variables in a recipe", () => {
+    // Recipe lines are tab-indented; shell text stays plain, make vars are colored.
+    expect(line("\t$(CC) -o $@ $<")).toEqual([
+      { text: "$(CC)", tag: "variableName" },
+      { text: "-o", tag: null },
+      { text: "$@", tag: "variableName" },
+      { text: "$<", tag: "variableName" },
+    ]);
+  });
+
+  it("highlights known functions inside $(...) as keywords", () => {
+    const tokens = line("SRC := $(wildcard *.c)");
+    expect(tokens.find((t) => t.text === "$(wildcard")).toEqual({
+      text: "$(wildcard",
+      tag: "keyword",
+    });
+  });
+
+  it("highlights conditional directives as keywords", () => {
+    const tokens = line("ifeq ($(OS),Windows)");
+    expect(tokens[0]).toEqual({ text: "ifeq", tag: "keyword" });
+    expect(tokens.find((t) => t.text === "$(OS)")).toEqual({ text: "$(OS)", tag: "variableName" });
+  });
+
+  it("highlights .PHONY and other special targets as keywords", () => {
+    expect(line(".PHONY: build clean")).toEqual([
+      { text: ".PHONY", tag: "keyword" },
+      { text: ":", tag: null },
+      { text: "build", tag: null },
+      { text: "clean", tag: null },
+    ]);
+  });
+
+  it("treats # as a comment to end of line", () => {
+    expect(line("# top-level comment")).toEqual([
+      { text: "# top-level comment", tag: "comment" },
+    ]);
+  });
+
+  it("leaves an escaped $$ plain", () => {
+    const tokens = line("\techo $$HOME");
+    expect(tokens.find((t) => t.text.includes("HOME"))?.tag).toBeNull();
+  });
+
+  it("exposes a non-trivial function vocabulary", () => {
+    expect(MAKE_FUNCTIONS.has("wildcard")).toBe(true);
+    expect(MAKE_FUNCTIONS.has("patsubst")).toBe(true);
+    expect(MAKE_FUNCTIONS.has("foreach")).toBe(true);
+    expect(MAKE_FUNCTIONS.size).toBeGreaterThan(20);
+  });
+});

--- a/frontend/src/domains/editor/utils/dialects/files/makefileLanguage.ts
+++ b/frontend/src/domains/editor/utils/dialects/files/makefileLanguage.ts
@@ -1,0 +1,115 @@
+// Syntax highlighting for GNU Makefiles. Line-oriented: a line beginning with a
+// tab is a recipe (shell body, kept plain apart from make variables); other lines
+// are directives, rules (`target: prereqs`), or variable assignments. Highlights
+// targets/assigned names as definitions, `$(...)`/`$@` as variables, known make
+// functions as keywords, directives/special targets as keywords, assignment
+// operators as operators, and `#` comments to end of line.
+
+import type { StreamParser } from "@codemirror/language";
+
+// Conditional/inclusion/definition directives that open a logical line.
+const MAKE_DIRECTIVES: ReadonlySet<string> = new Set([
+  "ifeq", "ifneq", "ifdef", "ifndef", "else", "endif",
+  "include", "-include", "sinclude",
+  "define", "endef", "export", "unexport", "override", "vpath",
+]);
+
+// Built-in `.UPPER` targets that change make's behavior rather than build a file.
+const MAKE_SPECIAL_TARGETS: ReadonlySet<string> = new Set([
+  ".PHONY", ".DEFAULT", ".PRECIOUS", ".SUFFIXES", ".INTERMEDIATE",
+  ".SECONDARY", ".SECONDEXPANSION", ".DELETE_ON_ERROR", ".IGNORE",
+  ".LOW_RESOLUTION_TIME", ".SILENT", ".EXPORT_ALL_VARIABLES",
+  ".NOTPARALLEL", ".ONESHELL", ".POSIX",
+]);
+
+// Built-in functions invoked as `$(name ...)`.
+const MAKE_FUNCTIONS: ReadonlySet<string> = new Set([
+  "subst", "patsubst", "strip", "findstring", "filter", "filter-out",
+  "sort", "word", "wordlist", "words", "firstword", "lastword",
+  "dir", "notdir", "suffix", "basename", "addsuffix", "addprefix",
+  "join", "wildcard", "realpath", "abspath", "if", "or", "and",
+  "foreach", "call", "value", "eval", "origin", "flavor", "shell",
+  "error", "warning", "info", "guile",
+]);
+
+interface MakefileState {
+  // Current line is a tab-indented recipe body (shell), not a make directive/rule.
+  inRecipe: boolean;
+  // Still at the first token of a non-recipe line (target / assigned-var / directive).
+  lineStart: boolean;
+}
+
+const makefile: StreamParser<MakefileState> = {
+  startState: () => ({ inRecipe: false, lineStart: true }),
+  token(stream, state) {
+    if (stream.sol()) {
+      state.inRecipe = stream.string.startsWith("\t");
+      state.lineStart = !state.inRecipe;
+    }
+
+    // Make variable/function references work anywhere, including inside recipes.
+    if (stream.peek() === "$") {
+      if (stream.match(/^\$\$/)) return null; // escaped literal dollar
+      if (stream.match(/^\$[@<^?*+|%]/)) return "variableName"; // automatic vars
+      const fn = stream.match(/^\$[({]\s*([A-Za-z][\w-]*)/, false) as RegExpMatchArray | null;
+      if (fn && MAKE_FUNCTIONS.has(fn[1])) {
+        stream.match(/^\$[({]\s*[A-Za-z][\w-]*/);
+        return "keyword";
+      }
+      if (stream.match(/^\$[({][^)}\n]*[)}]/)) return "variableName";
+      stream.next();
+      return "variableName";
+    }
+
+    if (stream.peek() === "#") {
+      stream.skipToEnd();
+      return "comment";
+    }
+    if (stream.eatSpace()) return null;
+
+    // Recipe body: everything else is shell text, left plain.
+    if (state.inRecipe) {
+      if (!stream.match(/^[^$#]+/)) stream.next();
+      return null;
+    }
+
+    // First token of a rule/assignment/directive line.
+    if (state.lineStart) {
+      state.lineStart = false;
+      const word = stream.match(/^[-.\w%/]+/) as RegExpMatchArray | null;
+      if (word) {
+        if (MAKE_DIRECTIVES.has(word[0])) return "keyword";
+        if (MAKE_SPECIAL_TARGETS.has(word[0])) return "keyword";
+        return "def"; // target name or assigned variable
+      }
+    }
+
+    if (stream.match(/^(::=|:=|\+=|\?=|!=|=)/)) return "operator";
+    if (stream.match(/^:/)) return null; // rule separator
+
+    const quote = stream.peek();
+    if (quote === '"' || quote === "'") {
+      stream.next();
+      while (!stream.eol()) {
+        const ch = stream.next();
+        if (ch === "\\") {
+          stream.next();
+          continue;
+        }
+        if (ch === quote) break;
+      }
+      return "string";
+    }
+
+    if (stream.match(/^\d+\b/)) return "number";
+    if (!stream.match(/^[^\s$#]+/)) stream.next();
+    return null;
+  },
+};
+
+export {
+  MAKE_DIRECTIVES,
+  MAKE_FUNCTIONS,
+  MAKE_SPECIAL_TARGETS,
+  makefile,
+};

--- a/frontend/src/domains/editor/utils/dialects/files/makefileLanguage.ts
+++ b/frontend/src/domains/editor/utils/dialects/files/makefileLanguage.ts
@@ -28,6 +28,19 @@ const MAKE_FUNCTIONS: ReadonlySet<string> = new Set([
   "error", "warning", "info", "guile",
 ]);
 
+// Token patterns, hoisted so token() allocates no RegExp per call.
+const DOLLAR_ESCAPE_RE = /^\$\$/;
+const AUTO_VAR_RE = /^\$[@<^?*+|%]/;
+const FN_OPEN_RE = /^\$[({]\s*([A-Za-z][\w-]*)/;
+const REF_TAIL_RE = /^[^)}\n]*[)}]/;
+const VAR_REF_RE = /^\$[({][^)}\n]*[)}]/;
+const RECIPE_TEXT_RE = /^[^$#]+/;
+const FIRST_WORD_RE = /^[-.\w%/]+/;
+const ASSIGN_OP_RE = /^(::=|:=|\+=|\?=|!=|=)/;
+const COLON_RE = /^:/;
+const NUMBER_RE = /^\d+\b/;
+const BAREWORD_RE = /^[^\s$#]+/;
+
 interface MakefileState {
   // Current line is a tab-indented recipe body (shell), not a make directive/rule.
   inRecipe: boolean;
@@ -45,14 +58,15 @@ const makefile: StreamParser<MakefileState> = {
 
     // Make variable/function references work anywhere, including inside recipes.
     if (stream.peek() === "$") {
-      if (stream.match(/^\$\$/)) return null; // escaped literal dollar
-      if (stream.match(/^\$[@<^?*+|%]/)) return "variableName"; // automatic vars
-      const fn = stream.match(/^\$[({]\s*([A-Za-z][\w-]*)/, false) as RegExpMatchArray | null;
-      if (fn && MAKE_FUNCTIONS.has(fn[1])) {
-        stream.match(/^\$[({]\s*[A-Za-z][\w-]*/);
-        return "keyword";
+      if (stream.match(DOLLAR_ESCAPE_RE)) return null; // escaped literal dollar
+      if (stream.match(AUTO_VAR_RE)) return "variableName"; // automatic vars
+      const fn = stream.match(FN_OPEN_RE) as RegExpMatchArray | null;
+      if (fn) {
+        if (MAKE_FUNCTIONS.has(fn[1])) return "keyword";
+        stream.match(REF_TAIL_RE); // `$(VAR...)`: consume the rest of the reference
+        return "variableName";
       }
-      if (stream.match(/^\$[({][^)}\n]*[)}]/)) return "variableName";
+      if (stream.match(VAR_REF_RE)) return "variableName";
       stream.next();
       return "variableName";
     }
@@ -65,14 +79,14 @@ const makefile: StreamParser<MakefileState> = {
 
     // Recipe body: everything else is shell text, left plain.
     if (state.inRecipe) {
-      if (!stream.match(/^[^$#]+/)) stream.next();
+      if (!stream.match(RECIPE_TEXT_RE)) stream.next();
       return null;
     }
 
     // First token of a rule/assignment/directive line.
     if (state.lineStart) {
       state.lineStart = false;
-      const word = stream.match(/^[-.\w%/]+/) as RegExpMatchArray | null;
+      const word = stream.match(FIRST_WORD_RE) as RegExpMatchArray | null;
       if (word) {
         if (MAKE_DIRECTIVES.has(word[0])) return "keyword";
         if (MAKE_SPECIAL_TARGETS.has(word[0])) return "keyword";
@@ -80,8 +94,8 @@ const makefile: StreamParser<MakefileState> = {
       }
     }
 
-    if (stream.match(/^(::=|:=|\+=|\?=|!=|=)/)) return "operator";
-    if (stream.match(/^:/)) return null; // rule separator
+    if (stream.match(ASSIGN_OP_RE)) return "operator";
+    if (stream.match(COLON_RE)) return null; // rule separator
 
     const quote = stream.peek();
     if (quote === '"' || quote === "'") {
@@ -97,8 +111,8 @@ const makefile: StreamParser<MakefileState> = {
       return "string";
     }
 
-    if (stream.match(/^\d+\b/)) return "number";
-    if (!stream.match(/^[^\s$#]+/)) stream.next();
+    if (stream.match(NUMBER_RE)) return "number";
+    if (!stream.match(BAREWORD_RE)) stream.next();
     return null;
   },
 };

--- a/frontend/src/domains/editor/utils/dialects/files/makefileLanguage.ts
+++ b/frontend/src/domains/editor/utils/dialects/files/makefileLanguage.ts
@@ -1,9 +1,5 @@
-// Syntax highlighting for GNU Makefiles. Line-oriented: a line beginning with a
-// tab is a recipe (shell body, kept plain apart from make variables); other lines
-// are directives, rules (`target: prereqs`), or variable assignments. Highlights
-// targets/assigned names as definitions, `$(...)`/`$@` as variables, known make
-// functions as keywords, directives/special targets as keywords, assignment
-// operators as operators, and `#` comments to end of line.
+// Syntax highlighting for GNU Makefiles. Line-oriented: a tab-indented line is a
+// recipe (shell body); other lines are directives, rules, or variable assignments.
 
 import type { StreamParser } from "@codemirror/language";
 

--- a/frontend/src/domains/editor/utils/dialects/registry.test.ts
+++ b/frontend/src/domains/editor/utils/dialects/registry.test.ts
@@ -38,13 +38,15 @@ describe("resolveDialect", () => {
     expect(resolveDialect({ languageId: "json" }).id).toBe("json");
     expect(resolveDialect({ languageId: "yaml" }).id).toBe("yaml");
     expect(resolveDialect({ languageId: "markdown" }).id).toBe("markdown");
+    expect(resolveDialect({ languageId: "makefile" }).id).toBe("makefile");
+    expect(resolveDialect({ languageId: "gitignore" }).id).toBe("gitignore");
     expect(resolveDialect({ languageId: "brainfuck" }).id).toBe("plaintext");
   });
 });
 
 describe("editorLanguageExtensions", () => {
   it("produces a grammar for known languages", () => {
-    for (const languageId of ["sql", "json", "yaml", "markdown", "python", "mongoshell", "esrest", "rediscli"]) {
+    for (const languageId of ["sql", "json", "yaml", "markdown", "python", "mongoshell", "esrest", "rediscli", "makefile", "gitignore"]) {
       expect(editorLanguageExtensions({ languageId }).length).toBeGreaterThan(0);
     }
   });

--- a/frontend/src/domains/editor/utils/dialects/registry.test.ts
+++ b/frontend/src/domains/editor/utils/dialects/registry.test.ts
@@ -65,6 +65,10 @@ describe("editorCompletionExtensions", () => {
   it("contributes completion for sql buffers", () => {
     expect(editorCompletionExtensions({ languageId: "sql" }).length).toBeGreaterThan(0);
   });
+
+  it("contributes completion for makefile buffers", () => {
+    expect(editorCompletionExtensions({ languageId: "makefile" }).length).toBeGreaterThan(0);
+  });
 });
 
 describe("sqlLike / statementHighlight", () => {

--- a/frontend/src/domains/editor/utils/dialects/registry.ts
+++ b/frontend/src/domains/editor/utils/dialects/registry.ts
@@ -22,6 +22,8 @@ import { RedisCliDialect, RedisDialect } from "./connections/redis";
 import { MongoDbDialect, MongoshellDialect } from "./connections/mongodb";
 import { DbtYamlDialect } from "./files/dbtYaml";
 import { SqlMeshYamlDialect } from "./files/sqlmeshYaml";
+import { MakefileDialect } from "./files/makefile";
+import { GitignoreDialect } from "./files/gitignore";
 import {
   DockerfileDialect,
   HtmlDialect,
@@ -91,6 +93,8 @@ const DIALECTS: readonly Dialect[] = [
   new ShellDialect(),
   new DockerfileDialect(),
   new TomlDialect(),
+  new MakefileDialect(),
+  new GitignoreDialect(),
   new PlainTextDialect(),
 ];
 

--- a/frontend/src/domains/files/components/FileTreeView/constants.ts
+++ b/frontend/src/domains/files/components/FileTreeView/constants.ts
@@ -1,6 +1,22 @@
 const FILE_TREE_DBT_MARKERS = ["dbt_project.yml"];
 const FILE_TREE_SQLMESH_MARKERS = ["config.yaml", "config.yml"];
 
+// Filenames (lowercased) that open with the Makefile grammar; `*.mk`/`*.make`/
+// `*.makefile` extensions are handled alongside these.
+const FILE_KIND_MAKEFILE_NAMES: ReadonlySet<string> = new Set([
+  "makefile",
+  "gnumakefile",
+]);
+
+// Ignore-file names (lowercased) that share the `.gitignore` glob grammar.
+const FILE_KIND_GITIGNORE_NAMES: ReadonlySet<string> = new Set([
+  ".gitignore",
+  ".dockerignore",
+  ".npmignore",
+  ".eslintignore",
+  ".prettierignore",
+]);
+
 const FILE_TREE_DEFAULT_EXPANDED_DIRS = [
   "models",
   "marts",
@@ -15,6 +31,8 @@ const FILE_TREE_DEFAULT_EXPANDED_DIRS = [
 ];
 
 export {
+  FILE_KIND_GITIGNORE_NAMES,
+  FILE_KIND_MAKEFILE_NAMES,
   FILE_TREE_DBT_MARKERS,
   FILE_TREE_DEFAULT_EXPANDED_DIRS,
   FILE_TREE_SQLMESH_MARKERS,

--- a/frontend/src/domains/files/components/FileTreeView/utils.test.ts
+++ b/frontend/src/domains/files/components/FileTreeView/utils.test.ts
@@ -69,8 +69,24 @@ describe("fileKindForName", () => {
     expect(fileKindForName("poetry.lock")).toBe("toml");
   });
 
-  it("maps Makefile to shell and falls back to text for unknown extensions", () => {
-    expect(fileKindForName("Makefile")).toBe("shell");
+  it("maps Makefiles and their variants to the makefile grammar", () => {
+    expect(fileKindForName("Makefile")).toBe("makefile");
+    expect(fileKindForName("makefile")).toBe("makefile");
+    expect(fileKindForName("GNUmakefile")).toBe("makefile");
+    expect(fileKindForName("build.mk")).toBe("makefile");
+    expect(fileKindForName("rules.make")).toBe("makefile");
+    expect(fileKindForName("common.makefile")).toBe("makefile");
+  });
+
+  it("maps ignore-file names to the gitignore grammar", () => {
+    expect(fileKindForName(".gitignore")).toBe("gitignore");
+    expect(fileKindForName(".dockerignore")).toBe("gitignore");
+    expect(fileKindForName(".npmignore")).toBe("gitignore");
+    expect(fileKindForName(".eslintignore")).toBe("gitignore");
+    expect(fileKindForName(".prettierignore")).toBe("gitignore");
+  });
+
+  it("falls back to text for unknown extensions", () => {
     expect(fileKindForName("notes.unknownext")).toBe("text");
   });
 });

--- a/frontend/src/domains/files/components/FileTreeView/utils.ts
+++ b/frontend/src/domains/files/components/FileTreeView/utils.ts
@@ -142,12 +142,13 @@ function fileGlyphKind(name: string): string {
 function fileKindForName(name: string): string {
   const lower = name.toLowerCase();
   if (lower === "dockerfile" || lower.endsWith(".dockerfile")) return "dockerfile";
-  if (FILE_KIND_MAKEFILE_NAMES.has(lower) || lower.endsWith(".makefile")) return "makefile";
+  if (FILE_KIND_MAKEFILE_NAMES.has(lower)) return "makefile";
   if (FILE_KIND_GITIGNORE_NAMES.has(lower)) return "gitignore";
   const ext = name.split(".").pop()?.toLowerCase() ?? "";
   switch (ext) {
     case "mk":
     case "make":
+    case "makefile":
       return "makefile";
     case "sql":
       return "sql";

--- a/frontend/src/domains/files/components/FileTreeView/utils.ts
+++ b/frontend/src/domains/files/components/FileTreeView/utils.ts
@@ -6,6 +6,8 @@ import { useDbtStore } from "@domains/dbt/hooks";
 import { useGitStore } from "@domains/git/hooks";
 import { useSqlMeshStore } from "@domains/sqlmesh/hooks";
 import {
+  FILE_KIND_GITIGNORE_NAMES,
+  FILE_KIND_MAKEFILE_NAMES,
   FILE_TREE_DBT_MARKERS,
   FILE_TREE_SQLMESH_MARKERS,
 } from "./constants";
@@ -140,9 +142,13 @@ function fileGlyphKind(name: string): string {
 function fileKindForName(name: string): string {
   const lower = name.toLowerCase();
   if (lower === "dockerfile" || lower.endsWith(".dockerfile")) return "dockerfile";
-  if (lower === "makefile" || lower.endsWith(".makefile")) return "shell";
+  if (FILE_KIND_MAKEFILE_NAMES.has(lower) || lower.endsWith(".makefile")) return "makefile";
+  if (FILE_KIND_GITIGNORE_NAMES.has(lower)) return "gitignore";
   const ext = name.split(".").pop()?.toLowerCase() ?? "";
   switch (ext) {
+    case "mk":
+    case "make":
+      return "makefile";
     case "sql":
       return "sql";
     case "json":

--- a/frontend/src/shell/utils/app.test.ts
+++ b/frontend/src/shell/utils/app.test.ts
@@ -70,6 +70,7 @@ import {
   zoomTerminal,
 } from "./app";
 import { listFolderTreeIPC, openProjectDialogIPC, openProjectIPC, readTextFileIPC } from "../ipc";
+import { clearSelfWrites, recordSelfWrite } from "./selfWrites";
 import { dbtProjectPaneScanProjectIPC } from "@domains/dbt/components/DbtProjectPane/ipc";
 import { scanSqlMeshProjectIPC } from "@domains/sqlmesh/components/SqlMeshProjectPane/ipc";
 import type { FileTreeEntry } from "@shared";
@@ -409,6 +410,7 @@ describe("toPersisted", () => {
 describe("refreshOnAppFocus", () => {
   beforeEach(() => {
     vi.mocked(readTextFileIPC).mockReset();
+    clearSelfWrites();
     useTabsStore.setState({ tabs: [], layout: null, activeId: null, focusedPaneGroupId: null });
     useGitStore.setState({ repoPath: null });
     useProjectStore.setState({ activeProjectPath: "/proj/active", loading: false });
@@ -453,6 +455,52 @@ describe("refreshOnAppFocus", () => {
 
     const updated = useTabsStore.getState().tabs.find((t) => t.id === "f1");
     expect(updated?.text).toBe("SELECT 2;");
+    expect(updated?.refreshToken).toBe(1);
+  });
+
+  it("does not clobber live edits when the disk change is the app's own autosave echo", async () => {
+    // User saved "SELECT 1;" (recorded as a self-write), then kept typing so the
+    // live buffer is "SELECT 12;". The watcher echo re-reads the just-saved,
+    // now-stale "SELECT 1;". It must NOT overwrite the buffer or remount.
+    const fileTab: EditorTab = {
+      id: "f1",
+      title: "main.sql",
+      text: "SELECT 12;",
+      kind: "sql",
+      cursor: 0,
+      tabType: "file",
+      filePath: "/repo/main.sql",
+    };
+    useTabsStore.setState({ tabs: [fileTab], layout: null, activeId: "f1", focusedPaneGroupId: null });
+    recordSelfWrite("/repo/main.sql", "SELECT 1;");
+    vi.mocked(readTextFileIPC).mockResolvedValue("SELECT 1;");
+
+    await refreshOnAppFocus();
+
+    const updated = useTabsStore.getState().tabs.find((t) => t.id === "f1");
+    expect(updated?.text).toBe("SELECT 12;");
+    expect(updated?.refreshToken).toBeUndefined();
+  });
+
+  it("still reconciles a genuine external edit that is not the app's own write", async () => {
+    const fileTab: EditorTab = {
+      id: "f1",
+      title: "main.sql",
+      text: "SELECT 12;",
+      kind: "sql",
+      cursor: 0,
+      tabType: "file",
+      filePath: "/repo/main.sql",
+    };
+    useTabsStore.setState({ tabs: [fileTab], layout: null, activeId: "f1", focusedPaneGroupId: null });
+    recordSelfWrite("/repo/main.sql", "SELECT 1;");
+    // An external editor wrote something we never saved.
+    vi.mocked(readTextFileIPC).mockResolvedValue("EXTERNAL EDIT");
+
+    await refreshOnAppFocus();
+
+    const updated = useTabsStore.getState().tabs.find((t) => t.id === "f1");
+    expect(updated?.text).toBe("EXTERNAL EDIT");
     expect(updated?.refreshToken).toBe(1);
   });
 

--- a/frontend/src/shell/utils/app.ts
+++ b/frontend/src/shell/utils/app.ts
@@ -10,6 +10,7 @@ import { useSettingsStore } from "@shared/settings";
 import { PANE_GROUPS_KEY } from "../constants";
 import type { PersistedPaneLayout } from "../types";
 import { openProjectDialogIPC, readTextFileIPC } from "../ipc";
+import { isSelfWrite } from "./selfWrites";
 
 function toPersisted(tabs: EditorTab[]): PersistedTab[] {
   // The "Uncommitted Changes" git-diff tab is transient: never restore it on
@@ -86,6 +87,9 @@ async function refreshFileTabFromDisk(tab: EditorTab): Promise<void> {
   if (!tab.filePath) return;
   try {
     const diskText = await readTextFileIPC(tab.filePath);
+    // Skip our own autosave echo; overwriting would revert keystrokes typed since
+    // the save and remount-jump the scroll. Only external edits reconcile.
+    if (isSelfWrite(tab.filePath, diskText)) return;
     const current = useTabsStore.getState().tabs.find((candidate) => candidate.id === tab.id);
     if (current && current.text !== diskText) {
       useTabsStore.getState().updateTab(tab.id, {

--- a/frontend/src/shell/utils/selfWrites.test.ts
+++ b/frontend/src/shell/utils/selfWrites.test.ts
@@ -1,0 +1,32 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { clearSelfWrites, isSelfWrite, recordSelfWrite } from "./selfWrites";
+
+describe("selfWrites registry", () => {
+  beforeEach(() => clearSelfWrites());
+
+  it("recognizes disk content that matches the app's last write", () => {
+    recordSelfWrite("/repo/a.sql", "SELECT 1;");
+    expect(isSelfWrite("/repo/a.sql", "SELECT 1;")).toBe(true);
+  });
+
+  it("treats content that differs from the last write as external", () => {
+    recordSelfWrite("/repo/a.sql", "SELECT 1;");
+    expect(isSelfWrite("/repo/a.sql", "SELECT 2;")).toBe(false);
+  });
+
+  it("only compares against the most recent write per path", () => {
+    recordSelfWrite("/repo/a.sql", "v1");
+    recordSelfWrite("/repo/a.sql", "v2");
+    expect(isSelfWrite("/repo/a.sql", "v1")).toBe(false);
+    expect(isSelfWrite("/repo/a.sql", "v2")).toBe(true);
+  });
+
+  it("keys writes by path", () => {
+    recordSelfWrite("/repo/a.sql", "A");
+    expect(isSelfWrite("/repo/b.sql", "A")).toBe(false);
+  });
+
+  it("reports no self-write for an unknown path", () => {
+    expect(isSelfWrite("/repo/never.sql", "anything")).toBe(false);
+  });
+});

--- a/frontend/src/shell/utils/selfWrites.ts
+++ b/frontend/src/shell/utils/selfWrites.ts
@@ -1,0 +1,22 @@
+// Lets the disk-reconcile tell its own autosave echo from a real external edit,
+// so the watcher firing on our own write doesn't clobber the live buffer.
+const lastSelfWrite = new Map<string, string>();
+
+function recordSelfWrite(path: string, content: string): void {
+  lastSelfWrite.set(path, content);
+}
+
+// True when the on-disk change is our own last write, not an external edit.
+function isSelfWrite(path: string, diskText: string): boolean {
+  return lastSelfWrite.get(path) === diskText;
+}
+
+function clearSelfWrites(): void {
+  lastSelfWrite.clear();
+}
+
+export {
+  clearSelfWrites,
+  isSelfWrite,
+  recordSelfWrite,
+};


### PR DESCRIPTION
## What does this PR do?

- `Makefile` & `.gitignore` syntax highlighting. CodeMirror `StreamParser` grammars, registered as file dialects.
 - `Makefile`: targets/pattern rules, $(...)/$@ variables, built-in functions, directives (ifeq/include/…), .PHONY-style special targets, assignment operators, recipes, comments. Replaces the old Makefile => shell mapping.
- `.gitignore`: # comments, leading ! negation, glob metacharacters, trailing-slash dirs. Shared by .dockerignore/.npmignore/.eslintignore/.prettierignore.
- Filename map: Makefile/makefile/GNUmakefile/*.mk/*.make/*.makefile => makefile; the ignore-file names => gitignore.
- `Makefile` autocomplete. A `MakefileCompletionProvider` on the shared `CompletionProvider` abstraction
- Fix: editor no longer clobbers typing. The filesystem watcher fired on the app's own autosave writes; the disk-reconcile then re-read the just-saved file and overwrote the live buffer with now-stale text (reverting keystrokes + jumping scroll). Added a self-write registry so the reconcile skips its own echo and only applies genuine external edits.

## Checklist

- [ ] I opened an issue first for non-trivial changes, or this is a small fix.
- [x] Tests added/updated for my change.
- [x] **I license my contribution under the MIT License**, per [CONTRIBUTING.md](../CONTRIBUTING.md). I confirm this is my original work, or that I have the right to submit it.
