### PR TITLE
[Fix] Persist editor edits and restore exact scroll position

### DIFF
--- a/crates/arris-engines/src/persistence/impl_console_tabs_store.rs
+++ b/crates/arris-engines/src/persistence/impl_console_tabs_store.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use tokio::fs;
 
 use super::impl_json_store::JsonFile;
-use super::{PersistedConsoleTab, StoreError};
+use super::{PersistedConsoleTab, ScrollAnchor, StoreError};
 
 /// On-disk index entry: every field of [`PersistedConsoleTab`] except `text`.
 /// `console_tabs.json` is a flat array of these; the body of each console /
@@ -22,7 +22,7 @@ struct ConsoleTabIndexEntry {
     #[serde(default)]
     cursor: usize,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    scroll_anchor: Option<usize>,
+    scroll_anchor: Option<ScrollAnchor>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     closed: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -396,10 +396,10 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let store = store_in(tmp.path());
         let mut tab = sample_tab();
-        tab.scroll_anchor = Some(123);
+        tab.scroll_anchor = Some(ScrollAnchor { line: 123, offset: 4.5 });
         store.save(&[tab.clone()]).await.unwrap();
         let loaded = store.load().await.unwrap();
-        assert_eq!(loaded[0].scroll_anchor, Some(123));
+        assert_eq!(loaded[0].scroll_anchor, Some(ScrollAnchor { line: 123, offset: 4.5 }));
     }
 
     #[tokio::test]

--- a/crates/arris-engines/src/persistence/impl_console_tabs_store.rs
+++ b/crates/arris-engines/src/persistence/impl_console_tabs_store.rs
@@ -22,6 +22,8 @@ struct ConsoleTabIndexEntry {
     #[serde(default)]
     cursor: usize,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    scroll_anchor: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     closed: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     is_federation: Option<bool>,
@@ -45,6 +47,7 @@ impl ConsoleTabIndexEntry {
             kind: t.kind.clone(),
             connection_id: t.connection_id.clone(),
             cursor: t.cursor,
+            scroll_anchor: t.scroll_anchor,
             closed: t.closed,
             is_federation: t.is_federation,
             tab_type: t.tab_type.clone(),
@@ -65,6 +68,7 @@ impl ConsoleTabIndexEntry {
             kind: self.kind,
             connection_id: self.connection_id,
             cursor: self.cursor,
+            scroll_anchor: self.scroll_anchor,
             closed: self.closed,
             is_federation: self.is_federation,
             tab_type: self.tab_type,
@@ -302,6 +306,7 @@ mod tests {
             kind: "sql".into(),
             connection_id: None,
             cursor: 0,
+            scroll_anchor: None,
             closed: None,
             is_federation: None,
             tab_type: None,
@@ -384,6 +389,17 @@ mod tests {
         store.save(&[tab.clone()]).await.unwrap();
         let loaded = store.load().await.unwrap();
         assert_eq!(loaded[0].tab_type.as_deref(), Some("console"));
+    }
+
+    #[tokio::test]
+    async fn round_trip_persists_scroll_anchor() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = store_in(tmp.path());
+        let mut tab = sample_tab();
+        tab.scroll_anchor = Some(123);
+        store.save(&[tab.clone()]).await.unwrap();
+        let loaded = store.load().await.unwrap();
+        assert_eq!(loaded[0].scroll_anchor, Some(123));
     }
 
     #[tokio::test]

--- a/crates/arris-engines/src/persistence/impl_console_tabs_store.rs
+++ b/crates/arris-engines/src/persistence/impl_console_tabs_store.rs
@@ -396,10 +396,10 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let store = store_in(tmp.path());
         let mut tab = sample_tab();
-        tab.scroll_anchor = Some(ScrollAnchor { line: 123, offset: 4.5 });
+        tab.scroll_anchor = Some(ScrollAnchor { line: 123, offset: -4.5 });
         store.save(&[tab.clone()]).await.unwrap();
         let loaded = store.load().await.unwrap();
-        assert_eq!(loaded[0].scroll_anchor, Some(ScrollAnchor { line: 123, offset: 4.5 }));
+        assert_eq!(loaded[0].scroll_anchor, Some(ScrollAnchor { line: 123, offset: -4.5 }));
     }
 
     #[tokio::test]

--- a/crates/arris-engines/src/persistence/types.rs
+++ b/crates/arris-engines/src/persistence/types.rs
@@ -311,11 +311,8 @@ impl Default for AppPreferences {
     }
 }
 
-/// Runtime / IPC shape of a persisted console or notebook tab. Carries the live
-/// `text` (SQL body or full nbformat `.ipynb` JSON). On disk the text lives in a
-/// sidecar file, never inline in the index (see `ConsoleTabsStore`).
-/// Top-of-viewport row (`line`, char offset) plus its sub-line pixel remainder
-/// (`offset`), so the editor restores the exact scroll position on reopen.
+/// CodeMirror scroll snapshot: anchor row `line` (char offset) plus `offset` =
+/// row top minus scrollTop in pixels (<= 0), for pixel-exact restore.
 #[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ScrollAnchor {
@@ -323,6 +320,9 @@ pub struct ScrollAnchor {
     pub offset: f64,
 }
 
+/// Runtime / IPC shape of a persisted console or notebook tab. Carries the live
+/// `text` (SQL body or full nbformat `.ipynb` JSON). On disk the text lives in a
+/// sidecar file, never inline in the index (see `ConsoleTabsStore`).
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PersistedConsoleTab {

--- a/crates/arris-engines/src/persistence/types.rs
+++ b/crates/arris-engines/src/persistence/types.rs
@@ -314,6 +314,15 @@ impl Default for AppPreferences {
 /// Runtime / IPC shape of a persisted console or notebook tab. Carries the live
 /// `text` (SQL body or full nbformat `.ipynb` JSON). On disk the text lives in a
 /// sidecar file, never inline in the index (see `ConsoleTabsStore`).
+/// Top-of-viewport row (`line`, char offset) plus its sub-line pixel remainder
+/// (`offset`), so the editor restores the exact scroll position on reopen.
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ScrollAnchor {
+    pub line: usize,
+    pub offset: f64,
+}
+
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PersistedConsoleTab {
@@ -325,11 +334,8 @@ pub struct PersistedConsoleTab {
     pub connection_id: Option<String>,
     #[serde(default)]
     pub cursor: usize,
-    /// Char offset of the line to re-anchor at the top of the viewport on
-    /// reopen, so the editor restores the row the user was viewing instead of
-    /// jumping to the caret line.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub scroll_anchor: Option<usize>,
+    pub scroll_anchor: Option<ScrollAnchor>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub closed: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/arris-engines/src/persistence/types.rs
+++ b/crates/arris-engines/src/persistence/types.rs
@@ -325,6 +325,11 @@ pub struct PersistedConsoleTab {
     pub connection_id: Option<String>,
     #[serde(default)]
     pub cursor: usize,
+    /// Char offset of the line to re-anchor at the top of the viewport on
+    /// reopen, so the editor restores the row the user was viewing instead of
+    /// jumping to the caret line.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scroll_anchor: Option<usize>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub closed: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/frontend/src/domains/editor/components/EditorPane/index.test.tsx
+++ b/frontend/src/domains/editor/components/EditorPane/index.test.tsx
@@ -1356,23 +1356,20 @@ describe("tab-switch edit persistence", () => {
     expect(cmDocText()).toContain("aaa edited");
   });
 
-  it("captures the scroll offset into the leaving tab on switch, and restores it on return", () => {
-    const t1 = { ...tabFor("c1"), id: "t1", title: "A", text: "aaa" } as EditorTab;
+  it("records the top-row scroll anchor onto the leaving tab when switching away", () => {
+    const doc = Array.from({ length: 60 }, (_, i) => `line ${i + 1}`).join("\n");
+    const t1 = { ...tabFor("c1"), id: "t1", title: "A", text: doc } as EditorTab;
     const t2 = { ...tabFor("c1"), id: "t2", title: "B", text: "bbb" } as EditorTab;
     useTabsStore.setState({ tabs: [], layout: null, focusedPaneGroupId: null, activeId: null });
     useTabsStore.getState().setTabs([t1, t2]);
     useTabsStore.getState().focusTab("t1");
     render(<EditorPane />);
 
-    const scroller = document.querySelector(".cm-scroller") as HTMLElement;
-    scroller.scrollTop = 250;
-
     act(() => { useTabsStore.getState().focusTab("t2"); });
-    // The offset the user left t1 at is recorded on the tab, not lost.
-    expect(useTabsStore.getState().tabs.find((t) => t.id === "t1")?.scrollTop).toBe(250);
-
-    act(() => { useTabsStore.getState().focusTab("t1"); });
-    expect((document.querySelector(".cm-scroller") as HTMLElement).scrollTop).toBe(250);
+    // A numeric anchor (char offset of the top line) is captured on the tab we
+    // left, so the remount can re-anchor instead of jumping to the caret.
+    const anchor = useTabsStore.getState().tabs.find((t) => t.id === "t1")?.scrollAnchor;
+    expect(anchor).toBeTypeOf("number");
   });
 });
 

--- a/frontend/src/domains/editor/components/EditorPane/index.test.tsx
+++ b/frontend/src/domains/editor/components/EditorPane/index.test.tsx
@@ -1355,6 +1355,25 @@ describe("tab-switch edit persistence", () => {
     act(() => { useTabsStore.getState().focusTab("t1"); });
     expect(cmDocText()).toContain("aaa edited");
   });
+
+  it("captures the scroll offset into the leaving tab on switch, and restores it on return", () => {
+    const t1 = { ...tabFor("c1"), id: "t1", title: "A", text: "aaa" } as EditorTab;
+    const t2 = { ...tabFor("c1"), id: "t2", title: "B", text: "bbb" } as EditorTab;
+    useTabsStore.setState({ tabs: [], layout: null, focusedPaneGroupId: null, activeId: null });
+    useTabsStore.getState().setTabs([t1, t2]);
+    useTabsStore.getState().focusTab("t1");
+    render(<EditorPane />);
+
+    const scroller = document.querySelector(".cm-scroller") as HTMLElement;
+    scroller.scrollTop = 250;
+
+    act(() => { useTabsStore.getState().focusTab("t2"); });
+    // The offset the user left t1 at is recorded on the tab, not lost.
+    expect(useTabsStore.getState().tabs.find((t) => t.id === "t1")?.scrollTop).toBe(250);
+
+    act(() => { useTabsStore.getState().focusTab("t1"); });
+    expect((document.querySelector(".cm-scroller") as HTMLElement).scrollTop).toBe(250);
+  });
 });
 
 // Typing writes text/cursor/selection to the tabs store on every keystroke.

--- a/frontend/src/domains/editor/components/EditorPane/index.test.tsx
+++ b/frontend/src/domains/editor/components/EditorPane/index.test.tsx
@@ -1366,10 +1366,11 @@ describe("tab-switch edit persistence", () => {
     render(<EditorPane />);
 
     act(() => { useTabsStore.getState().focusTab("t2"); });
-    // A numeric anchor (char offset of the top line) is captured on the tab we
-    // left, so the remount can re-anchor instead of jumping to the caret.
+    // A row + pixel anchor is captured on the tab we left, so the remount can
+    // re-anchor instead of jumping to the caret.
     const anchor = useTabsStore.getState().tabs.find((t) => t.id === "t1")?.scrollAnchor;
-    expect(anchor).toBeTypeOf("number");
+    expect(anchor?.line).toBeTypeOf("number");
+    expect(anchor?.offset).toBeTypeOf("number");
   });
 });
 

--- a/frontend/src/domains/editor/components/EditorPane/index.test.tsx
+++ b/frontend/src/domains/editor/components/EditorPane/index.test.tsx
@@ -1326,6 +1326,37 @@ describe("statement highlight box", () => {
   });
 });
 
