### PR TITLE
[Fix] Align icon and filename vertically in file tree rows

### DIFF
--- a/frontend/src/domains/files/components/FileTreeView/index.css
+++ b/frontend/src/domains/files/components/FileTreeView/index.css
@@ -67,8 +67,11 @@
 }
 .mdbc-file-icon {
   flex: none;
+  display: inline-flex;
+  align-items: center;
   color: var(--m-fg-3, #a0a0aa);
 }
+.mdbc-file-icon svg { display: block; }
 .mdbc-file-icon.folder { color: var(--m-fg-2, #d0d0d8); }
 .mdbc-file-icon.file.sql  { color: #6aa9ff; }
 .mdbc-file-icon.file.yaml { color: #ffd75e; }


### PR DESCRIPTION
## What does this PR do?

File-type icon and filename now vertically center within each file tree row.

## Checklist

- [ ] I opened an issue first for non-trivial changes, or this is a small fix.
- [x] Tests added/updated for my change.
- [x] **I license my contribution under the MIT License**, per [CONTRIBUTING.md](../CONTRIBUTING.md). I confirm this is my original work, or that I have the right to submit it.
