### PR TITLE
[Feature] Add an option to open project in new window

### DIFF
--- a/docs/src/pages/reference/shortcuts.astro
+++ b/docs/src/pages/reference/shortcuts.astro
@@ -70,6 +70,11 @@ import Callout from "../../components/docs/Callout/Callout.astro";
         <td>Global</td>
       </tr>
       <tr>
+        <td class="font-medium text-fg"><kbd>&#8984;&#8679;O</kbd></td>
+        <td>Open project folder in a new window</td>
+        <td>Global</td>
+      </tr>
+      <tr>
         <td class="font-medium text-fg"><kbd>&#8984;Q</kbd></td>
         <td>Quit Arris</td>
         <td>Global</td>

--- a/frontend/src/shared/settings/constants.ts
+++ b/frontend/src/shared/settings/constants.ts
@@ -47,6 +47,7 @@ export const ACTIONS = {
   searchFiles: { label: "Search Files", category: "navigation", defaultShortcut: { key: "Mod-p" } },
   searchContent: { label: "Search Content", category: "navigation", defaultShortcut: { key: "Mod-Shift-f" } },
   openProject: { label: "Open Project", category: "navigation", defaultShortcut: { key: "Mod-o" } },
+  openProjectNewWindow: { label: "Open Project in New Window", category: "navigation", defaultShortcut: { key: "Mod-Shift-o" } },
 
   toggleSidebar: { label: "Toggle Sidebar", category: "sidebar", defaultShortcut: { key: "Mod-Shift-s" } },
   showDefinition: { label: "Show Definition", category: "sidebar", defaultShortcut: { key: "Mod-b" } },

--- a/frontend/src/shell/components/App/index.test.tsx
+++ b/frontend/src/shell/components/App/index.test.tsx
@@ -90,7 +90,8 @@ import { useChartEditorStore } from "@domains/chart/hooks";
 import { useBackgroundTasksStore } from "../../hooks/backgroundTasksStore";
 import { useDbtStore } from "@domains/dbt/hooks";
 import { useSqlMeshStore } from "@domains/sqlmesh/hooks";
-import { closeProjectIPC } from "@shell/ipc";
+import { StrictMode } from "react";
+import { closeProjectIPC, openProjectIPC, takePendingLaunchIPC } from "@shell/ipc";
 
 const realUseAppState = (await vi.importActual<typeof import("@shell/hooks")>("@shell/hooks")).useAppState;
 
@@ -198,6 +199,32 @@ describe("App bootstrapping — no welcome screen flash", () => {
       expect(screen.getByTestId("content-view")).toBeTruthy();
     });
     expect(screen.queryByTestId("welcome-screen")).toBeNull();
+  });
+
+  it("opens the launch path once under StrictMode, never falling back to reopen-last", async () => {
+    // Regression: StrictMode double-invokes the bootstrap effect. The launch
+    // path is consume-once, so a second run would see null and wrongly reopen
+    // the last project. The bootstrap must run exactly once.
+    useRecentsStore.setState({
+      recents: [{ path: "/proj/old", name: "old", kind: "folder", openedAt: Date.now() }],
+    });
+    vi.mocked(openProjectIPC).mockClear();
+    vi.mocked(takePendingLaunchIPC).mockReset();
+    vi.mocked(takePendingLaunchIPC).mockResolvedValueOnce("/proj/launched").mockResolvedValue(null);
+
+    render(
+      <StrictMode>
+        <App />
+      </StrictMode>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("content-view")).toBeTruthy();
+    });
+    const openedRoots = vi.mocked(openProjectIPC).mock.calls.map((call) => call[0]);
+    expect(openedRoots).toContain("/proj/launched");
+    expect(openedRoots).not.toContain("/proj/old");
+    vi.mocked(takePendingLaunchIPC).mockResolvedValue(null);
   });
 
   it("shows welcome screen when reopenLastProject preference is disabled", async () => {

--- a/frontend/src/shell/components/App/index.test.tsx
+++ b/frontend/src/shell/components/App/index.test.tsx
@@ -62,8 +62,10 @@ vi.mock("@shell/ipc", () => ({
   openFileIndexIPC: vi.fn().mockResolvedValue(undefined),
   openProjectDialogIPC: vi.fn(),
   openProjectIPC: vi.fn().mockResolvedValue({ root: "", connections: [], tabs: [], federationTabs: [], paneLayout: { layout: null, focusedPaneGroupId: null } }),
+  openProjectInNewWindowIPC: vi.fn().mockResolvedValue(undefined),
   readTextFileIPC: vi.fn(),
   saveTabsIPC: vi.fn(),
+  takePendingLaunchIPC: vi.fn().mockResolvedValue(null),
 }));
 vi.mock("@domains/results/components/ResultsTableView/utils", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@domains/results/components/ResultsTableView/utils")>()),

--- a/frontend/src/shell/components/WelcomeScreen/constants.ts
+++ b/frontend/src/shell/components/WelcomeScreen/constants.ts
@@ -47,10 +47,16 @@ SELECT * FROM (VALUES
   (5, 'USB-C Hub', 59.95, DATE '2024-03-01')
 ) AS t(id, product, amount, order_date)`;
 
+// Recent-project right-click menu: open that project in a separate window.
+const RECENT_MENU_OPEN_NEW_WINDOW_ID = "open-new-window";
+const RECENT_MENU_OPEN_NEW_WINDOW_LABEL = "Open in New Window";
+
 export {
   DBT_EXAMPLE_MODEL_SQL,
   DBT_PROFILES_YML,
   DBT_PROJECT_YML,
+  RECENT_MENU_OPEN_NEW_WINDOW_ID,
+  RECENT_MENU_OPEN_NEW_WINDOW_LABEL,
   SAMPLE_CONNECTION_NAME,
   SAMPLE_DUCKDB_FILE,
   SAMPLE_ORDERS_SQL,

--- a/frontend/src/shell/components/WelcomeScreen/constants.ts
+++ b/frontend/src/shell/components/WelcomeScreen/constants.ts
@@ -51,10 +51,14 @@ SELECT * FROM (VALUES
 const RECENT_MENU_OPEN_NEW_WINDOW_ID = "open-new-window";
 const RECENT_MENU_OPEN_NEW_WINDOW_LABEL = "Open in New Window";
 
+// Folder-picker title for the "Open in new window" button.
+const OPEN_FOLDER_NEW_WINDOW_DIALOG_TITLE = "Open folder in new window";
+
 export {
   DBT_EXAMPLE_MODEL_SQL,
   DBT_PROFILES_YML,
   DBT_PROJECT_YML,
+  OPEN_FOLDER_NEW_WINDOW_DIALOG_TITLE,
   RECENT_MENU_OPEN_NEW_WINDOW_ID,
   RECENT_MENU_OPEN_NEW_WINDOW_LABEL,
   SAMPLE_CONNECTION_NAME,

--- a/frontend/src/shell/components/WelcomeScreen/hooks.ts
+++ b/frontend/src/shell/components/WelcomeScreen/hooks.ts
@@ -1,10 +1,12 @@
 import { useState } from "react";
 import { useProjectStore } from "@shell/hooks/projectStore";
 import { useRecentsStore } from "@shell/hooks/recentsStore";
+import { openProjectInNewWindow } from "@shell/utils/app";
 import {
   doScaffoldAndOpen,
   joinProjectPath,
   pickAndOpenFolder,
+  pickAndOpenFolderInNewWindow,
 } from "./utils";
 import {
   welcomeGitCloneIPC,
@@ -83,8 +85,16 @@ function useWelcomeScreen(): WelcomeScreenViewModel {
     pickAndOpenFolder().catch(() => {});
   }
 
+  function onClickOpenFolderNewWindow() {
+    pickAndOpenFolderInNewWindow().catch(() => {});
+  }
+
   function onClickRecentProject(path: string) {
     useProjectStore.getState().openProject(path);
+  }
+
+  function onOpenRecentProjectNewWindow(path: string) {
+    openProjectInNewWindow(path).catch(() => {});
   }
 
   function onClickShowCloneDialog() {
@@ -110,11 +120,13 @@ function useWelcomeScreen(): WelcomeScreenViewModel {
     onCancelScaffold,
     onClickNewProject,
     onClickOpenFolder,
+    onClickOpenFolderNewWindow,
     onClickRecentProject,
     onClickShowCloneDialog,
     onCloneSubmit,
     onConfirmScaffold,
     onCreateNewProject,
+    onOpenRecentProjectNewWindow,
     pendingNewProject,
     pendingScaffold,
     recents,

--- a/frontend/src/shell/components/WelcomeScreen/hooks.ts
+++ b/frontend/src/shell/components/WelcomeScreen/hooks.ts
@@ -1,12 +1,12 @@
 import { useState } from "react";
 import { useProjectStore } from "@shell/hooks/projectStore";
 import { useRecentsStore } from "@shell/hooks/recentsStore";
-import { openProjectInNewWindow } from "@shell/utils/app";
+import { openProjectInNewWindow, pickAndOpenFolderInNewWindow } from "@shell/utils/app";
+import { OPEN_FOLDER_NEW_WINDOW_DIALOG_TITLE } from "./constants";
 import {
   doScaffoldAndOpen,
   joinProjectPath,
   pickAndOpenFolder,
-  pickAndOpenFolderInNewWindow,
 } from "./utils";
 import {
   welcomeGitCloneIPC,
@@ -86,7 +86,7 @@ function useWelcomeScreen(): WelcomeScreenViewModel {
   }
 
   function onClickOpenFolderNewWindow() {
-    pickAndOpenFolderInNewWindow().catch(() => {});
+    pickAndOpenFolderInNewWindow(OPEN_FOLDER_NEW_WINDOW_DIALOG_TITLE).catch(() => {});
   }
 
   function onClickRecentProject(path: string) {

--- a/frontend/src/shell/components/WelcomeScreen/index.test.tsx
+++ b/frontend/src/shell/components/WelcomeScreen/index.test.tsx
@@ -17,6 +17,7 @@ vi.mock("@shell/ipc", () => ({
     children: [],
   }),
   openFileIndexIPC: vi.fn().mockResolvedValue(undefined),
+  openProjectDialogIPC: vi.fn(),
   openProjectIPC: vi.fn().mockResolvedValue({
     root: "",
     connections: [],
@@ -31,7 +32,7 @@ import { useConnectionsStore } from "@domains/connection/hooks";
 
 import { open as openDialog } from "@tauri-apps/plugin-dialog";
 import { invoke } from "@tauri-apps/api/core";
-import { openProjectIPC, openProjectInNewWindowIPC } from "@shell/ipc";
+import { openProjectDialogIPC, openProjectIPC, openProjectInNewWindowIPC } from "@shell/ipc";
 import { useRecentsStore } from "@shell/hooks/recentsStore";
 import { useProjectStore } from "@shell/hooks/projectStore";
 import { useTabsStore } from "../../hooks/tabsStore";
@@ -347,7 +348,7 @@ describe("WelcomeScreen", () => {
   });
 
   it("opens the picked folder in a new window from the toolbar button", async () => {
-    vi.mocked(openDialog).mockResolvedValue("/proj/nw");
+    vi.mocked(openProjectDialogIPC).mockResolvedValue("/proj/nw");
     render(<WelcomeScreen />);
     await act(async () => {
       fireEvent.click(screen.getByTestId("welcome-open-folder-new-window"));

--- a/frontend/src/shell/components/WelcomeScreen/index.test.tsx
+++ b/frontend/src/shell/components/WelcomeScreen/index.test.tsx
@@ -25,11 +25,13 @@ vi.mock("@shell/ipc", () => ({
     federationTabs: [],
     paneLayout: { layout: null, focusedPaneGroupId: null },
   }),
+  openProjectInNewWindowIPC: vi.fn().mockResolvedValue(undefined),
 }));
 import { useConnectionsStore } from "@domains/connection/hooks";
 
 import { open as openDialog } from "@tauri-apps/plugin-dialog";
 import { invoke } from "@tauri-apps/api/core";
+import { openProjectIPC, openProjectInNewWindowIPC } from "@shell/ipc";
 import { useRecentsStore } from "@shell/hooks/recentsStore";
 import { useProjectStore } from "@shell/hooks/projectStore";
 import { useTabsStore } from "../../hooks/tabsStore";
@@ -342,6 +344,49 @@ describe("WelcomeScreen", () => {
     expect(screen.queryByTestId("welcome-confirm-dialog")).toBeNull();
     expect(invoke).toHaveBeenCalledWith("cmd_create_folder", { path: "/tmp/scratch" });
     expect(useTabsStore.getState().tabs.length).toBe(1);
+  });
+
+  it("opens the picked folder in a new window from the toolbar button", async () => {
+    vi.mocked(openDialog).mockResolvedValue("/proj/nw");
+    render(<WelcomeScreen />);
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("welcome-open-folder-new-window"));
+    });
+    expect(openProjectInNewWindowIPC).toHaveBeenCalledWith("/proj/nw");
+    expect(openProjectIPC).not.toHaveBeenCalled();
+  });
+
+  it("plain-clicking a recent opens it in the current window", () => {
+    useRecentsStore.setState({
+      recents: [{ path: "/proj/demo", name: "demo", kind: "folder", openedAt: Date.now() }],
+    });
+    render(<WelcomeScreen />);
+    fireEvent.click(screen.getByTestId("welcome-recent-/proj/demo"));
+    expect(openProjectIPC).toHaveBeenCalledWith("/proj/demo");
+    expect(openProjectInNewWindowIPC).not.toHaveBeenCalled();
+  });
+
+  it("cmd/ctrl-clicking a recent opens it in a new window", () => {
+    useRecentsStore.setState({
+      recents: [{ path: "/proj/demo", name: "demo", kind: "folder", openedAt: Date.now() }],
+    });
+    render(<WelcomeScreen />);
+    fireEvent.click(screen.getByTestId("welcome-recent-/proj/demo"), { metaKey: true });
+    expect(openProjectInNewWindowIPC).toHaveBeenCalledWith("/proj/demo");
+    expect(openProjectIPC).not.toHaveBeenCalled();
+  });
+
+  it("right-clicking a recent offers Open in New Window", async () => {
+    useRecentsStore.setState({
+      recents: [{ path: "/proj/demo", name: "demo", kind: "folder", openedAt: Date.now() }],
+    });
+    render(<WelcomeScreen />);
+    fireEvent.contextMenu(screen.getByTestId("welcome-recent-/proj/demo"));
+    const item = screen.getByTestId("welcome-recent-open-new-window");
+    expect(item.textContent).toContain("Open in New Window");
+    await act(async () => { fireEvent.click(item); });
+    expect(openProjectInNewWindowIPC).toHaveBeenCalledWith("/proj/demo");
+    expect(openProjectIPC).not.toHaveBeenCalled();
   });
 });
 

--- a/frontend/src/shell/components/WelcomeScreen/index.tsx
+++ b/frontend/src/shell/components/WelcomeScreen/index.tsx
@@ -1,7 +1,12 @@
 import { Icon } from "@shared/ui/Icon";
+import { ContextMenu, useContextMenu } from "@shared/ui/ContextMenu";
 import { CloneDialog } from "./components/CloneDialog";
 import { ConfirmDialog } from "./components/ConfirmDialog";
 import { NewProjectDialog } from "./components/NewProjectDialog";
+import {
+  RECENT_MENU_OPEN_NEW_WINDOW_ID,
+  RECENT_MENU_OPEN_NEW_WINDOW_LABEL,
+} from "./constants";
 import { useWelcomeScreen } from "./hooks";
 import { timeAgo } from "./utils";
 import "./index.css";
@@ -15,16 +20,21 @@ export function WelcomeScreen() {
     onCancelScaffold,
     onClickNewProject,
     onClickOpenFolder,
+    onClickOpenFolderNewWindow,
     onClickRecentProject,
     onClickShowCloneDialog,
     onCloneSubmit,
     onConfirmScaffold,
     onCreateNewProject,
+    onOpenRecentProjectNewWindow,
     pendingNewProject,
     pendingScaffold,
     recents,
     showCloneDialog,
   } = useWelcomeScreen();
+
+  const recentMenu = useContextMenu<string>();
+  const recentMenuPath = recentMenu.state?.context;
 
   return (
     <div className="mdbc welcome-screen" data-testid="welcome-screen">
@@ -99,6 +109,16 @@ export function WelcomeScreen() {
             <button
               type="button"
               className="mdbc-btn welcome-action-btn"
+              data-testid="welcome-open-folder-new-window"
+              onClick={onClickOpenFolderNewWindow}
+            >
+              <Icon name="folder" size={14} />
+              Open in new window
+            </button>
+
+            <button
+              type="button"
+              className="mdbc-btn welcome-action-btn"
               data-testid="welcome-clone"
               onClick={onClickShowCloneDialog}
             >
@@ -119,7 +139,12 @@ export function WelcomeScreen() {
                   className="welcome-recent-card"
                   data-testid={`welcome-recent-${recent.path}`}
                   title={recent.path}
-                  onClick={() => onClickRecentProject(recent.path)}
+                  onClick={(event) =>
+                    event.metaKey || event.ctrlKey
+                      ? onOpenRecentProjectNewWindow(recent.path)
+                      : onClickRecentProject(recent.path)
+                  }
+                  onContextMenu={(event) => recentMenu.open(event, recent.path)}
                 >
                   <span className="welcome-recent-icon" aria-hidden="true">
                     <Icon name="folder" size={16} />
@@ -166,6 +191,23 @@ export function WelcomeScreen() {
           message="This folder already contains files. Scaffold files may overwrite existing content. Continue anyway?"
           onConfirm={onConfirmScaffold}
           onCancel={onCancelScaffold}
+        />
+      )}
+
+      {recentMenu.state && recentMenuPath && (
+        <ContextMenu
+          x={recentMenu.state.x}
+          y={recentMenu.state.y}
+          items={[
+            {
+              id: RECENT_MENU_OPEN_NEW_WINDOW_ID,
+              label: RECENT_MENU_OPEN_NEW_WINDOW_LABEL,
+              testId: "welcome-recent-open-new-window",
+              action: () => onOpenRecentProjectNewWindow(recentMenuPath),
+            },
+          ]}
+          onClose={recentMenu.close}
+          data-testid="welcome-recent-context-menu"
         />
       )}
     </div>

--- a/frontend/src/shell/components/WelcomeScreen/types.ts
+++ b/frontend/src/shell/components/WelcomeScreen/types.ts
@@ -39,11 +39,13 @@ interface WelcomeScreenViewModel {
   onCancelScaffold: () => void;
   onClickNewProject: (kind: ProjectKind) => void;
   onClickOpenFolder: () => void;
+  onClickOpenFolderNewWindow: () => void;
   onClickRecentProject: (path: string) => void;
   onClickShowCloneDialog: () => void;
   onCloneSubmit: (url: string, dest: string) => void;
   onConfirmScaffold: () => void;
   onCreateNewProject: (name: string, location: string) => void;
+  onOpenRecentProjectNewWindow: (path: string) => void;
   pendingNewProject: PendingNewProject | null;
   pendingScaffold: PendingScaffold | null;
   recents: RecentEntry[];

--- a/frontend/src/shell/components/WelcomeScreen/utils.ts
+++ b/frontend/src/shell/components/WelcomeScreen/utils.ts
@@ -2,7 +2,6 @@ import { useConnectionsStore } from "@domains/connection/hooks";
 import type { ScopedConnection } from "@domains/connection";
 import { open as openDialog } from "@tauri-apps/plugin-dialog";
 import { useProjectStore } from "@shell/hooks/projectStore";
-import { openProjectInNewWindow } from "@shell/utils/app";
 import { useTabsStore } from "../../hooks/tabsStore";
 import {
   DBT_EXAMPLE_MODEL_SQL,
@@ -101,16 +100,9 @@ async function pickAndOpenFolder(): Promise<void> {
   useProjectStore.getState().openProject(selected);
 }
 
-async function pickAndOpenFolderInNewWindow(): Promise<void> {
-  const selected = await openDialog({ directory: true, title: "Open folder in new window" });
-  if (typeof selected !== "string") return;
-  await openProjectInNewWindow(selected);
-}
-
 export {
   doScaffoldAndOpen,
   joinProjectPath,
   pickAndOpenFolder,
-  pickAndOpenFolderInNewWindow,
   timeAgo,
 };

--- a/frontend/src/shell/components/WelcomeScreen/utils.ts
+++ b/frontend/src/shell/components/WelcomeScreen/utils.ts
@@ -2,6 +2,7 @@ import { useConnectionsStore } from "@domains/connection/hooks";
 import type { ScopedConnection } from "@domains/connection";
 import { open as openDialog } from "@tauri-apps/plugin-dialog";
 import { useProjectStore } from "@shell/hooks/projectStore";
+import { openProjectInNewWindow } from "@shell/utils/app";
 import { useTabsStore } from "../../hooks/tabsStore";
 import {
   DBT_EXAMPLE_MODEL_SQL,
@@ -100,9 +101,16 @@ async function pickAndOpenFolder(): Promise<void> {
   useProjectStore.getState().openProject(selected);
 }
 
+async function pickAndOpenFolderInNewWindow(): Promise<void> {
+  const selected = await openDialog({ directory: true, title: "Open folder in new window" });
+  if (typeof selected !== "string") return;
+  await openProjectInNewWindow(selected);
+}
+
 export {
   doScaffoldAndOpen,
   joinProjectPath,
   pickAndOpenFolder,
+  pickAndOpenFolderInNewWindow,
   timeAgo,
 };

--- a/frontend/src/shell/hooks/appState.ts
+++ b/frontend/src/shell/hooks/appState.ts
@@ -94,7 +94,13 @@ function useAppBootstrap(
   setBootstrapping: (bootstrapping: boolean) => void,
   hydrated: MutableRefObject<boolean>,
 ): void {
+  // Bootstrap must run exactly once per process. StrictMode double-invokes
+  // effects in dev; without this guard the second run sees the consume-once
+  // launch path already taken and wrongly reopens the last project.
+  const bootstrapped = useRef(false);
   useEffect(() => {
+    if (bootstrapped.current) return;
+    bootstrapped.current = true;
     useSettingsStore.getState().hydrate();
     hydrateFrontendStores();
 

--- a/frontend/src/shell/hooks/appState.ts
+++ b/frontend/src/shell/hooks/appState.ts
@@ -21,6 +21,7 @@ import {
   listenAppEventIPC,
   savePaneLayoutIPC,
   saveTabsIPC,
+  takePendingLaunchIPC,
 } from "../ipc";
 import { ACTION_ORDER, useSettingsStore } from "@shared/settings";
 import type { AppViewModel } from "../types";
@@ -104,8 +105,12 @@ function useAppBootstrap(
     useSettingsStore.getState().hydrate();
     hydrateFrontendStores();
 
-    Promise.all([listConnectionsIPC(), appPreferencesLoadIPC().catch(() => null)])
-      .then(async ([connections, preferences]) => {
+    Promise.all([
+      listConnectionsIPC(),
+      appPreferencesLoadIPC().catch(() => null),
+      takePendingLaunchIPC().catch(() => null),
+    ])
+      .then(async ([connections, preferences, pendingLaunch]) => {
         setConnections(connections);
         // Restore only carries the connected-status snapshot, not a schema fetch,
         // so eagerly load schemas for already-connected connections; otherwise the
@@ -113,7 +118,7 @@ function useAppBootstrap(
         useConnectionsStore.getState().hydrateConnectedSchemas();
         if (preferences) useSettingsStore.getState().hydrate(preferences);
         hydrated.current = true;
-        await openPendingLaunchOrReopenLast();
+        await openPendingLaunchOrReopenLast(pendingLaunch);
         setBootstrapping(false);
       })
       .catch((error) => {

--- a/frontend/src/shell/hooks/appState.ts
+++ b/frontend/src/shell/hooks/appState.ts
@@ -30,9 +30,10 @@ import {
   isBareKeySpec,
   isTypingTarget,
   matchesShortcut,
+  openPendingLaunchOrReopenLast,
   openProjectFromMenu,
+  pickAndOpenFolderInNewWindow,
   refreshOnAppFocus,
-  reopenLastProjectIfNeeded,
   runCommand,
   toPersisted,
   useGlobalCommands,
@@ -106,7 +107,7 @@ function useAppBootstrap(
         useConnectionsStore.getState().hydrateConnectedSchemas();
         if (preferences) useSettingsStore.getState().hydrate(preferences);
         hydrated.current = true;
-        await reopenLastProjectIfNeeded();
+        await openPendingLaunchOrReopenLast();
         setBootstrapping(false);
       })
       .catch((error) => {
@@ -226,6 +227,7 @@ function useAppDragDrop(): void {
 function useAppMenuEvents(): void {
   useAppMenuEvent("menu:open-settings", onMenuOpenSettings);
   useAppMenuEvent("menu:open-project", onMenuOpenProject);
+  useAppMenuEvent("menu:open-project-new-window", onMenuOpenProjectNewWindow);
   useAppMenuEvent("menu:save-file", onMenuSaveFile);
   useAppMenuEvent("menu:new-project", onMenuNewProject);
   useAppMenuEvent("menu:close-editor", onMenuCloseEditor);
@@ -356,6 +358,10 @@ function onMenuOpenSettings(): void {
 
 function onMenuOpenProject(): void {
   openProjectFromMenu().catch(() => {});
+}
+
+function onMenuOpenProjectNewWindow(): void {
+  pickAndOpenFolderInNewWindow().catch(() => {});
 }
 
 function onMenuSaveFile(): void {

--- a/frontend/src/shell/ipc.ts
+++ b/frontend/src/shell/ipc.ts
@@ -39,6 +39,16 @@ function openProjectIPC(root: string): Promise<ProjectOpenResult> {
   return invoke("cmd_open_project", { root });
 }
 
+function openProjectInNewWindowIPC(path: string): Promise<void> {
+  return invoke("cmd_open_project_in_new_window", { path });
+}
+
+// This process's launch project path (set by "open in new window"), returned
+// once then cleared so a later reload does not reopen it.
+function takePendingLaunchIPC(): Promise<string | null> {
+  return invoke("cmd_take_pending_launch");
+}
+
 function readTextFileIPC(path: string): Promise<string> {
   return invoke("cmd_read_text_file", { path });
 }
@@ -85,7 +95,9 @@ export {
   openFileIndexIPC,
   openProjectDialogIPC,
   openProjectIPC,
+  openProjectInNewWindowIPC,
   readTextFileIPC,
+  takePendingLaunchIPC,
   savePaneLayoutIPC,
   saveTabsIPC,
 };

--- a/frontend/src/shell/ipc.ts
+++ b/frontend/src/shell/ipc.ts
@@ -71,8 +71,8 @@ function moveTabToProjectIPC(id: string): Promise<string> {
   return invoke("cmd_move_tab_to_project", { id });
 }
 
-function openProjectDialogIPC() {
-  return openDialog({ directory: true, multiple: false });
+function openProjectDialogIPC(title?: string) {
+  return openDialog({ directory: true, multiple: false, title });
 }
 
 function listenAppEventIPC(event: string, handler: () => void) {

--- a/frontend/src/shell/utils/app.test.ts
+++ b/frontend/src/shell/utils/app.test.ts
@@ -20,8 +20,10 @@ vi.mock("../ipc", () => ({
     federationTabs: [],
     paneLayout: { layout: null, focusedPaneGroupId: null },
   }),
+  openProjectInNewWindowIPC: vi.fn().mockResolvedValue(undefined),
   readTextFileIPC: vi.fn(),
   saveTabsIPC: vi.fn(),
+  takePendingLaunchIPC: vi.fn().mockResolvedValue(null),
 }));
 
 vi.mock("@shared/ui/utils/theme", () => ({
@@ -67,10 +69,20 @@ import {
   zoomDirectionFromKey,
   zoomDirectionFromWheel,
   zoomEditor,
+  openPendingLaunchOrReopenLast,
+  openProjectInNewWindow,
+  pickAndOpenFolderInNewWindow,
   zoomFocusedPane,
   zoomTerminal,
 } from "./app";
-import { listFolderTreeIPC, openProjectDialogIPC, openProjectIPC, readTextFileIPC } from "../ipc";
+import {
+  listFolderTreeIPC,
+  openProjectDialogIPC,
+  openProjectIPC,
+  openProjectInNewWindowIPC,
+  readTextFileIPC,
+  takePendingLaunchIPC,
+} from "../ipc";
 import { clearSelfWrites, recordSelfWrite } from "./selfWrites";
 import { dbtProjectPaneScanProjectIPC } from "@domains/dbt/components/DbtProjectPane/ipc";
 import { scanSqlMeshProjectIPC } from "@domains/sqlmesh/components/SqlMeshProjectPane/ipc";
@@ -621,5 +633,65 @@ describe("openProjectFromMenu", () => {
     vi.mocked(openProjectDialogIPC).mockResolvedValue(["/a", "/b"] as any);
     await openProjectFromMenu();
     expect(listFolderTreeIPC).not.toHaveBeenCalled();
+  });
+});
+
+describe("openProjectInNewWindow", () => {
+  beforeEach(() => {
+    vi.mocked(openProjectInNewWindowIPC).mockClear();
+  });
+
+  it("spawns a new window for the given path", async () => {
+    await openProjectInNewWindow("/proj/two");
+    expect(openProjectInNewWindowIPC).toHaveBeenCalledWith("/proj/two");
+  });
+});
+
+describe("pickAndOpenFolderInNewWindow", () => {
+  beforeEach(() => {
+    vi.mocked(openProjectDialogIPC).mockReset();
+    vi.mocked(openProjectInNewWindowIPC).mockClear();
+  });
+
+  it("opens the picked folder in a new window", async () => {
+    vi.mocked(openProjectDialogIPC).mockResolvedValue("/proj/pick");
+    await pickAndOpenFolderInNewWindow();
+    expect(openProjectInNewWindowIPC).toHaveBeenCalledWith("/proj/pick");
+  });
+
+  it("noops when the dialog is cancelled", async () => {
+    vi.mocked(openProjectDialogIPC).mockResolvedValue(null);
+    await pickAndOpenFolderInNewWindow();
+    expect(openProjectInNewWindowIPC).not.toHaveBeenCalled();
+  });
+});
+
+describe("openPendingLaunchOrReopenLast", () => {
+  beforeEach(() => {
+    vi.mocked(takePendingLaunchIPC).mockReset();
+    vi.mocked(openProjectIPC).mockClear();
+    vi.mocked(openProjectIPC).mockResolvedValue({
+      root: "",
+      connections: [],
+      tabs: [],
+      federationTabs: [],
+      paneLayout: { layout: null, focusedPaneGroupId: null },
+    });
+    useProjectStore.setState({ activeProjectPath: null, loading: false });
+    useFilesStore.getState().clear();
+  });
+
+  it("opens the launch path in this window, winning over reopen-last", async () => {
+    vi.mocked(takePendingLaunchIPC).mockResolvedValue("/proj/launched");
+    useSettingsStore.setState({ reopenLastProject: true });
+    await openPendingLaunchOrReopenLast();
+    expect(openProjectIPC).toHaveBeenCalledWith("/proj/launched");
+  });
+
+  it("falls back to reopen-last when there is no launch path", async () => {
+    vi.mocked(takePendingLaunchIPC).mockResolvedValue(null);
+    useSettingsStore.setState({ reopenLastProject: false });
+    await openPendingLaunchOrReopenLast();
+    expect(openProjectIPC).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/shell/utils/app.test.ts
+++ b/frontend/src/shell/utils/app.test.ts
@@ -81,7 +81,6 @@ import {
   openProjectIPC,
   openProjectInNewWindowIPC,
   readTextFileIPC,
-  takePendingLaunchIPC,
 } from "../ipc";
 import { clearSelfWrites, recordSelfWrite } from "./selfWrites";
 import { dbtProjectPaneScanProjectIPC } from "@domains/dbt/components/DbtProjectPane/ipc";
@@ -668,7 +667,6 @@ describe("pickAndOpenFolderInNewWindow", () => {
 
 describe("openPendingLaunchOrReopenLast", () => {
   beforeEach(() => {
-    vi.mocked(takePendingLaunchIPC).mockReset();
     vi.mocked(openProjectIPC).mockClear();
     vi.mocked(openProjectIPC).mockResolvedValue({
       root: "",
@@ -682,16 +680,14 @@ describe("openPendingLaunchOrReopenLast", () => {
   });
 
   it("opens the launch path in this window, winning over reopen-last", async () => {
-    vi.mocked(takePendingLaunchIPC).mockResolvedValue("/proj/launched");
     useSettingsStore.setState({ reopenLastProject: true });
-    await openPendingLaunchOrReopenLast();
+    await openPendingLaunchOrReopenLast("/proj/launched");
     expect(openProjectIPC).toHaveBeenCalledWith("/proj/launched");
   });
 
   it("falls back to reopen-last when there is no launch path", async () => {
-    vi.mocked(takePendingLaunchIPC).mockResolvedValue(null);
     useSettingsStore.setState({ reopenLastProject: false });
-    await openPendingLaunchOrReopenLast();
+    await openPendingLaunchOrReopenLast(null);
     expect(openProjectIPC).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/shell/utils/app.ts
+++ b/frontend/src/shell/utils/app.ts
@@ -11,7 +11,6 @@ import {
   openProjectDialogIPC,
   openProjectInNewWindowIPC,
   readTextFileIPC,
-  takePendingLaunchIPC,
 } from "../ipc";
 import { isSelfWrite } from "./selfWrites";
 
@@ -57,17 +56,17 @@ async function openProjectInNewWindow(path: string): Promise<void> {
   await openProjectInNewWindowIPC(path);
 }
 
-async function pickAndOpenFolderInNewWindow(): Promise<void> {
-  const selected = await openProjectDialogIPC();
+async function pickAndOpenFolderInNewWindow(title?: string): Promise<void> {
+  const selected = await openProjectDialogIPC(title);
   if (typeof selected === "string") {
     await openProjectInNewWindow(selected);
   }
 }
 
-// On launch, a path handed to this process by "open in new window" wins over the
-// auto-reopen-last-project setting; a plain launch falls back to reopen-last.
-async function openPendingLaunchOrReopenLast(): Promise<void> {
-  const pending = await takePendingLaunchIPC().catch(() => null);
+// On launch, a path handed to this process by "open in new window" (read once in
+// bootstrap) wins over the auto-reopen-last-project setting; a plain launch (null)
+// falls back to reopen-last.
+async function openPendingLaunchOrReopenLast(pending: string | null): Promise<void> {
   if (typeof pending === "string" && pending.length > 0) {
     await useProjectStore.getState().openProject(pending).catch(() => {});
     return;

--- a/frontend/src/shell/utils/app.ts
+++ b/frontend/src/shell/utils/app.ts
@@ -7,7 +7,12 @@ import { useProjectStore } from "@shell/hooks/projectStore";
 import { useRecentsStore } from "@shell/hooks/recentsStore";
 import type { DatabaseKind, PersistedTab, QueryLanguage } from "@shared";
 import { useSettingsStore } from "@shared/settings";
-import { openProjectDialogIPC, readTextFileIPC } from "../ipc";
+import {
+  openProjectDialogIPC,
+  openProjectInNewWindowIPC,
+  readTextFileIPC,
+  takePendingLaunchIPC,
+} from "../ipc";
 import { isSelfWrite } from "./selfWrites";
 
 function toPersisted(tabs: EditorTab[]): PersistedTab[] {
@@ -44,6 +49,30 @@ async function openProjectFromMenu(): Promise<void> {
 
 async function handleDroppedPath(path: string): Promise<void> {
   await useProjectStore.getState().openProject(path);
+}
+
+// Open a project in a new window (a fresh app process), leaving this window's
+// project untouched. Caller supplies the path (recent card, drop, menu dialog).
+async function openProjectInNewWindow(path: string): Promise<void> {
+  await openProjectInNewWindowIPC(path);
+}
+
+async function pickAndOpenFolderInNewWindow(): Promise<void> {
+  const selected = await openProjectDialogIPC();
+  if (typeof selected === "string") {
+    await openProjectInNewWindow(selected);
+  }
+}
+
+// On launch, a path handed to this process by "open in new window" wins over the
+// auto-reopen-last-project setting; a plain launch falls back to reopen-last.
+async function openPendingLaunchOrReopenLast(): Promise<void> {
+  const pending = await takePendingLaunchIPC().catch(() => null);
+  if (typeof pending === "string" && pending.length > 0) {
+    await useProjectStore.getState().openProject(pending).catch(() => {});
+    return;
+  }
+  await reopenLastProjectIfNeeded();
 }
 
 async function refreshOnAppFocus(): Promise<void> {
@@ -195,7 +224,10 @@ export {
   isRunnableQueryKind,
   kindForConnection,
   nextFontSize,
+  openPendingLaunchOrReopenLast,
   openProjectFromMenu,
+  openProjectInNewWindow,
+  pickAndOpenFolderInNewWindow,
   queryLanguageForEditorKind,
   refreshOnAppFocus,
   reopenLastProjectIfNeeded,

--- a/frontend/src/shell/utils/commands.ts
+++ b/frontend/src/shell/utils/commands.ts
@@ -33,7 +33,7 @@ import { useChartEditorStore } from "@domains/chart/hooks";
 import { useCommandRegistryStore } from "../hooks/commandRegistryStore";
 import { useFileSearchStore } from "@domains/files/hooks";
 import { useTabsStore } from "../hooks/tabsStore";
-import { openProjectFromMenu } from "./app";
+import { openProjectFromMenu, pickAndOpenFolderInNewWindow } from "./app";
 
 interface CommandSpec {
   run: () => void;
@@ -223,6 +223,7 @@ function useGlobalCommands(): void {
     searchFiles: { run: () => useFileSearchStore.getState().show("file") },
     searchContent: { run: () => useFileSearchStore.getState().show("content") },
     openProject: { run: () => { openProjectFromMenu().catch(() => {}); } },
+    openProjectNewWindow: { run: () => { pickAndOpenFolderInNewWindow().catch(() => {}); } },
     toggleSidebar: { run: () => useSettingsStore.getState().toggleSidebarLeftVisible() },
     showProjectPane: { run: () => useSettingsStore.getState().setSidebarLeftTab("files") },
     showGitPane: {

--- a/src-tauri/src/commands/constants.rs
+++ b/src-tauri/src/commands/constants.rs
@@ -1,0 +1,7 @@
+//! Constants for the Tauri command layer.
+
+/// argv[0] is the executable path; project-path parsing skips it.
+pub const ARGV_PROGRAM_SKIP: usize = 1;
+
+/// Args beginning with this prefix are OS/CLI flags, not a project path.
+pub const ARG_FLAG_PREFIX: char = '-';

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,6 +1,7 @@
 mod agent;
 mod canvas;
 mod connection;
+mod constants;
 mod dbt;
 mod federation;
 mod file;

--- a/src-tauri/src/commands/project.rs
+++ b/src-tauri/src/commands/project.rs
@@ -1,11 +1,32 @@
 use std::path::Path;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use arris_engines::{AppEnvironment, IpcError, ProjectOpenResult};
 use tauri::{Emitter, State};
 
+use crate::commands::constants::{ARGV_PROGRAM_SKIP, ARG_FLAG_PREFIX};
 use crate::helpers::ipc_err;
 use crate::watcher::ProjectWatcher;
+
+/// A project path handed to this process on launch (by "open in new window"),
+/// consumed once by the frontend on startup. Each OS process owns exactly one.
+pub struct PendingLaunch(Mutex<Option<String>>);
+
+impl PendingLaunch {
+    /// Read the launch project path from process args: the first positional
+    /// argument after the program name, skipping OS/CLI flags.
+    pub fn from_args<I: IntoIterator<Item = String>>(args: I) -> Self {
+        let path = args
+            .into_iter()
+            .skip(ARGV_PROGRAM_SKIP)
+            .find(|arg| !arg.starts_with(ARG_FLAG_PREFIX));
+        Self(Mutex::new(path))
+    }
+
+    fn take(&self) -> Option<String> {
+        self.0.lock().expect("PendingLaunch mutex poisoned").take()
+    }
+}
 
 #[tauri::command]
 pub async fn cmd_open_project(
@@ -36,4 +57,58 @@ pub async fn cmd_close_project(
     watcher.stop();
     env.close_project().await;
     Ok(())
+}
+
+/// Open a project in a NEW window by spawning a fresh instance of this app with
+/// the folder path as a launch arg. The new process gets its own isolated
+/// `AppEnvironment`, leaving this window's project untouched.
+#[tauri::command]
+pub fn cmd_open_project_in_new_window(path: String) -> Result<(), IpcError> {
+    let exe = std::env::current_exe().map_err(ipc_err)?;
+    std::process::Command::new(exe)
+        .arg(path)
+        .spawn()
+        .map_err(ipc_err)?;
+    Ok(())
+}
+
+/// Return this process's launch project path once, clearing it so a later
+/// reload does not reopen it.
+#[tauri::command]
+pub fn cmd_take_pending_launch(pending: State<'_, PendingLaunch>) -> Option<String> {
+    pending.take()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn args(parts: &[&str]) -> Vec<String> {
+        parts.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn from_args_picks_first_positional_after_program() {
+        let pending = PendingLaunch::from_args(args(&["/bin/arris", "/home/me/proj"]));
+        assert_eq!(pending.take(), Some("/home/me/proj".to_string()));
+    }
+
+    #[test]
+    fn from_args_skips_leading_flags() {
+        let pending = PendingLaunch::from_args(args(&["/bin/arris", "-psn_0_123", "/home/me/proj"]));
+        assert_eq!(pending.take(), Some("/home/me/proj".to_string()));
+    }
+
+    #[test]
+    fn from_args_is_none_without_a_path() {
+        let pending = PendingLaunch::from_args(args(&["/bin/arris"]));
+        assert_eq!(pending.take(), None);
+    }
+
+    #[test]
+    fn take_clears_after_first_call() {
+        let pending = PendingLaunch::from_args(args(&["/bin/arris", "/proj"]));
+        assert_eq!(pending.take(), Some("/proj".to_string()));
+        assert_eq!(pending.take(), None);
+    }
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -33,6 +33,7 @@ fn main() {
             app.manage(env);
             app.manage(AgentRuns::default());
             app.manage(watcher::ProjectWatcher::default());
+            app.manage(PendingLaunch::from_args(std::env::args()));
 
             let about = AboutMetadataBuilder::new()
                 .name(Some("Arris".to_string()))
@@ -60,6 +61,12 @@ fn main() {
             let open_project_item = MenuItemBuilder::with_id("menu_open_project", "Open...")
                 .accelerator("CmdOrCtrl+O")
                 .build(app)?;
+            let open_project_new_window_item = MenuItemBuilder::with_id(
+                "menu_open_project_new_window",
+                "Open in New Window...",
+            )
+            .accelerator("CmdOrCtrl+Shift+O")
+            .build(app)?;
             let save_file_item = MenuItemBuilder::with_id("menu_save_file", "Save")
                 .accelerator("CmdOrCtrl+S")
                 .build(app)?;
@@ -70,6 +77,7 @@ fn main() {
             let file_submenu = SubmenuBuilder::new(app, "File")
                 .item(&new_project_item)
                 .item(&open_project_item)
+                .item(&open_project_new_window_item)
                 .separator()
                 .item(&save_file_item)
                 .separator()
@@ -118,6 +126,8 @@ fn main() {
                     let _ = handle.emit("menu:new-project", ());
                 } else if id == "menu_open_project" {
                     let _ = handle.emit("menu:open-project", ());
+                } else if id == "menu_open_project_new_window" {
+                    let _ = handle.emit("menu:open-project-new-window", ());
                 } else if id == "menu_save_file" {
                     let _ = handle.emit("menu:save-file", ());
                 } else if id == "menu_close_editor" {
@@ -179,6 +189,8 @@ fn main() {
             cmd_app_preferences_save,
             cmd_list_editor_fonts,
             cmd_open_project,
+            cmd_open_project_in_new_window,
+            cmd_take_pending_launch,
             cmd_close_project,
             cmd_scan_dbt_project,
             cmd_dbt_check_cli,


### PR DESCRIPTION
## What does this PR do?

Opening a project currently replaces the project in the current window. This adds a second option: open it in a new window, leaving the current window untouched.

- New window is a separate OS process spawned with the folder as a launch arg.
- **Backend:** `cmd_open_project_in_new_window` (spawns `current_exe`).
- **Cleanup:** launch path fetched concurrently at boot; deduped the folder picker into one `@shell/utils/app` helper.

## Checklist

- [ ] I opened an issue first for non-trivial changes, or this is a small fix.
- [x] Tests added/updated for my change.
- [x] **I license my contribution under the MIT License**, per [CONTRIBUTING.md](../CONTRIBUTING.md). I confirm this is my original work, or that I have the right to submit it.