+// The pane keeps text stale in render (volatile-field equality), so the mount
+// effect must seed the editor from the LIVE store on remount. Otherwise a tab
+// switch remounts with pre-edit text and discards unsaved keystrokes.
+describe("tab-switch edit persistence", () => {
+  function cmDocText(): string {
+    const content = document.querySelector(".cm-content") as HTMLElement | null;
+    return content?.textContent ?? "";
+  }
+
+  it("preserves unsaved edits when switching away from a tab and back", () => {
+    const t1 = { ...tabFor("c1"), id: "t1", title: "A", text: "aaa" } as EditorTab;
+    const t2 = { ...tabFor("c1"), id: "t2", title: "B", text: "bbb" } as EditorTab;
+    useTabsStore.setState({ tabs: [], layout: null, focusedPaneGroupId: null, activeId: null });
+    useTabsStore.getState().setTabs([t1, t2]);
+    useTabsStore.getState().focusTab("t1");
+    render(<EditorPane />);
+    expect(cmDocText()).toContain("aaa");
+
+    // Simulate per-keystroke store writes for the active tab (volatile fields).
+    act(() => {
+      useTabsStore.getState().updateTab("t1", { text: "aaa edited", cursor: 10 });
+    });
+
+    act(() => { useTabsStore.getState().focusTab("t2"); });
+    expect(cmDocText()).toContain("bbb");
+
+    act(() => { useTabsStore.getState().focusTab("t1"); });
+    expect(cmDocText()).toContain("aaa edited");
+  });
+});
+
 // Typing writes text/cursor/selection to the tabs store on every keystroke.
 // The pane subscribes with an equality fn that ignores those fields, so pure
 // typing churn must produce ZERO React commits in the editor pane; structural

--- a/frontend/src/domains/editor/components/EditorPane/index.tsx
+++ b/frontend/src/domains/editor/components/EditorPane/index.tsx
@@ -841,6 +841,7 @@ function PaneGroupView({ groupId }: { groupId: string }) {
       host: editorHostRef.current,
       initialDoc: seed.text,
       initialCursor: seed.cursor,
+      initialScrollTop: seed.scrollTop,
       // One patch per editor update: a keystroke changes doc AND selection, so
       // separate callbacks meant three store writes (and three re-render waves
       // through every tab subscriber) per key. Single write instead.
@@ -921,6 +922,9 @@ function PaneGroupView({ groupId }: { groupId: string }) {
     editorHandleRef.current = handle;
     useEditorHandleStore.getState().setHandle(handle, activeTab?.id ?? null);
     return () => {
+      // Remember where this tab was scrolled so switching back restores it
+      // instead of jumping to the caret line on remount.
+      updateTab(activeTab.id, { scrollTop: handle.getScrollTop() });
       editorHandleRef.current = null;
       useEditorHandleStore.getState().clearHandle();
       handle.destroy();

--- a/frontend/src/domains/editor/components/EditorPane/index.tsx
+++ b/frontend/src/domains/editor/components/EditorPane/index.tsx
@@ -841,7 +841,7 @@ function PaneGroupView({ groupId }: { groupId: string }) {
       host: editorHostRef.current,
       initialDoc: seed.text,
       initialCursor: seed.cursor,
-      initialScrollTop: seed.scrollTop,
+      initialScrollAnchor: seed.scrollAnchor,
       // One patch per editor update: a keystroke changes doc AND selection, so
       // separate callbacks meant three store writes (and three re-render waves
       // through every tab subscriber) per key. Single write instead.
@@ -922,9 +922,9 @@ function PaneGroupView({ groupId }: { groupId: string }) {
     editorHandleRef.current = handle;
     useEditorHandleStore.getState().setHandle(handle, activeTab?.id ?? null);
     return () => {
-      // Remember where this tab was scrolled so switching back restores it
-      // instead of jumping to the caret line on remount.
-      updateTab(activeTab.id, { scrollTop: handle.getScrollTop() });
+      // Remember the top row so switching back restores it instead of jumping
+      // to the caret line on remount.
+      updateTab(activeTab.id, { scrollAnchor: handle.getScrollAnchor() });
       editorHandleRef.current = null;
       useEditorHandleStore.getState().clearHandle();
       handle.destroy();

--- a/frontend/src/domains/editor/components/EditorPane/index.tsx
+++ b/frontend/src/domains/editor/components/EditorPane/index.tsx
@@ -854,6 +854,7 @@ function PaneGroupView({ groupId }: { groupId: string }) {
         }
         if (currentSqlMeshModel) markRenderedStale(currentSqlMeshModel.name);
       },
+      onScroll: (anchor) => updateTab(activeTab.id, { scrollAnchor: anchor }),
       languageId: activeTab.kind,
       fileName: activeTab.filePath,
       connectionKind: tabConnection?.kind,

--- a/frontend/src/domains/editor/components/EditorPane/index.tsx
+++ b/frontend/src/domains/editor/components/EditorPane/index.tsx
@@ -833,10 +833,14 @@ function PaneGroupView({ groupId }: { groupId: string }) {
 
   useEffect(() => {
     if (!editorHostRef.current || !activeTab) return;
+    // Seed from the live store, not the render-scope activeTab: text/cursor are
+    // volatile fields kept stale in render, so a tab switch would otherwise
+    // remount with pre-edit text and discard unsaved keystrokes.
+    const seed = freshActiveTab() ?? activeTab;
     const handle = mountEditor({
       host: editorHostRef.current,
-      initialDoc: activeTab.text,
-      initialCursor: activeTab.cursor,
+      initialDoc: seed.text,
+      initialCursor: seed.cursor,
       // One patch per editor update: a keystroke changes doc AND selection, so
       // separate callbacks meant three store writes (and three re-render waves
       // through every tab subscriber) per key. Single write instead.

--- a/frontend/src/domains/editor/components/EditorPane/utils.ts
+++ b/frontend/src/domains/editor/components/EditorPane/utils.ts
@@ -331,7 +331,7 @@ function exportActiveResults(format: ExportFormat): boolean {
 // need structural tab state (id/kind/title/result/isRunning/...) compare with
 // these ignored so typing does not re-render the whole pane group; handlers
 // that need the live buffer read it from the store at invocation time.
-const VOLATILE_TAB_FIELDS = new Set(["text", "cursor", "selection"]);
+const VOLATILE_TAB_FIELDS = new Set(["text", "cursor", "selection", "scrollTop"]);
 
 function tabEqualIgnoringVolatile(
   a: EditorTab | null | undefined,

--- a/frontend/src/domains/editor/components/EditorPane/utils.ts
+++ b/frontend/src/domains/editor/components/EditorPane/utils.ts
@@ -331,7 +331,7 @@ function exportActiveResults(format: ExportFormat): boolean {
 // need structural tab state (id/kind/title/result/isRunning/...) compare with
 // these ignored so typing does not re-render the whole pane group; handlers
 // that need the live buffer read it from the store at invocation time.
-const VOLATILE_TAB_FIELDS = new Set(["text", "cursor", "selection", "scrollTop"]);
+const VOLATILE_TAB_FIELDS = new Set(["text", "cursor", "selection", "scrollAnchor"]);
 
 function tabEqualIgnoringVolatile(
   a: EditorTab | null | undefined,

--- a/frontend/src/domains/editor/utils/ui/constants.ts
+++ b/frontend/src/domains/editor/utils/ui/constants.ts
@@ -15,4 +15,8 @@ const SEMANTIC_CONTEXT_CHARS = 4000;
 // plugin rebuilds when the background parser finishes (tree identity check).
 const SEMANTIC_PARSE_BUDGET_MS = 50;
 
-export { SEMANTIC_CONTEXT_CHARS, SEMANTIC_PARSE_BUDGET_MS };
+// Debounce for persisting the scroll anchor while the user scrolls. Coalesces
+// the rapid scroll-event stream into one store write once scrolling settles.
+const SCROLL_ANCHOR_DEBOUNCE_MS = 150;
+
+export { SEMANTIC_CONTEXT_CHARS, SEMANTIC_PARSE_BUDGET_MS, SCROLL_ANCHOR_DEBOUNCE_MS };

--- a/frontend/src/domains/editor/utils/ui/constants.ts
+++ b/frontend/src/domains/editor/utils/ui/constants.ts
@@ -19,18 +19,8 @@ const SEMANTIC_PARSE_BUDGET_MS = 50;
 // the rapid scroll-event stream into one store write once scrolling settles.
 const SCROLL_ANCHOR_DEBOUNCE_MS = 150;
 
-// Pixel inset from the scroller's top-left corner when sampling the top row, to
-// clear the border edge.
-const ANCHOR_SAMPLE_INSET_PX = 1;
-
-// No margin when re-scrolling the anchor row to the top; the pixel remainder is
-// reapplied separately, so a margin would double-count.
-const ANCHOR_SCROLL_Y_MARGIN_PX = 0;
-
 export {
   SEMANTIC_CONTEXT_CHARS,
   SEMANTIC_PARSE_BUDGET_MS,
   SCROLL_ANCHOR_DEBOUNCE_MS,
-  ANCHOR_SAMPLE_INSET_PX,
-  ANCHOR_SCROLL_Y_MARGIN_PX,
 };

--- a/frontend/src/domains/editor/utils/ui/constants.ts
+++ b/frontend/src/domains/editor/utils/ui/constants.ts
@@ -19,4 +19,18 @@ const SEMANTIC_PARSE_BUDGET_MS = 50;
 // the rapid scroll-event stream into one store write once scrolling settles.
 const SCROLL_ANCHOR_DEBOUNCE_MS = 150;
 
-export { SEMANTIC_CONTEXT_CHARS, SEMANTIC_PARSE_BUDGET_MS, SCROLL_ANCHOR_DEBOUNCE_MS };
+// Pixel inset from the scroller's top-left corner when sampling the top row, to
+// clear the border edge.
+const ANCHOR_SAMPLE_INSET_PX = 1;
+
+// No margin when re-scrolling the anchor row to the top; the pixel remainder is
+// reapplied separately, so a margin would double-count.
+const ANCHOR_SCROLL_Y_MARGIN_PX = 0;
+
+export {
+  SEMANTIC_CONTEXT_CHARS,
+  SEMANTIC_PARSE_BUDGET_MS,
+  SCROLL_ANCHOR_DEBOUNCE_MS,
+  ANCHOR_SAMPLE_INSET_PX,
+  ANCHOR_SCROLL_Y_MARGIN_PX,
+};

--- a/frontend/src/domains/editor/utils/ui/setup.test.ts
+++ b/frontend/src/domains/editor/utils/ui/setup.test.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 
 import { mountEditor, type EditorHandle } from "./setup";
+import { SCROLL_ANCHOR_DEBOUNCE_MS } from "./constants";
 import { SCHEMA_NODE_DRAG_MIME } from "./schemaDrag";
 import { useSettingsStore } from "@shared/settings";
 
@@ -72,6 +73,21 @@ describe("mountEditor scroll restore", () => {
     });
     expect(host.querySelector(".cm-editor")).toBeTruthy();
     expect(unmount.getScrollAnchor()).toBeTypeOf("number");
+  });
+
+  it("reports the anchor to onScroll (debounced) when the viewport scrolls", () => {
+    let reported: number | null = null;
+    unmount = mountEditor({
+      host,
+      initialDoc: longDoc,
+      languageId: "sql",
+      onScroll: (a) => { reported = a; },
+    });
+    vi.useFakeTimers();
+    (host.querySelector(".cm-scroller") as HTMLElement).dispatchEvent(new Event("scroll"));
+    vi.advanceTimersByTime(SCROLL_ANCHOR_DEBOUNCE_MS + 10);
+    vi.useRealTimers();
+    expect(reported).toBeTypeOf("number");
   });
 });
 

--- a/frontend/src/domains/editor/utils/ui/setup.test.ts
+++ b/frontend/src/domains/editor/utils/ui/setup.test.ts
@@ -50,6 +50,33 @@ describe("mountEditor json read-only", () => {
   });
 });
 
+describe("mountEditor scroll restore", () => {
+  const longDoc = Array.from({ length: 200 }, (_, i) => `line ${i + 1}`).join("\n");
+
+  it("restores initialScrollTop and reads it back via getScrollTop", () => {
+    unmount = mountEditor({
+      host,
+      initialDoc: longDoc,
+      languageId: "sql",
+      initialScrollTop: 640,
+    });
+    expect(unmount.getScrollTop()).toBe(640);
+  });
+
+  it("does not scroll to the caret when a scroll offset is restored", () => {
+    // Caret deep in the doc but the user was scrolled to the top: the restored
+    // offset must win so switching back does not jump to the caret line.
+    unmount = mountEditor({
+      host,
+      initialDoc: longDoc,
+      languageId: "sql",
+      initialCursor: longDoc.length,
+      initialScrollTop: 0,
+    });
+    expect(unmount.getScrollTop()).toBe(0);
+  });
+});
+
 describe("mountEditor gutter strip", () => {
   // the run-status icon must sit INSIDE the same strip as the line
   // number (JetBrains-style), universally. The whole gutter band shares the

--- a/frontend/src/domains/editor/utils/ui/setup.test.ts
+++ b/frontend/src/domains/editor/utils/ui/setup.test.ts
@@ -69,7 +69,7 @@ describe("mountEditor scroll restore", () => {
       initialDoc: longDoc,
       languageId: "sql",
       initialCursor: longDoc.length,
-      initialScrollAnchor: { line: line40, offset: 6 },
+      initialScrollAnchor: { line: line40, offset: -6 },
     });
     expect(host.querySelector(".cm-editor")).toBeTruthy();
     expect(unmount.getScrollAnchor().line).toBeTypeOf("number");

--- a/frontend/src/domains/editor/utils/ui/setup.test.ts
+++ b/frontend/src/domains/editor/utils/ui/setup.test.ts
@@ -53,27 +53,25 @@ describe("mountEditor json read-only", () => {
 describe("mountEditor scroll restore", () => {
   const longDoc = Array.from({ length: 200 }, (_, i) => `line ${i + 1}`).join("\n");
 
-  it("restores initialScrollTop and reads it back via getScrollTop", () => {
-    unmount = mountEditor({
-      host,
-      initialDoc: longDoc,
-      languageId: "sql",
-      initialScrollTop: 640,
-    });
-    expect(unmount.getScrollTop()).toBe(640);
+  it("reports the top line's char offset as the scroll anchor (0 at the top)", () => {
+    unmount = mountEditor({ host, initialDoc: longDoc, languageId: "sql" });
+    // Fresh mount sits at the top, so the anchor is the first line's offset.
+    expect(unmount.getScrollAnchor()).toBe(0);
   });
 
-  it("does not scroll to the caret when a scroll offset is restored", () => {
-    // Caret deep in the doc but the user was scrolled to the top: the restored
-    // offset must win so switching back does not jump to the caret line.
+  it("accepts a restored anchor without throwing and mounts the editor", () => {
+    // Anchor at the start of line 40; the restore path scrolls that line to the
+    // top instead of revealing the caret.
+    const line40 = longDoc.split("\n").slice(0, 39).join("\n").length + 1;
     unmount = mountEditor({
       host,
       initialDoc: longDoc,
       languageId: "sql",
       initialCursor: longDoc.length,
-      initialScrollTop: 0,
+      initialScrollAnchor: line40,
     });
-    expect(unmount.getScrollTop()).toBe(0);
+    expect(host.querySelector(".cm-editor")).toBeTruthy();
+    expect(unmount.getScrollAnchor()).toBeTypeOf("number");
   });
 });
 

--- a/frontend/src/domains/editor/utils/ui/setup.test.ts
+++ b/frontend/src/domains/editor/utils/ui/setup.test.ts
@@ -54,14 +54,14 @@ describe("mountEditor json read-only", () => {
 describe("mountEditor scroll restore", () => {
   const longDoc = Array.from({ length: 200 }, (_, i) => `line ${i + 1}`).join("\n");
 
-  it("reports the top line's char offset as the scroll anchor (0 at the top)", () => {
+  it("reports the top row and zero pixel offset as the anchor at the top", () => {
     unmount = mountEditor({ host, initialDoc: longDoc, languageId: "sql" });
-    // Fresh mount sits at the top, so the anchor is the first line's offset.
-    expect(unmount.getScrollAnchor()).toBe(0);
+    // Fresh mount sits at the top: first row, no sub-line remainder.
+    expect(unmount.getScrollAnchor()).toEqual({ line: 0, offset: 0 });
   });
 
   it("accepts a restored anchor without throwing and mounts the editor", () => {
-    // Anchor at the start of line 40; the restore path scrolls that line to the
+    // Anchor at the start of line 40; the restore path scrolls that row to the
     // top instead of revealing the caret.
     const line40 = longDoc.split("\n").slice(0, 39).join("\n").length + 1;
     unmount = mountEditor({
@@ -69,14 +69,14 @@ describe("mountEditor scroll restore", () => {
       initialDoc: longDoc,
       languageId: "sql",
       initialCursor: longDoc.length,
-      initialScrollAnchor: line40,
+      initialScrollAnchor: { line: line40, offset: 6 },
     });
     expect(host.querySelector(".cm-editor")).toBeTruthy();
-    expect(unmount.getScrollAnchor()).toBeTypeOf("number");
+    expect(unmount.getScrollAnchor().line).toBeTypeOf("number");
   });
 
   it("reports the anchor to onScroll (debounced) when the viewport scrolls", () => {
-    let reported: number | null = null;
+    let reported: { line: number; offset: number } | null = null;
     unmount = mountEditor({
       host,
       initialDoc: longDoc,
@@ -87,7 +87,8 @@ describe("mountEditor scroll restore", () => {
     (host.querySelector(".cm-scroller") as HTMLElement).dispatchEvent(new Event("scroll"));
     vi.advanceTimersByTime(SCROLL_ANCHOR_DEBOUNCE_MS + 10);
     vi.useRealTimers();
-    expect(reported).toBeTypeOf("number");
+    expect(reported).not.toBeNull();
+    expect(reported!.line).toBeTypeOf("number");
   });
 });
 

--- a/frontend/src/domains/editor/utils/ui/setup.test.ts
+++ b/frontend/src/domains/editor/utils/ui/setup.test.ts
@@ -78,6 +78,21 @@ describe("mountEditor scroll restore", () => {
     expect(unmount.getScrollAnchor()).toEqual({ line: line40, offset: -6 });
   });
 
+  it("keeps the settled anchor when the viewport height changes before the read", () => {
+    // Tab switch away from a markdown tab removes the mode bar in the same
+    // commit that unmounts the editor; the host resize clamps scrollTop before
+    // the cleanup reads. A height mismatch must return the settled anchor.
+    unmount = mountEditor({
+      host,
+      initialDoc: longDoc,
+      languageId: "sql",
+      initialScrollAnchor: { line: 100, offset: -3 },
+    });
+    const scroller = host.querySelector(".cm-scroller") as HTMLElement;
+    Object.defineProperty(scroller, "clientHeight", { value: 30, configurable: true });
+    expect(unmount.getScrollAnchor()).toEqual({ line: 100, offset: -3 });
+  });
+
   it("reports the anchor to onScroll (debounced) when the viewport scrolls", () => {
     let reported: { line: number; offset: number } | null = null;
     unmount = mountEditor({

--- a/frontend/src/domains/editor/utils/ui/setup.test.ts
+++ b/frontend/src/domains/editor/utils/ui/setup.test.ts
@@ -60,9 +60,12 @@ describe("mountEditor scroll restore", () => {
     expect(unmount.getScrollAnchor()).toEqual({ line: 0, offset: 0 });
   });
 
-  it("accepts a restored anchor without throwing and mounts the editor", () => {
+  it("round-trips a restored anchor read back before CodeMirror applies it", () => {
     // Anchor at the start of line 40; the restore path scrolls that row to the
-    // top instead of revealing the caret.
+    // top instead of revealing the caret. Reading the anchor back BEFORE the
+    // next measure (the app remounts the editor when effect deps settle right
+    // after a tab switch) must return the pending anchor unchanged, not the
+    // still-unscrolled top of the document.
     const line40 = longDoc.split("\n").slice(0, 39).join("\n").length + 1;
     unmount = mountEditor({
       host,
@@ -72,7 +75,7 @@ describe("mountEditor scroll restore", () => {
       initialScrollAnchor: { line: line40, offset: -6 },
     });
     expect(host.querySelector(".cm-editor")).toBeTruthy();
-    expect(unmount.getScrollAnchor().line).toBeTypeOf("number");
+    expect(unmount.getScrollAnchor()).toEqual({ line: line40, offset: -6 });
   });
 
   it("reports the anchor to onScroll (debounced) when the viewport scrolls", () => {

--- a/frontend/src/domains/editor/utils/ui/setup.ts
+++ b/frontend/src/domains/editor/utils/ui/setup.ts
@@ -1,12 +1,8 @@
 // CodeMirror 6 mount / unmount helper. Wraps the per-tab editor lifecycle so
 // the React component can stay declarative.
 
-import {
-  SCROLL_ANCHOR_DEBOUNCE_MS,
-  ANCHOR_SAMPLE_INSET_PX,
-  ANCHOR_SCROLL_Y_MARGIN_PX,
-} from "./constants";
-import { Compartment, EditorState, Prec } from "@codemirror/state";
+import { SCROLL_ANCHOR_DEBOUNCE_MS } from "./constants";
+import { Compartment, EditorSelection, EditorState, Prec } from "@codemirror/state";
 import {
   EditorView,
   lineNumbers,
@@ -579,31 +575,26 @@ function mountEditor(opts: MountOptions): EditorHandle {
   view.dom.dataset.arrisLang = opts.languageId;
   if (opts.connectionKind) view.dom.dataset.arrisConnectionKind = opts.connectionKind;
 
-  // Top-of-viewport row plus how far it is scrolled above the fold, read from
-  // real geometry so restore reproduces the exact pixel, not just the row start.
+  // CodeMirror's own scroll snapshot: anchor row `line` plus `offset` = row top
+  // minus scrollTop, computed from internal geometry (immune to surrounding
+  // layout like the markdown mode bar, unlike client-coords sampling).
   const readScrollAnchor = (): ScrollAnchor => {
-    const rect = view.scrollDOM.getBoundingClientRect();
-    const pos = view.posAtCoords({
-      x: rect.left + ANCHOR_SAMPLE_INSET_PX,
-      y: rect.top + ANCHOR_SAMPLE_INSET_PX,
-    });
-    if (pos == null) return { line: 0, offset: 0 };
-    const line = view.state.doc.lineAt(pos).from;
-    const coords = view.coordsAtPos(line);
-    const offset = coords ? Math.max(0, rect.top - coords.top) : 0;
-    return { line, offset };
+    const target = view.scrollSnapshot().value;
+    return { line: target.range.head, offset: target.yMargin };
   };
 
   // A restored anchor (tab switch) wins over the cursor reveal; else reveal the
   // opened offset (e.g. clicking a SQLMesh test in the side pane).
   if (opts.initialScrollAnchor) {
     const pos = clampCursor(opts.initialDoc, opts.initialScrollAnchor.line);
-    const px = opts.initialScrollAnchor.offset;
-    view.dispatch({
-      effects: EditorView.scrollIntoView(pos, { y: "start", yMargin: ANCHOR_SCROLL_Y_MARGIN_PX }),
-    });
-    // Reapply the sub-line remainder after CodeMirror has scrolled and measured.
-    if (px > 0) view.requestMeasure({ read: () => {}, write: () => { view.scrollDOM.scrollTop += px; } });
+    // Rebuild a snapshot target for the saved anchor (the ScrollTarget class is
+    // not exported, so retarget a fresh snapshot). CodeMirror applies snapshot
+    // targets after its measure loop settles, making the restore pixel-exact.
+    const snapshot = view.scrollSnapshot();
+    const target = snapshot.value as { range: unknown; yMargin: number };
+    target.range = EditorSelection.cursor(pos);
+    target.yMargin = opts.initialScrollAnchor.offset;
+    view.dispatch({ effects: snapshot });
   } else if (typeof opts.initialCursor === "number" && opts.initialCursor > 0) {
     const pos = clampCursor(opts.initialDoc, opts.initialCursor);
     view.dispatch({ effects: EditorView.scrollIntoView(pos, { y: "start" }) });

--- a/frontend/src/domains/editor/utils/ui/setup.ts
+++ b/frontend/src/domains/editor/utils/ui/setup.ts
@@ -579,6 +579,15 @@ function mountEditor(opts: MountOptions): EditorHandle {
   // minus scrollTop, computed from internal geometry (immune to surrounding
   // layout like the markdown mode bar, unlike client-coords sampling).
   const readScrollAnchor = (): ScrollAnchor => {
+    // A dispatched restore CodeMirror has not applied yet (unmount races the
+    // next measure, e.g. an editor remount from an effect-deps change) must
+    // round-trip unchanged instead of reading back as top-of-doc.
+    const pending = (
+      view as unknown as {
+        viewState: { scrollTarget: { range: { head: number }; yMargin: number; isSnapshot?: boolean } | null };
+      }
+    ).viewState.scrollTarget;
+    if (pending?.isSnapshot) return { line: pending.range.head, offset: pending.yMargin };
     const target = view.scrollSnapshot().value;
     return { line: target.range.head, offset: target.yMargin };
   };

--- a/frontend/src/domains/editor/utils/ui/setup.ts
+++ b/frontend/src/domains/editor/utils/ui/setup.ts
@@ -1,6 +1,7 @@
 // CodeMirror 6 mount / unmount helper. Wraps the per-tab editor lifecycle so
 // the React component can stay declarative.
 
+import { SCROLL_ANCHOR_DEBOUNCE_MS } from "./constants";
 import { Compartment, EditorState, Prec } from "@codemirror/state";
 import {
   EditorView,
@@ -74,6 +75,9 @@ interface MountOptions {
   /// are present only when the selection changed; `selection.from`/`to` are
   /// equal for a collapsed caret, a non-empty range means text is highlighted.
   onEdit?: (patch: EditorEditPatch) => void;
+  /// Fired (debounced) when the user scrolls, with the char offset of the line
+  /// now at the top of the viewport, so the owner can persist it for restore.
+  onScroll?: (anchor: number) => void;
   languageId: string;
   /// DatabaseKind of the tab's connection; picks the SQL dialect when `languageId === "sql"`.
   connectionKind?: DatabaseKind;
@@ -591,11 +595,33 @@ function mountEditor(opts: MountOptions): EditorHandle {
     view.dispatch({ effects: EditorView.scrollIntoView(pos, { y: "start" }) });
   }
 
+  // Char offset of the line at the top of the viewport. Resolved from real
+  // rendered geometry (the pixel at the viewport's top edge) rather than mapping
+  // scrollTop through block heights, which mixes coordinate spaces and drifts by
+  // the content's top padding.
+  const readScrollAnchor = (): number => {
+    const rect = view.scrollDOM.getBoundingClientRect();
+    const pos = view.posAtCoords({ x: rect.left + 1, y: rect.top + 1 });
+    return pos == null ? 0 : view.state.doc.lineAt(pos).from;
+  };
+
+  // Persist the anchor as the user scrolls (debounced) so restore works without
+  // relying on unmount/quit hooks, which don't fire reliably in the webview.
+  let scrollTimer: ReturnType<typeof setTimeout> | null = null;
+  const onScrollDom = () => {
+    if (!opts.onScroll) return;
+    if (scrollTimer) clearTimeout(scrollTimer);
+    scrollTimer = setTimeout(() => opts.onScroll?.(readScrollAnchor()), SCROLL_ANCHOR_DEBOUNCE_MS);
+  };
+  view.scrollDOM.addEventListener("scroll", onScrollDom, { passive: true });
+
   return {
-    destroy: () => view.destroy(),
-    // Char offset of the line at the top of the viewport, for line-anchored
-    // scroll restore across a remount.
-    getScrollAnchor: () => view.lineBlockAtHeight(view.scrollDOM.scrollTop).from,
+    destroy: () => {
+      if (scrollTimer) clearTimeout(scrollTimer);
+      view.scrollDOM.removeEventListener("scroll", onScrollDom);
+      view.destroy();
+    },
+    getScrollAnchor: readScrollAnchor,
     updateCompletionSchema: (updateOpts: CompletionUpdateOpts) => {
       const newExt = editorCompletionExtensions({
         languageId: opts.languageId,

--- a/frontend/src/domains/editor/utils/ui/setup.ts
+++ b/frontend/src/domains/editor/utils/ui/setup.ts
@@ -578,7 +578,7 @@ function mountEditor(opts: MountOptions): EditorHandle {
   // CodeMirror's own scroll snapshot: anchor row `line` plus `offset` = row top
   // minus scrollTop, computed from internal geometry (immune to surrounding
   // layout like the markdown mode bar, unlike client-coords sampling).
-  const readScrollAnchor = (): ScrollAnchor => {
+  const readLiveAnchor = (): ScrollAnchor => {
     // A dispatched restore CodeMirror has not applied yet (unmount races the
     // next measure, e.g. an editor remount from an effect-deps change) must
     // round-trip unchanged instead of reading back as top-of-doc.
@@ -590,6 +590,20 @@ function mountEditor(opts: MountOptions): EditorHandle {
     if (pending?.isSnapshot) return { line: pending.range.head, offset: pending.yMargin };
     const target = view.scrollSnapshot().value;
     return { line: target.range.head, offset: target.yMargin };
+  };
+
+  // Last anchor observed at the current viewport height. A tab switch away
+  // from a markdown tab removes the Raw/Preview/Split bar in the same React
+  // commit that unmounts the editor; the host grows and, near the bottom of
+  // the document, the browser clamps scrollTop BEFORE the effect cleanup reads
+  // the anchor. When the viewport height no longer matches, return the last
+  // settled anchor instead of the clamped live read.
+  let settledAnchor = opts.initialScrollAnchor ?? null;
+  let settledHeight = view.scrollDOM.clientHeight;
+
+  const readScrollAnchor = (): ScrollAnchor => {
+    if (settledAnchor && view.scrollDOM.clientHeight !== settledHeight) return settledAnchor;
+    return readLiveAnchor();
   };
 
   // A restored anchor (tab switch) wins over the cursor reveal; else reveal the
@@ -613,15 +627,36 @@ function mountEditor(opts: MountOptions): EditorHandle {
   // relying on unmount/quit hooks, which don't fire reliably in the webview.
   let scrollTimer: ReturnType<typeof setTimeout> | null = null;
   const onScrollDom = () => {
+    // Same-height scrolls are genuine; a height change means a resize-induced
+    // clamp, whose scroll must not overwrite the settled anchor.
+    if (view.scrollDOM.clientHeight === settledHeight) settledAnchor = readLiveAnchor();
     if (!opts.onScroll) return;
     if (scrollTimer) clearTimeout(scrollTimer);
     scrollTimer = setTimeout(() => opts.onScroll?.(readScrollAnchor()), SCROLL_ANCHOR_DEBOUNCE_MS);
   };
   view.scrollDOM.addEventListener("scroll", onScrollDom, { passive: true });
 
+  // A genuine live resize (pane drag, window resize) re-baselines the anchor a
+  // frame later; a tab-switch unmount destroys the editor first, so the
+  // pre-resize anchor survives for the cleanup read.
+  let resizeRaf = 0;
+  const resizeObserver =
+    typeof ResizeObserver === "undefined"
+      ? null
+      : new ResizeObserver(() => {
+          cancelAnimationFrame(resizeRaf);
+          resizeRaf = requestAnimationFrame(() => {
+            settledHeight = view.scrollDOM.clientHeight;
+            settledAnchor = readLiveAnchor();
+          });
+        });
+  resizeObserver?.observe(view.scrollDOM);
+
   return {
     destroy: () => {
       if (scrollTimer) clearTimeout(scrollTimer);
+      cancelAnimationFrame(resizeRaf);
+      resizeObserver?.disconnect();
       view.scrollDOM.removeEventListener("scroll", onScrollDom);
       view.destroy();
     },

--- a/frontend/src/domains/editor/utils/ui/setup.ts
+++ b/frontend/src/domains/editor/utils/ui/setup.ts
@@ -1,7 +1,11 @@
 // CodeMirror 6 mount / unmount helper. Wraps the per-tab editor lifecycle so
 // the React component can stay declarative.
 
-import { SCROLL_ANCHOR_DEBOUNCE_MS } from "./constants";
+import {
+  SCROLL_ANCHOR_DEBOUNCE_MS,
+  ANCHOR_SAMPLE_INSET_PX,
+  ANCHOR_SCROLL_Y_MARGIN_PX,
+} from "./constants";
 import { Compartment, EditorState, Prec } from "@codemirror/state";
 import {
   EditorView,
@@ -31,7 +35,7 @@ import { arrisHighlight } from "@shared/ui/utils/codeHighlight";
 import { lineCommentKeymap } from "./lineCommentToggler";
 import { jinjaAutoCloseKeymap } from "./jinjaAutoClose";
 import { indentContinuationExtension } from "./indentContinuation";
-import type { DatabaseKind, DiffHunk, KeywordCase } from "@shared";
+import type { DatabaseKind, DiffHunk, KeywordCase, ScrollAnchor } from "@shared";
 import type { SqlSchemaDict } from "../autocomplete/sqlSchema";
 import { gitGutterExtension, type GitHunkActions } from "./gitGutter";
 import { editorSearchExtension, openEditorSearch } from "./search";
@@ -61,12 +65,8 @@ interface MountOptions {
   host: HTMLElement;
   initialDoc: string;
   initialCursor?: number;
-  /// Char offset of the line that was at the top of the viewport, to restore on
-  /// mount (runtime only). Anchoring by line (not pixels) survives CodeMirror's
-  /// post-mount height measurement, which reflows an estimated layout and would
-  /// otherwise drift a raw pixel offset onto the wrong row. Wins over the
-  /// cursor-reveal below so a tab switch returns to the row the user was on.
-  initialScrollAnchor?: number;
+  /// Viewport position to restore on mount; wins over the cursor-reveal below.
+  initialScrollAnchor?: ScrollAnchor;
   /// Fired ONCE per editor update that changes the document and/or selection,
   /// carrying every changed field together so the owner can commit a single
   /// store write per keystroke (a keystroke changes doc AND selection; separate
@@ -75,9 +75,8 @@ interface MountOptions {
   /// are present only when the selection changed; `selection.from`/`to` are
   /// equal for a collapsed caret, a non-empty range means text is highlighted.
   onEdit?: (patch: EditorEditPatch) => void;
-  /// Fired (debounced) when the user scrolls, with the char offset of the line
-  /// now at the top of the viewport, so the owner can persist it for restore.
-  onScroll?: (anchor: number) => void;
+  /// Fired (debounced) on scroll with the current top-of-viewport anchor.
+  onScroll?: (anchor: ScrollAnchor) => void;
   languageId: string;
   /// DatabaseKind of the tab's connection; picks the SQL dialect when `languageId === "sql"`.
   connectionKind?: DatabaseKind;
@@ -154,7 +153,7 @@ interface CompletionUpdateOpts {
 
 interface EditorHandle {
   destroy: () => void;
-  getScrollAnchor: () => number;
+  getScrollAnchor: () => ScrollAnchor;
   updateDiffHunks: (hunks: DiffHunk[]) => void;
   updateShortcuts: () => void;
   updateCompletionSchema: (opts: CompletionUpdateOpts) => void;
@@ -580,30 +579,35 @@ function mountEditor(opts: MountOptions): EditorHandle {
   view.dom.dataset.arrisLang = opts.languageId;
   if (opts.connectionKind) view.dom.dataset.arrisConnectionKind = opts.connectionKind;
 
-  // A restored scroll anchor (tab switch) wins over the cursor reveal so we
-  // return to the row the user was on, not the caret. EditorState.create only
-  // seeds the selection; otherwise, when opened at a specific offset (e.g.
-  // clicking a SQLMesh test in the side pane), scroll that line to the top.
-  const scrollTarget =
-    typeof opts.initialScrollAnchor === "number"
-      ? opts.initialScrollAnchor
-      : typeof opts.initialCursor === "number" && opts.initialCursor > 0
-        ? opts.initialCursor
-        : null;
-  if (scrollTarget !== null) {
-    const pos = clampCursor(opts.initialDoc, scrollTarget);
+  // Top-of-viewport row plus how far it is scrolled above the fold, read from
+  // real geometry so restore reproduces the exact pixel, not just the row start.
+  const readScrollAnchor = (): ScrollAnchor => {
+    const rect = view.scrollDOM.getBoundingClientRect();
+    const pos = view.posAtCoords({
+      x: rect.left + ANCHOR_SAMPLE_INSET_PX,
+      y: rect.top + ANCHOR_SAMPLE_INSET_PX,
+    });
+    if (pos == null) return { line: 0, offset: 0 };
+    const line = view.state.doc.lineAt(pos).from;
+    const coords = view.coordsAtPos(line);
+    const offset = coords ? Math.max(0, rect.top - coords.top) : 0;
+    return { line, offset };
+  };
+
+  // A restored anchor (tab switch) wins over the cursor reveal; else reveal the
+  // opened offset (e.g. clicking a SQLMesh test in the side pane).
+  if (opts.initialScrollAnchor) {
+    const pos = clampCursor(opts.initialDoc, opts.initialScrollAnchor.line);
+    const px = opts.initialScrollAnchor.offset;
+    view.dispatch({
+      effects: EditorView.scrollIntoView(pos, { y: "start", yMargin: ANCHOR_SCROLL_Y_MARGIN_PX }),
+    });
+    // Reapply the sub-line remainder after CodeMirror has scrolled and measured.
+    if (px > 0) view.requestMeasure({ read: () => {}, write: () => { view.scrollDOM.scrollTop += px; } });
+  } else if (typeof opts.initialCursor === "number" && opts.initialCursor > 0) {
+    const pos = clampCursor(opts.initialDoc, opts.initialCursor);
     view.dispatch({ effects: EditorView.scrollIntoView(pos, { y: "start" }) });
   }
-
-  // Char offset of the line at the top of the viewport. Resolved from real
-  // rendered geometry (the pixel at the viewport's top edge) rather than mapping
-  // scrollTop through block heights, which mixes coordinate spaces and drifts by
-  // the content's top padding.
-  const readScrollAnchor = (): number => {
-    const rect = view.scrollDOM.getBoundingClientRect();
-    const pos = view.posAtCoords({ x: rect.left + 1, y: rect.top + 1 });
-    return pos == null ? 0 : view.state.doc.lineAt(pos).from;
-  };
 
   // Persist the anchor as the user scrolls (debounced) so restore works without
   // relying on unmount/quit hooks, which don't fire reliably in the webview.

--- a/frontend/src/domains/editor/utils/ui/setup.ts
+++ b/frontend/src/domains/editor/utils/ui/setup.ts
@@ -60,6 +60,10 @@ interface MountOptions {
   host: HTMLElement;
   initialDoc: string;
   initialCursor?: number;
+  /// Prior scroll offset to restore on mount (runtime only). When set, it wins
+  /// over the cursor-reveal below so a tab switch returns to where the user was
+  /// scrolled, not to the caret line.
+  initialScrollTop?: number;
   /// Fired ONCE per editor update that changes the document and/or selection,
   /// carrying every changed field together so the owner can commit a single
   /// store write per keystroke (a keystroke changes doc AND selection; separate
@@ -144,6 +148,7 @@ interface CompletionUpdateOpts {
 
 interface EditorHandle {
   destroy: () => void;
+  getScrollTop: () => number;
   updateDiffHunks: (hunks: DiffHunk[]) => void;
   updateShortcuts: () => void;
   updateCompletionSchema: (opts: CompletionUpdateOpts) => void;
@@ -569,16 +574,20 @@ function mountEditor(opts: MountOptions): EditorHandle {
   view.dom.dataset.arrisLang = opts.languageId;
   if (opts.connectionKind) view.dom.dataset.arrisConnectionKind = opts.connectionKind;
 
-  // EditorState.create only seeds the selection; the viewport still renders at
-  // the top. When opened at a specific offset (e.g. clicking a SQLMesh test in
-  // the side pane), scroll that line to the top so it's actually in view.
-  if (typeof opts.initialCursor === "number" && opts.initialCursor > 0) {
+  // A restored scroll offset (tab switch) wins over the cursor reveal so we
+  // return to where the user was, not to the caret. EditorState.create only
+  // seeds the selection; otherwise, when opened at a specific offset (e.g.
+  // clicking a SQLMesh test in the side pane), scroll that line to the top.
+  if (typeof opts.initialScrollTop === "number") {
+    view.scrollDOM.scrollTop = opts.initialScrollTop;
+  } else if (typeof opts.initialCursor === "number" && opts.initialCursor > 0) {
     const pos = clampCursor(opts.initialDoc, opts.initialCursor);
     view.dispatch({ effects: EditorView.scrollIntoView(pos, { y: "start" }) });
   }
 
   return {
     destroy: () => view.destroy(),
+    getScrollTop: () => view.scrollDOM.scrollTop,
     updateCompletionSchema: (updateOpts: CompletionUpdateOpts) => {
       const newExt = editorCompletionExtensions({
         languageId: opts.languageId,

--- a/frontend/src/domains/editor/utils/ui/setup.ts
+++ b/frontend/src/domains/editor/utils/ui/setup.ts
@@ -60,10 +60,12 @@ interface MountOptions {
   host: HTMLElement;
   initialDoc: string;
   initialCursor?: number;
-  /// Prior scroll offset to restore on mount (runtime only). When set, it wins
-  /// over the cursor-reveal below so a tab switch returns to where the user was
-  /// scrolled, not to the caret line.
-  initialScrollTop?: number;
+  /// Char offset of the line that was at the top of the viewport, to restore on
+  /// mount (runtime only). Anchoring by line (not pixels) survives CodeMirror's
+  /// post-mount height measurement, which reflows an estimated layout and would
+  /// otherwise drift a raw pixel offset onto the wrong row. Wins over the
+  /// cursor-reveal below so a tab switch returns to the row the user was on.
+  initialScrollAnchor?: number;
   /// Fired ONCE per editor update that changes the document and/or selection,
   /// carrying every changed field together so the owner can commit a single
   /// store write per keystroke (a keystroke changes doc AND selection; separate
@@ -148,7 +150,7 @@ interface CompletionUpdateOpts {
 
 interface EditorHandle {
   destroy: () => void;
-  getScrollTop: () => number;
+  getScrollAnchor: () => number;
   updateDiffHunks: (hunks: DiffHunk[]) => void;
   updateShortcuts: () => void;
   updateCompletionSchema: (opts: CompletionUpdateOpts) => void;
@@ -574,20 +576,26 @@ function mountEditor(opts: MountOptions): EditorHandle {
   view.dom.dataset.arrisLang = opts.languageId;
   if (opts.connectionKind) view.dom.dataset.arrisConnectionKind = opts.connectionKind;
 
-  // A restored scroll offset (tab switch) wins over the cursor reveal so we
-  // return to where the user was, not to the caret. EditorState.create only
+  // A restored scroll anchor (tab switch) wins over the cursor reveal so we
+  // return to the row the user was on, not the caret. EditorState.create only
   // seeds the selection; otherwise, when opened at a specific offset (e.g.
   // clicking a SQLMesh test in the side pane), scroll that line to the top.
-  if (typeof opts.initialScrollTop === "number") {
-    view.scrollDOM.scrollTop = opts.initialScrollTop;
-  } else if (typeof opts.initialCursor === "number" && opts.initialCursor > 0) {
-    const pos = clampCursor(opts.initialDoc, opts.initialCursor);
+  const scrollTarget =
+    typeof opts.initialScrollAnchor === "number"
+      ? opts.initialScrollAnchor
+      : typeof opts.initialCursor === "number" && opts.initialCursor > 0
+        ? opts.initialCursor
+        : null;
+  if (scrollTarget !== null) {
+    const pos = clampCursor(opts.initialDoc, scrollTarget);
     view.dispatch({ effects: EditorView.scrollIntoView(pos, { y: "start" }) });
   }
 
   return {
     destroy: () => view.destroy(),
-    getScrollTop: () => view.scrollDOM.scrollTop,
+    // Char offset of the line at the top of the viewport, for line-anchored
+    // scroll restore across a remount.
+    getScrollAnchor: () => view.lineBlockAtHeight(view.scrollDOM.scrollTop).from,
     updateCompletionSchema: (updateOpts: CompletionUpdateOpts) => {
       const newExt = editorCompletionExtensions({
         languageId: opts.languageId,

--- a/frontend/src/shared/backendTypes.ts
+++ b/frontend/src/shared/backendTypes.ts
@@ -285,6 +285,8 @@ interface PersistedTab {
   kind: string;
   connectionId?: string;
   cursor: number;
+  /** Char offset of the line to re-anchor at the viewport top on reopen. */
+  scrollAnchor?: number;
   tabType?: TabType;
   filePath?: string;
   tableRef?: TableRef;

--- a/frontend/src/shared/backendTypes.ts
+++ b/frontend/src/shared/backendTypes.ts
@@ -278,6 +278,13 @@ interface ObjectIdentity {
   name: string;
 }
 
+/** Top-of-viewport row (`line`, char offset) plus its sub-line pixel remainder
+ * (`offset`); anchoring by row survives CM6's post-mount height re-measurement. */
+interface ScrollAnchor {
+  line: number;
+  offset: number;
+}
+
 interface PersistedTab {
   id: string;
   title: string;
@@ -285,8 +292,7 @@ interface PersistedTab {
   kind: string;
   connectionId?: string;
   cursor: number;
-  /** Char offset of the line to re-anchor at the viewport top on reopen. */
-  scrollAnchor?: number;
+  scrollAnchor?: ScrollAnchor;
   tabType?: TabType;
   filePath?: string;
   tableRef?: TableRef;
@@ -652,6 +658,7 @@ export type {
   SchemaNode,
   TabType,
   ObjectIdentity,
+  ScrollAnchor,
   PersistedTab,
   ChartKind,
   LineStyle,

--- a/frontend/src/shared/backendTypes.ts
+++ b/frontend/src/shared/backendTypes.ts
@@ -278,8 +278,8 @@ interface ObjectIdentity {
   name: string;
 }
 
-/** Top-of-viewport row (`line`, char offset) plus its sub-line pixel remainder
- * (`offset`); anchoring by row survives CM6's post-mount height re-measurement. */
+/** CodeMirror scroll snapshot: anchor row `line` (char offset) plus `offset` =
+ * row top minus scrollTop in pixels (<= 0), for pixel-exact restore. */
 interface ScrollAnchor {
   line: number;
   offset: number;

--- a/frontend/src/shell/types.ts
+++ b/frontend/src/shell/types.ts
@@ -37,10 +37,12 @@ interface EditorTab extends PersistedTab {
   /// Anchors the editor's run-status indicator (spinner / check / X) to the
   /// statement's first line; persists until the next run replaces it.
   runRange?: { from: number; to: number };
-  /// Last editor scroll offset (runtime only). Captured when the editor
-  /// unmounts (tab switch) and restored on remount so the view returns to
-  /// where the user was scrolled rather than jumping to the caret line.
-  scrollTop?: number;
+  /// Char offset of the line that was at the top of the editor viewport
+  /// (runtime only). Captured when the editor unmounts (tab switch) and used to
+  /// re-anchor the scroll on remount so the view returns to the same row rather
+  /// than jumping to the caret line. Line-anchored, not pixels, so it survives
+  /// CodeMirror's post-mount height measurement.
+  scrollAnchor?: number;
 }
 
 /// A leaf in the pane layout tree: one editor pane owning a subset of tabs.

--- a/frontend/src/shell/types.ts
+++ b/frontend/src/shell/types.ts
@@ -37,12 +37,6 @@ interface EditorTab extends PersistedTab {
   /// Anchors the editor's run-status indicator (spinner / check / X) to the
   /// statement's first line; persists until the next run replaces it.
   runRange?: { from: number; to: number };
-  /// Char offset of the line that was at the top of the editor viewport
-  /// (runtime only). Captured when the editor unmounts (tab switch) and used to
-  /// re-anchor the scroll on remount so the view returns to the same row rather
-  /// than jumping to the caret line. Line-anchored, not pixels, so it survives
-  /// CodeMirror's post-mount height measurement.
-  scrollAnchor?: number;
 }
 
 /// A leaf in the pane layout tree: one editor pane owning a subset of tabs.

--- a/frontend/src/shell/types.ts
+++ b/frontend/src/shell/types.ts
@@ -37,6 +37,10 @@ interface EditorTab extends PersistedTab {
   /// Anchors the editor's run-status indicator (spinner / check / X) to the
   /// statement's first line; persists until the next run replaces it.
   runRange?: { from: number; to: number };
+  /// Last editor scroll offset (runtime only). Captured when the editor
+  /// unmounts (tab switch) and restored on remount so the view returns to
+  /// where the user was scrolled rather than jumping to the caret line.
+  scrollTop?: number;
 }
 
 /// A leaf in the pane layout tree: one editor pane owning a subset of tabs.

--- a/frontend/src/shell/utils/app.test.ts
+++ b/frontend/src/shell/utils/app.test.ts
@@ -421,10 +421,10 @@ describe("toPersisted", () => {
 
   it("persists each tab's stored scroll anchor", () => {
     const result = toPersisted([
-      { ...base, id: "1", scrollAnchor: { line: 42, offset: 3 } },
+      { ...base, id: "1", scrollAnchor: { line: 42, offset: -3 } },
       { ...base, id: "2", scrollAnchor: { line: 7, offset: 0 } },
     ]);
-    expect(result.find((t) => t.id === "1")?.scrollAnchor).toEqual({ line: 42, offset: 3 });
+    expect(result.find((t) => t.id === "1")?.scrollAnchor).toEqual({ line: 42, offset: -3 });
     expect(result.find((t) => t.id === "2")?.scrollAnchor).toEqual({ line: 7, offset: 0 });
   });
 });

--- a/frontend/src/shell/utils/app.test.ts
+++ b/frontend/src/shell/utils/app.test.ts
@@ -90,7 +90,6 @@ import { useSettingsStore } from "@shared/settings";
 import { useTabsStore } from "../hooks/tabsStore";
 import type { EditorTab } from "../types";
 import { useDbtStore } from "@domains/dbt/hooks";
-import { useEditorHandleStore } from "@domains/editor/hooks";
 import { useFilesStore } from "@domains/files/hooks";
 import { useGitStore } from "@domains/git/hooks";
 import { useSqlMeshStore } from "@domains/sqlmesh/hooks";
@@ -420,27 +419,13 @@ describe("toPersisted", () => {
     expect(result.find((t) => t.id === "open")?.closed).toBeUndefined();
   });
 
-  it("persists a tab's stored scroll anchor", () => {
-    useEditorHandleStore.setState({ handle: null, activeTabId: null });
-    const result = toPersisted([{ ...base, scrollAnchor: 42 }]);
-    expect(result[0].scrollAnchor).toBe(42);
-  });
-
-  it("captures the active tab's live scroll anchor from the editor handle", () => {
-    // The mounted editor's live anchor is fresher than the store's (which only
-    // updates on unmount), so it must win for the active tab at save time.
-    useEditorHandleStore.setState({
-      handle: { getScrollAnchor: () => 128 } as never,
-      activeTabId: "1",
-    });
+  it("persists each tab's stored scroll anchor", () => {
     const result = toPersisted([
       { ...base, id: "1", scrollAnchor: 42 },
       { ...base, id: "2", scrollAnchor: 7 },
     ]);
-    expect(result.find((t) => t.id === "1")?.scrollAnchor).toBe(128);
-    // Inactive tabs keep their stored anchor.
+    expect(result.find((t) => t.id === "1")?.scrollAnchor).toBe(42);
     expect(result.find((t) => t.id === "2")?.scrollAnchor).toBe(7);
-    useEditorHandleStore.setState({ handle: null, activeTabId: null });
   });
 });
 

--- a/frontend/src/shell/utils/app.test.ts
+++ b/frontend/src/shell/utils/app.test.ts
@@ -90,6 +90,7 @@ import { useSettingsStore } from "@shared/settings";
 import { useTabsStore } from "../hooks/tabsStore";
 import type { EditorTab } from "../types";
 import { useDbtStore } from "@domains/dbt/hooks";
+import { useEditorHandleStore } from "@domains/editor/hooks";
 import { useFilesStore } from "@domains/files/hooks";
 import { useGitStore } from "@domains/git/hooks";
 import { useSqlMeshStore } from "@domains/sqlmesh/hooks";
@@ -417,6 +418,29 @@ describe("toPersisted", () => {
     expect(result).toHaveLength(2);
     expect(result.find((t) => t.id === "closed")?.closed).toBe(true);
     expect(result.find((t) => t.id === "open")?.closed).toBeUndefined();
+  });
+
+  it("persists a tab's stored scroll anchor", () => {
+    useEditorHandleStore.setState({ handle: null, activeTabId: null });
+    const result = toPersisted([{ ...base, scrollAnchor: 42 }]);
+    expect(result[0].scrollAnchor).toBe(42);
+  });
+
+  it("captures the active tab's live scroll anchor from the editor handle", () => {
+    // The mounted editor's live anchor is fresher than the store's (which only
+    // updates on unmount), so it must win for the active tab at save time.
+    useEditorHandleStore.setState({
+      handle: { getScrollAnchor: () => 128 } as never,
+      activeTabId: "1",
+    });
+    const result = toPersisted([
+      { ...base, id: "1", scrollAnchor: 42 },
+      { ...base, id: "2", scrollAnchor: 7 },
+    ]);
+    expect(result.find((t) => t.id === "1")?.scrollAnchor).toBe(128);
+    // Inactive tabs keep their stored anchor.
+    expect(result.find((t) => t.id === "2")?.scrollAnchor).toBe(7);
+    useEditorHandleStore.setState({ handle: null, activeTabId: null });
   });
 });
 

--- a/frontend/src/shell/utils/app.test.ts
+++ b/frontend/src/shell/utils/app.test.ts
@@ -421,11 +421,11 @@ describe("toPersisted", () => {
 
   it("persists each tab's stored scroll anchor", () => {
     const result = toPersisted([
-      { ...base, id: "1", scrollAnchor: 42 },
-      { ...base, id: "2", scrollAnchor: 7 },
+      { ...base, id: "1", scrollAnchor: { line: 42, offset: 3 } },
+      { ...base, id: "2", scrollAnchor: { line: 7, offset: 0 } },
     ]);
-    expect(result.find((t) => t.id === "1")?.scrollAnchor).toBe(42);
-    expect(result.find((t) => t.id === "2")?.scrollAnchor).toBe(7);
+    expect(result.find((t) => t.id === "1")?.scrollAnchor).toEqual({ line: 42, offset: 3 });
+    expect(result.find((t) => t.id === "2")?.scrollAnchor).toEqual({ line: 7, offset: 0 });
   });
 });
 

--- a/frontend/src/shell/utils/app.ts
+++ b/frontend/src/shell/utils/app.ts
@@ -1,6 +1,5 @@
 import type { EditorTab } from "../types";
 import { useAgentStore } from "@domains/agent/hooks";
-import { useEditorHandleStore } from "@domains/editor/hooks";
 import { useTabsStore } from "../hooks/tabsStore";
 import { useFilesStore } from "@domains/files/hooks";
 import { useGitStore } from "@domains/git/hooks";
@@ -21,11 +20,6 @@ function toPersisted(tabs: EditorTab[]): PersistedTab[] {
   // NOTE: terminal tabs MUST stay persisted here. The pane layout references
   // tab ids; dropping terminals would make reconcileLayout prune their leaves
   // and silently lose the split on restart.
-  const { handle, activeTabId } = useEditorHandleStore.getState();
-  // The active tab's editor is still mounted at save time, so its live scroll
-  // anchor hasn't been written to the store yet (that only happens on unmount);
-  // read it straight off the handle.
-  const liveAnchor = handle ? handle.getScrollAnchor() : undefined;
   return tabs
     .filter((t) => t.tabType !== "gitdiff")
     .map(({ id, title, text, kind, connectionId, cursor, scrollAnchor, tabType, filePath, tableRef, tableEditable, closed, createdAt, chart }) => ({
@@ -35,7 +29,7 @@ function toPersisted(tabs: EditorTab[]): PersistedTab[] {
     kind,
     connectionId,
     cursor,
-    scrollAnchor: id === activeTabId ? liveAnchor ?? scrollAnchor : scrollAnchor,
+    scrollAnchor,
     tabType,
     filePath,
     tableRef,

--- a/frontend/src/shell/utils/app.ts
+++ b/frontend/src/shell/utils/app.ts
@@ -1,5 +1,6 @@
 import type { EditorTab } from "../types";
 import { useAgentStore } from "@domains/agent/hooks";
+import { useEditorHandleStore } from "@domains/editor/hooks";
 import { useTabsStore } from "../hooks/tabsStore";
 import { useFilesStore } from "@domains/files/hooks";
 import { useGitStore } from "@domains/git/hooks";
@@ -20,15 +21,21 @@ function toPersisted(tabs: EditorTab[]): PersistedTab[] {
   // NOTE: terminal tabs MUST stay persisted here. The pane layout references
   // tab ids; dropping terminals would make reconcileLayout prune their leaves
   // and silently lose the split on restart.
+  const { handle, activeTabId } = useEditorHandleStore.getState();
+  // The active tab's editor is still mounted at save time, so its live scroll
+  // anchor hasn't been written to the store yet (that only happens on unmount);
+  // read it straight off the handle.
+  const liveAnchor = handle ? handle.getScrollAnchor() : undefined;
   return tabs
     .filter((t) => t.tabType !== "gitdiff")
-    .map(({ id, title, text, kind, connectionId, cursor, tabType, filePath, tableRef, tableEditable, closed, createdAt, chart }) => ({
+    .map(({ id, title, text, kind, connectionId, cursor, scrollAnchor, tabType, filePath, tableRef, tableEditable, closed, createdAt, chart }) => ({
     id,
     title,
     text,
     kind,
     connectionId,
     cursor,
+    scrollAnchor: id === activeTabId ? liveAnchor ?? scrollAnchor : scrollAnchor,
     tabType,
     filePath,
     tableRef,


### PR DESCRIPTION
## What does this PR do?

Editor tabs previously lost unsaved edits and viewport position when switching tabs or restarting the app. This PR makes both fully persistent and makes scroll restore pixel-exact for every file type.

Changes:
- Keep unsaved tab edits across tab switches (editor seeds from the live store, not stale render state)
- Persist each tab's scroll position and restore it on tab switch and app restart
- Make restore pixel-exact via `CodeMirror` scroll snapshots instead of line-number anchoring
- Fix two remount races that corrupted the saved position: reading the anchor back before a pending restore applied, and the markdown Raw/Preview/Split bar's removal clamping `scrollTop` at unmount near the bottom of a document

## Checklist

- [ ] I opened an issue first for non-trivial changes, or this is a small fix.
- [x] Tests added/updated for my change.
- [x] **I license my contribution under the MIT License**, per [CONTRIBUTING.md](../CONTRIBUTING.md). I confirm this is my original work, or that I have the right to submit it.
