### PR TITLE
[Feature] Git hunk editing workflow and app-level task notifications

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2005,9 +2005,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/crates/arris-engines/src/git/impl_git_engine.rs
+++ b/crates/arris-engines/src/git/impl_git_engine.rs
@@ -659,15 +659,29 @@ impl GitEngine {
         self.apply_hunk(repo_path, file_path, hunk_index, &["apply", "--cached"])
     }
 
-    /// Restore (discard) a single diff hunk in the working tree. Reverse-applies
-    /// the hunk's patch via `git apply --reverse`, reverting that change.
-    pub fn restore_hunk(
+    /// Restore (discard) the single change block containing new-file `line`.
+    /// Git merges edits separated by fewer than 2*context+1 unchanged lines
+    /// into ONE diff hunk, so reverse-applying a whole hunk can revert
+    /// unrelated nearby edits. This rebuilds a zero-context patch for just the
+    /// contiguous run of added/deleted lines at `line` and reverse-applies it.
+    pub fn restore_change_block(
         &self,
         repo_path: &Path,
         file_path: &str,
-        hunk_index: usize,
+        line: u32,
     ) -> Result<(), GitError> {
-        self.apply_hunk(repo_path, file_path, hunk_index, &["apply", "--reverse"])
+        let root = self.git_toplevel(repo_path)?;
+        let abs = std::path::Path::new(file_path);
+        let rel = abs.strip_prefix(&root).unwrap_or(abs);
+        let output = Command::new("git")
+            .args(["diff", "HEAD", "--", &rel.to_string_lossy()])
+            .current_dir(&root)
+            .output()
+            .map_err(|e| GitError::Gix(e.to_string()))?;
+        let diff_text = String::from_utf8_lossy(&output.stdout);
+        let patch = Self::change_block_patch(&diff_text, line)
+            .ok_or_else(|| GitError::Gix(format!("no change block at line {line}")))?;
+        Self::apply_patch(&root, &patch, &["apply", "--reverse", "--unidiff-zero"])
     }
 
     /// Fetch all remotes, pruning deleted remote-tracking refs. Returns the
@@ -1323,10 +1337,14 @@ impl GitEngine {
         let diff_text = String::from_utf8_lossy(&output.stdout);
         let patch = Self::single_hunk_patch(&diff_text, hunk_index)
             .ok_or_else(|| GitError::Gix(format!("diff hunk {hunk_index} not found")))?;
+        Self::apply_patch(&root, &patch, git_args)
+    }
 
+    /// Pipe a patch into `git <git_args>` (an apply variant) run at `root`.
+    fn apply_patch(root: &Path, patch: &str, git_args: &[&str]) -> Result<(), GitError> {
         let mut child = Command::new("git")
             .args(git_args)
-            .current_dir(&root)
+            .current_dir(root)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
@@ -1385,6 +1403,133 @@ impl GitEngine {
         }
         let hunk = hunks.get(hunk_index)?;
         Some(format!("{header}{hunk}"))
+    }
+
+    /// Build a standalone zero-context patch for the change block (one
+    /// contiguous run of `-`/`+` lines between context lines) containing
+    /// new-file `line`. Returns `None` when no block spans that line.
+    fn change_block_patch(diff_text: &str, line: u32) -> Option<String> {
+        let mut header = String::new();
+        for l in diff_text.lines() {
+            if l.starts_with("@@ ") {
+                break;
+            }
+            header.push_str(l);
+            header.push('\n');
+        }
+        if header.is_empty() {
+            return None;
+        }
+
+        let hunks = Self::parse_diff_hunks(diff_text).ok()?;
+        for hunk in &hunks {
+            // Zero-count ranges name the line BEFORE the change; walking
+            // counters must start on the first real line either side.
+            let mut old_line = if hunk.old_count == 0 { hunk.old_start + 1 } else { hunk.old_start };
+            let mut new_line = if hunk.new_count == 0 { hunk.new_start + 1 } else { hunk.new_start };
+            let mut dels: Vec<&str> = Vec::new();
+            let mut adds: Vec<&str> = Vec::new();
+            let mut block_old_start = old_line;
+            let mut block_new_start = new_line;
+
+            let flush = |dels: &mut Vec<&str>,
+                             adds: &mut Vec<&str>,
+                             block_old_start: u32,
+                             block_new_start: u32,
+                             at_line: u32,
+                             at_eof: bool|
+             -> Option<String> {
+                if dels.is_empty() && adds.is_empty() {
+                    return None;
+                }
+                // Added blocks span their new-file rows. A deletion-only block
+                // occupies none, so it matches the row it sits above; at EOF
+                // the UI clamps that anchor to the last existing line.
+                let matched = if adds.is_empty() {
+                    line == at_line || (at_eof && line + 1 == at_line)
+                } else {
+                    line >= block_new_start && line < block_new_start + adds.len() as u32
+                };
+                if !matched {
+                    dels.clear();
+                    adds.clear();
+                    return None;
+                }
+                let old_range = if dels.is_empty() {
+                    format!("{},0", block_old_start.saturating_sub(1))
+                } else {
+                    format!("{},{}", block_old_start, dels.len())
+                };
+                let new_range = if adds.is_empty() {
+                    format!("{},0", block_new_start.saturating_sub(1))
+                } else {
+                    format!("{},{}", block_new_start, adds.len())
+                };
+                let mut body = String::new();
+                for d in dels.iter() {
+                    body.push('-');
+                    body.push_str(d);
+                    body.push('\n');
+                }
+                for a in adds.iter() {
+                    body.push('+');
+                    body.push_str(a);
+                    body.push('\n');
+                }
+                Some(format!("{header}@@ -{old_range} +{new_range} @@\n{body}"))
+            };
+
+            for diff_line in &hunk.lines {
+                match diff_line.kind.as_str() {
+                    "ctx" => {
+                        if let Some(patch) = flush(
+                            &mut dels,
+                            &mut adds,
+                            block_old_start,
+                            block_new_start,
+                            new_line,
+                            false,
+                        ) {
+                            return Some(patch);
+                        }
+                        old_line += 1;
+                        new_line += 1;
+                        block_old_start = old_line;
+                        block_new_start = new_line;
+                    }
+                    "del" => {
+                        if dels.is_empty() && adds.is_empty() {
+                            block_old_start = old_line;
+                            block_new_start = new_line;
+                        }
+                        dels.push(&diff_line.text);
+                        old_line += 1;
+                    }
+                    "add" => {
+                        if dels.is_empty() && adds.is_empty() {
+                            block_old_start = old_line;
+                        }
+                        if adds.is_empty() {
+                            block_new_start = new_line;
+                        }
+                        adds.push(&diff_line.text);
+                        new_line += 1;
+                    }
+                    _ => {}
+                }
+            }
+            if let Some(patch) = flush(
+                &mut dels,
+                &mut adds,
+                block_old_start,
+                block_new_start,
+                new_line,
+                true,
+            ) {
+                return Some(patch);
+            }
+        }
+        None
     }
 
     /// Absolute path of the repo's git directory (`git rev-parse --git-dir`),
@@ -2550,7 +2695,84 @@ index abc..def 100644
     }
 
     #[test]
-    fn restore_hunk_discards_only_selected_hunk() {
+    fn restore_change_block_reverts_only_block_in_merged_hunk() {
+        let engine = GitEngine::new();
+        let tmp = tempfile::tempdir().unwrap();
+        if !init_repo(tmp.path()) {
+            eprintln!("skipping: system git unavailable");
+            return;
+        }
+        commit_ten_line_file(tmp.path());
+        // Two edits 3 unchanged lines apart: git merges them into ONE hunk.
+        std::fs::write(
+            tmp.path().join("f.txt"),
+            "a\nB\nc\nd\ne\nF\ng\nh\ni\nj\n",
+        )
+        .unwrap();
+
+        let canon = tmp.path().canonicalize().unwrap();
+        let abs = canon.join("f.txt").to_string_lossy().to_string();
+        assert_eq!(engine.file_diff_hunks(tmp.path(), &abs).unwrap().len(), 1);
+
+        engine.restore_change_block(tmp.path(), &abs, 6).unwrap();
+
+        let content = std::fs::read_to_string(tmp.path().join("f.txt")).unwrap();
+        assert_eq!(content, "a\nB\nc\nd\ne\nf\ng\nh\ni\nj\n");
+    }
+
+    #[test]
+    fn restore_change_block_removes_inserted_run_only() {
+        let engine = GitEngine::new();
+        let tmp = tempfile::tempdir().unwrap();
+        if !init_repo(tmp.path()) {
+            eprintln!("skipping: system git unavailable");
+            return;
+        }
+        commit_ten_line_file(tmp.path());
+        // Edit line 2 and insert two lines after e; one merged hunk.
+        std::fs::write(
+            tmp.path().join("f.txt"),
+            "a\nB\nc\nd\ne\nX\nY\nf\ng\nh\ni\nj\n",
+        )
+        .unwrap();
+
+        let canon = tmp.path().canonicalize().unwrap();
+        let abs = canon.join("f.txt").to_string_lossy().to_string();
+
+        // Cursor on the second inserted row removes the whole inserted run.
+        engine.restore_change_block(tmp.path(), &abs, 7).unwrap();
+
+        let content = std::fs::read_to_string(tmp.path().join("f.txt")).unwrap();
+        assert_eq!(content, "a\nB\nc\nd\ne\nf\ng\nh\ni\nj\n");
+    }
+
+    #[test]
+    fn restore_change_block_restores_deleted_block_only() {
+        let engine = GitEngine::new();
+        let tmp = tempfile::tempdir().unwrap();
+        if !init_repo(tmp.path()) {
+            eprintln!("skipping: system git unavailable");
+            return;
+        }
+        commit_ten_line_file(tmp.path());
+        // Edit line 2 and delete f/g; deletion anchors on the row below (h).
+        std::fs::write(
+            tmp.path().join("f.txt"),
+            "a\nB\nc\nd\ne\nh\ni\nj\n",
+        )
+        .unwrap();
+
+        let canon = tmp.path().canonicalize().unwrap();
+        let abs = canon.join("f.txt").to_string_lossy().to_string();
+
+        engine.restore_change_block(tmp.path(), &abs, 6).unwrap();
+
+        let content = std::fs::read_to_string(tmp.path().join("f.txt")).unwrap();
+        assert_eq!(content, "a\nB\nc\nd\ne\nf\ng\nh\ni\nj\n");
+    }
+
+    #[test]
+    fn restore_change_block_restores_deletion_at_eof() {
         let engine = GitEngine::new();
         let tmp = tempfile::tempdir().unwrap();
         if !init_repo(tmp.path()) {
@@ -2560,18 +2782,40 @@ index abc..def 100644
         commit_ten_line_file(tmp.path());
         std::fs::write(
             tmp.path().join("f.txt"),
-            "A\nb\nc\nd\ne\nf\ng\nh\ni\nJ\n",
+            "a\nb\nc\nd\ne\nf\ng\nh\ni\n",
         )
         .unwrap();
 
         let canon = tmp.path().canonicalize().unwrap();
         let abs = canon.join("f.txt").to_string_lossy().to_string();
 
-        // Restore the first hunk: line 1 reverts, line 10 stays changed.
-        engine.restore_hunk(tmp.path(), &abs, 0).unwrap();
+        // The UI clamps the trailing-deletion anchor to the last line (9).
+        engine.restore_change_block(tmp.path(), &abs, 9).unwrap();
 
         let content = std::fs::read_to_string(tmp.path().join("f.txt")).unwrap();
-        assert_eq!(content, "a\nb\nc\nd\ne\nf\ng\nh\ni\nJ\n");
+        assert_eq!(content, "a\nb\nc\nd\ne\nf\ng\nh\ni\nj\n");
+    }
+
+    #[test]
+    fn restore_change_block_rejects_unchanged_line() {
+        let engine = GitEngine::new();
+        let tmp = tempfile::tempdir().unwrap();
+        if !init_repo(tmp.path()) {
+            eprintln!("skipping: system git unavailable");
+            return;
+        }
+        commit_ten_line_file(tmp.path());
+        std::fs::write(
+            tmp.path().join("f.txt"),
+            "a\nB\nc\nd\ne\nf\ng\nh\ni\nj\n",
+        )
+        .unwrap();
+
+        let canon = tmp.path().canonicalize().unwrap();
+        let abs = canon.join("f.txt").to_string_lossy().to_string();
+
+        // Line 4 sits inside the hunk's context but is not a change block.
+        assert!(engine.restore_change_block(tmp.path(), &abs, 4).is_err());
     }
 
     #[test]

--- a/crates/arris-engines/src/git/impl_git_engine.rs
+++ b/crates/arris-engines/src/git/impl_git_engine.rs
@@ -659,11 +659,8 @@ impl GitEngine {
         self.apply_hunk(repo_path, file_path, hunk_index, &["apply", "--cached"])
     }
 
-    /// Restore (discard) the single change block containing new-file `line`.
-    /// Git merges edits separated by fewer than 2*context+1 unchanged lines
-    /// into ONE diff hunk, so reverse-applying a whole hunk can revert
-    /// unrelated nearby edits. This rebuilds a zero-context patch for just the
-    /// contiguous run of added/deleted lines at `line` and reverse-applies it.
+    /// Discard only the change block at new-file `line` (git merges nearby
+    /// edits into one hunk), from both the worktree and any staged copy.
     pub fn restore_change_block(
         &self,
         repo_path: &Path,
@@ -673,15 +670,46 @@ impl GitEngine {
         let root = self.git_toplevel(repo_path)?;
         let abs = std::path::Path::new(file_path);
         let rel = abs.strip_prefix(&root).unwrap_or(abs);
+        let rel_str = rel.to_string_lossy();
+        let diff_text = Self::diff_output(&root, &["diff", "HEAD", "--", &rel_str])?;
+        let (header, blocks) = Self::change_blocks(&diff_text)
+            .ok_or_else(|| GitError::Gix(format!("no change block at line {line}")))?;
+        let target = blocks
+            .iter()
+            .find(|b| Self::block_matches_new_line(b, line))
+            .ok_or_else(|| GitError::Gix(format!("no change block at line {line}")))?;
+        let patch = format!("{header}{}", target.hunk);
+        Self::apply_patch(&root, &patch, &["apply", "--reverse", "--unidiff-zero"])?;
+
+        // A staged copy of the block would keep the file listed as changed
+        // even though the worktree now matches HEAD; drop it from the index.
+        let cached_text = Self::diff_output(&root, &["diff", "--cached", "--", &rel_str])?;
+        if let Some((cached_header, cached_blocks)) = Self::change_blocks(&cached_text) {
+            let hunks: String = cached_blocks
+                .iter()
+                .filter(|c| Self::old_ranges_overlap(target, c))
+                .map(|c| c.hunk.as_str())
+                .collect();
+            if !hunks.is_empty() {
+                let cached_patch = format!("{cached_header}{hunks}");
+                Self::apply_patch(
+                    &root,
+                    &cached_patch,
+                    &["apply", "--cached", "--reverse", "--unidiff-zero"],
+                )?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Run a `git diff` variant and return its stdout.
+    fn diff_output(root: &Path, args: &[&str]) -> Result<String, GitError> {
         let output = Command::new("git")
-            .args(["diff", "HEAD", "--", &rel.to_string_lossy()])
-            .current_dir(&root)
+            .args(args)
+            .current_dir(root)
             .output()
             .map_err(|e| GitError::Gix(e.to_string()))?;
-        let diff_text = String::from_utf8_lossy(&output.stdout);
-        let patch = Self::change_block_patch(&diff_text, line)
-            .ok_or_else(|| GitError::Gix(format!("no change block at line {line}")))?;
-        Self::apply_patch(&root, &patch, &["apply", "--reverse", "--unidiff-zero"])
+        Ok(String::from_utf8_lossy(&output.stdout).into_owned())
     }
 
     /// Fetch all remotes, pruning deleted remote-tracking refs. Returns the
@@ -1405,10 +1433,9 @@ impl GitEngine {
         Some(format!("{header}{hunk}"))
     }
 
-    /// Build a standalone zero-context patch for the change block (one
-    /// contiguous run of `-`/`+` lines between context lines) containing
-    /// new-file `line`. Returns `None` when no block spans that line.
-    fn change_block_patch(diff_text: &str, line: u32) -> Option<String> {
+    /// Split a unified diff into its file header and zero-context change
+    /// blocks (one per contiguous `-`/`+` run). `None` when the diff is empty.
+    fn change_blocks(diff_text: &str) -> Option<(String, Vec<ChangeBlock>)> {
         let mut header = String::new();
         for l in diff_text.lines() {
             if l.starts_with("@@ ") {
@@ -1422,6 +1449,7 @@ impl GitEngine {
         }
 
         let hunks = Self::parse_diff_hunks(diff_text).ok()?;
+        let mut blocks: Vec<ChangeBlock> = Vec::new();
         for hunk in &hunks {
             // Zero-count ranges name the line BEFORE the change; walking
             // counters must start on the first real line either side.
@@ -1436,34 +1464,20 @@ impl GitEngine {
                              adds: &mut Vec<&str>,
                              block_old_start: u32,
                              block_new_start: u32,
-                             at_line: u32,
-                             at_eof: bool|
-             -> Option<String> {
+                             at_eof: bool,
+                             blocks: &mut Vec<ChangeBlock>| {
                 if dels.is_empty() && adds.is_empty() {
-                    return None;
+                    return;
                 }
-                // Added blocks span their new-file rows. A deletion-only block
-                // occupies none, so it matches the row it sits above; at EOF
-                // the UI clamps that anchor to the last existing line.
-                let matched = if adds.is_empty() {
-                    line == at_line || (at_eof && line + 1 == at_line)
+                let (old_start, old_count) = if dels.is_empty() {
+                    (block_old_start.saturating_sub(1), 0)
                 } else {
-                    line >= block_new_start && line < block_new_start + adds.len() as u32
+                    (block_old_start, dels.len() as u32)
                 };
-                if !matched {
-                    dels.clear();
-                    adds.clear();
-                    return None;
-                }
-                let old_range = if dels.is_empty() {
-                    format!("{},0", block_old_start.saturating_sub(1))
+                let (new_start, new_count) = if adds.is_empty() {
+                    (block_new_start.saturating_sub(1), 0)
                 } else {
-                    format!("{},{}", block_old_start, dels.len())
-                };
-                let new_range = if adds.is_empty() {
-                    format!("{},0", block_new_start.saturating_sub(1))
-                } else {
-                    format!("{},{}", block_new_start, adds.len())
+                    (block_new_start, adds.len() as u32)
                 };
                 let mut body = String::new();
                 for d in dels.iter() {
@@ -1476,22 +1490,22 @@ impl GitEngine {
                     body.push_str(a);
                     body.push('\n');
                 }
-                Some(format!("{header}@@ -{old_range} +{new_range} @@\n{body}"))
+                blocks.push(ChangeBlock {
+                    old_start,
+                    old_count,
+                    new_start,
+                    new_count,
+                    at_eof,
+                    hunk: format!("@@ -{old_start},{old_count} +{new_start},{new_count} @@\n{body}"),
+                });
+                dels.clear();
+                adds.clear();
             };
 
             for diff_line in &hunk.lines {
                 match diff_line.kind.as_str() {
                     "ctx" => {
-                        if let Some(patch) = flush(
-                            &mut dels,
-                            &mut adds,
-                            block_old_start,
-                            block_new_start,
-                            new_line,
-                            false,
-                        ) {
-                            return Some(patch);
-                        }
+                        flush(&mut dels, &mut adds, block_old_start, block_new_start, false, &mut blocks);
                         old_line += 1;
                         new_line += 1;
                         block_old_start = old_line;
@@ -1518,18 +1532,35 @@ impl GitEngine {
                     _ => {}
                 }
             }
-            if let Some(patch) = flush(
-                &mut dels,
-                &mut adds,
-                block_old_start,
-                block_new_start,
-                new_line,
-                true,
-            ) {
-                return Some(patch);
-            }
+            flush(&mut dels, &mut adds, block_old_start, block_new_start, true, &mut blocks);
         }
-        None
+        Some((header, blocks))
+    }
+
+    /// Whether the block contains new-file `line`. A deletion-only block
+    /// matches the row it sits above (at EOF the UI clamps to the last line).
+    fn block_matches_new_line(block: &ChangeBlock, line: u32) -> bool {
+        if block.new_count == 0 {
+            line == block.new_start + 1 || (block.at_eof && line == block.new_start)
+        } else {
+            line >= block.new_start && line < block.new_start + block.new_count
+        }
+    }
+
+    /// Same-HEAD-span test in doubled coords (line n = 2n, gap after n = 2n+1);
+    /// one slack unit joins an insertion gap to an adjacent changed line.
+    fn old_ranges_overlap(a: &ChangeBlock, b: &ChangeBlock) -> bool {
+        let span = |start: u32, count: u32| -> (u64, u64) {
+            if count == 0 {
+                let gap = 2 * u64::from(start) + 1;
+                (gap, gap)
+            } else {
+                (2 * u64::from(start), 2 * u64::from(start + count - 1))
+            }
+        };
+        let (a_lo, a_hi) = span(a.old_start, a.old_count);
+        let (b_lo, b_hi) = span(b.old_start, b.old_count);
+        a_lo.max(b_lo) <= a_hi.min(b_hi) + 1
     }
 
     /// Absolute path of the repo's git directory (`git rev-parse --git-dir`),
@@ -2816,6 +2847,118 @@ index abc..def 100644
 
         // Line 4 sits inside the hunk's context but is not a change block.
         assert!(engine.restore_change_block(tmp.path(), &abs, 4).is_err());
+    }
+
+    #[test]
+    fn restore_change_block_unstages_staged_copy_of_block() {
+        let engine = GitEngine::new();
+        let tmp = tempfile::tempdir().unwrap();
+        if !init_repo(tmp.path()) {
+            eprintln!("skipping: system git unavailable");
+            return;
+        }
+        commit_ten_line_file(tmp.path());
+        std::fs::write(
+            tmp.path().join("f.txt"),
+            "a\nB\nc\nd\ne\nf\ng\nh\ni\nj\n",
+        )
+        .unwrap();
+        Command::new("git")
+            .args(["add", "f.txt"])
+            .current_dir(tmp.path())
+            .status()
+            .ok();
+
+        let canon = tmp.path().canonicalize().unwrap();
+        let abs = canon.join("f.txt").to_string_lossy().to_string();
+        engine.restore_change_block(tmp.path(), &abs, 2).unwrap();
+
+        let content = std::fs::read_to_string(tmp.path().join("f.txt")).unwrap();
+        assert_eq!(content, "a\nb\nc\nd\ne\nf\ng\nh\ni\nj\n");
+        let status = Command::new("git")
+            .args(["status", "--porcelain"])
+            .current_dir(tmp.path())
+            .output()
+            .unwrap();
+        assert_eq!(String::from_utf8_lossy(&status.stdout).trim(), "");
+    }
+
+    #[test]
+    fn restore_change_block_keeps_other_staged_blocks() {
+        let engine = GitEngine::new();
+        let tmp = tempfile::tempdir().unwrap();
+        if !init_repo(tmp.path()) {
+            eprintln!("skipping: system git unavailable");
+            return;
+        }
+        commit_ten_line_file(tmp.path());
+        // Two staged blocks (B at 2, F at 6); discarding F must leave B staged.
+        std::fs::write(
+            tmp.path().join("f.txt"),
+            "a\nB\nc\nd\ne\nF\ng\nh\ni\nj\n",
+        )
+        .unwrap();
+        Command::new("git")
+            .args(["add", "f.txt"])
+            .current_dir(tmp.path())
+            .status()
+            .ok();
+
+        let canon = tmp.path().canonicalize().unwrap();
+        let abs = canon.join("f.txt").to_string_lossy().to_string();
+        engine.restore_change_block(tmp.path(), &abs, 6).unwrap();
+
+        let content = std::fs::read_to_string(tmp.path().join("f.txt")).unwrap();
+        assert_eq!(content, "a\nB\nc\nd\ne\nf\ng\nh\ni\nj\n");
+        let cached = Command::new("git")
+            .args(["diff", "--cached"])
+            .current_dir(tmp.path())
+            .output()
+            .unwrap();
+        let cached = String::from_utf8_lossy(&cached.stdout);
+        assert!(cached.contains("+B"));
+        assert!(!cached.contains("+F"));
+    }
+
+    #[test]
+    fn restore_change_block_discards_staged_and_worktree_versions() {
+        let engine = GitEngine::new();
+        let tmp = tempfile::tempdir().unwrap();
+        if !init_repo(tmp.path()) {
+            eprintln!("skipping: system git unavailable");
+            return;
+        }
+        commit_ten_line_file(tmp.path());
+        // Stage version X of line 2, then edit the worktree to version Y:
+        // discarding the block must drop BOTH and leave the file clean.
+        std::fs::write(
+            tmp.path().join("f.txt"),
+            "a\nX\nc\nd\ne\nf\ng\nh\ni\nj\n",
+        )
+        .unwrap();
+        Command::new("git")
+            .args(["add", "f.txt"])
+            .current_dir(tmp.path())
+            .status()
+            .ok();
+        std::fs::write(
+            tmp.path().join("f.txt"),
+            "a\nY\nc\nd\ne\nf\ng\nh\ni\nj\n",
+        )
+        .unwrap();
+
+        let canon = tmp.path().canonicalize().unwrap();
+        let abs = canon.join("f.txt").to_string_lossy().to_string();
+        engine.restore_change_block(tmp.path(), &abs, 2).unwrap();
+
+        let content = std::fs::read_to_string(tmp.path().join("f.txt")).unwrap();
+        assert_eq!(content, "a\nb\nc\nd\ne\nf\ng\nh\ni\nj\n");
+        let status = Command::new("git")
+            .args(["status", "--porcelain"])
+            .current_dir(tmp.path())
+            .output()
+            .unwrap();
+        assert_eq!(String::from_utf8_lossy(&status.stdout).trim(), "");
     }
 
     #[test]

--- a/crates/arris-engines/src/git/impl_git_engine.rs
+++ b/crates/arris-engines/src/git/impl_git_engine.rs
@@ -659,35 +659,40 @@ impl GitEngine {
         self.apply_hunk(repo_path, file_path, hunk_index, &["apply", "--cached"])
     }
 
-    /// Discard only the change block at new-file `line` (git merges nearby
-    /// edits into one hunk), from both the worktree and any staged copy.
-    pub fn restore_change_block(
+    /// Discard every change block intersecting new-file lines
+    /// `start_line..=end_line`, from both the worktree and any staged copy.
+    pub fn restore_change_blocks(
         &self,
         repo_path: &Path,
         file_path: &str,
-        line: u32,
+        start_line: u32,
+        end_line: u32,
     ) -> Result<(), GitError> {
         let root = self.git_toplevel(repo_path)?;
         let abs = std::path::Path::new(file_path);
         let rel = abs.strip_prefix(&root).unwrap_or(abs);
         let rel_str = rel.to_string_lossy();
         let diff_text = Self::diff_output(&root, &["diff", "HEAD", "--", &rel_str])?;
-        let (header, blocks) = Self::change_blocks(&diff_text)
-            .ok_or_else(|| GitError::Gix(format!("no change block at line {line}")))?;
-        let target = blocks
+        let no_block = || GitError::Gix(format!("no change block in lines {start_line}-{end_line}"));
+        let (header, blocks) = Self::change_blocks(&diff_text).ok_or_else(no_block)?;
+        let targets: Vec<&ChangeBlock> = blocks
             .iter()
-            .find(|b| Self::block_matches_new_line(b, line))
-            .ok_or_else(|| GitError::Gix(format!("no change block at line {line}")))?;
-        let patch = format!("{header}{}", target.hunk);
+            .filter(|b| Self::block_matches_new_range(b, start_line, end_line))
+            .collect();
+        if targets.is_empty() {
+            return Err(no_block());
+        }
+        let hunks: String = targets.iter().map(|b| b.hunk.as_str()).collect();
+        let patch = format!("{header}{hunks}");
         Self::apply_patch(&root, &patch, &["apply", "--reverse", "--unidiff-zero"])?;
 
-        // A staged copy of the block would keep the file listed as changed
+        // A staged copy of a block would keep the file listed as changed
         // even though the worktree now matches HEAD; drop it from the index.
         let cached_text = Self::diff_output(&root, &["diff", "--cached", "--", &rel_str])?;
         if let Some((cached_header, cached_blocks)) = Self::change_blocks(&cached_text) {
             let hunks: String = cached_blocks
                 .iter()
-                .filter(|c| Self::old_ranges_overlap(target, c))
+                .filter(|c| targets.iter().any(|t| Self::old_ranges_overlap(t, c)))
                 .map(|c| c.hunk.as_str())
                 .collect();
             if !hunks.is_empty() {
@@ -1537,13 +1542,15 @@ impl GitEngine {
         Some((header, blocks))
     }
 
-    /// Whether the block contains new-file `line`. A deletion-only block
-    /// matches the row it sits above (at EOF the UI clamps to the last line).
-    fn block_matches_new_line(block: &ChangeBlock, line: u32) -> bool {
+    /// Whether the block intersects new-file lines `start..=end`. A deletion-
+    /// only block matches the row it sits above (EOF clamps to the last line).
+    fn block_matches_new_range(block: &ChangeBlock, start: u32, end: u32) -> bool {
         if block.new_count == 0 {
-            line == block.new_start + 1 || (block.at_eof && line == block.new_start)
+            let anchor = block.new_start + 1;
+            (anchor >= start && anchor <= end)
+                || (block.at_eof && block.new_start >= start && block.new_start <= end)
         } else {
-            line >= block.new_start && line < block.new_start + block.new_count
+            block.new_start <= end && start < block.new_start + block.new_count
         }
     }
 
@@ -2726,7 +2733,7 @@ index abc..def 100644
     }
 
     #[test]
-    fn restore_change_block_reverts_only_block_in_merged_hunk() {
+    fn restore_change_blocks_reverts_only_block_in_merged_hunk() {
         let engine = GitEngine::new();
         let tmp = tempfile::tempdir().unwrap();
         if !init_repo(tmp.path()) {
@@ -2745,14 +2752,14 @@ index abc..def 100644
         let abs = canon.join("f.txt").to_string_lossy().to_string();
         assert_eq!(engine.file_diff_hunks(tmp.path(), &abs).unwrap().len(), 1);
 
-        engine.restore_change_block(tmp.path(), &abs, 6).unwrap();
+        engine.restore_change_blocks(tmp.path(), &abs, 6, 6).unwrap();
 
         let content = std::fs::read_to_string(tmp.path().join("f.txt")).unwrap();
         assert_eq!(content, "a\nB\nc\nd\ne\nf\ng\nh\ni\nj\n");
     }
 
     #[test]
-    fn restore_change_block_removes_inserted_run_only() {
+    fn restore_change_blocks_removes_inserted_run_only() {
         let engine = GitEngine::new();
         let tmp = tempfile::tempdir().unwrap();
         if !init_repo(tmp.path()) {
@@ -2771,14 +2778,14 @@ index abc..def 100644
         let abs = canon.join("f.txt").to_string_lossy().to_string();
 
         // Cursor on the second inserted row removes the whole inserted run.
-        engine.restore_change_block(tmp.path(), &abs, 7).unwrap();
+        engine.restore_change_blocks(tmp.path(), &abs, 7, 7).unwrap();
 
         let content = std::fs::read_to_string(tmp.path().join("f.txt")).unwrap();
         assert_eq!(content, "a\nB\nc\nd\ne\nf\ng\nh\ni\nj\n");
     }
 
     #[test]
-    fn restore_change_block_restores_deleted_block_only() {
+    fn restore_change_blocks_restores_deleted_block_only() {
         let engine = GitEngine::new();
         let tmp = tempfile::tempdir().unwrap();
         if !init_repo(tmp.path()) {
@@ -2796,14 +2803,14 @@ index abc..def 100644
         let canon = tmp.path().canonicalize().unwrap();
         let abs = canon.join("f.txt").to_string_lossy().to_string();
 
-        engine.restore_change_block(tmp.path(), &abs, 6).unwrap();
+        engine.restore_change_blocks(tmp.path(), &abs, 6, 6).unwrap();
 
         let content = std::fs::read_to_string(tmp.path().join("f.txt")).unwrap();
         assert_eq!(content, "a\nB\nc\nd\ne\nf\ng\nh\ni\nj\n");
     }
 
     #[test]
-    fn restore_change_block_restores_deletion_at_eof() {
+    fn restore_change_blocks_restores_deletion_at_eof() {
         let engine = GitEngine::new();
         let tmp = tempfile::tempdir().unwrap();
         if !init_repo(tmp.path()) {
@@ -2821,14 +2828,14 @@ index abc..def 100644
         let abs = canon.join("f.txt").to_string_lossy().to_string();
 
         // The UI clamps the trailing-deletion anchor to the last line (9).
-        engine.restore_change_block(tmp.path(), &abs, 9).unwrap();
+        engine.restore_change_blocks(tmp.path(), &abs, 9, 9).unwrap();
 
         let content = std::fs::read_to_string(tmp.path().join("f.txt")).unwrap();
         assert_eq!(content, "a\nb\nc\nd\ne\nf\ng\nh\ni\nj\n");
     }
 
     #[test]
-    fn restore_change_block_rejects_unchanged_line() {
+    fn restore_change_blocks_rejects_unchanged_line() {
         let engine = GitEngine::new();
         let tmp = tempfile::tempdir().unwrap();
         if !init_repo(tmp.path()) {
@@ -2846,11 +2853,36 @@ index abc..def 100644
         let abs = canon.join("f.txt").to_string_lossy().to_string();
 
         // Line 4 sits inside the hunk's context but is not a change block.
-        assert!(engine.restore_change_block(tmp.path(), &abs, 4).is_err());
+        assert!(engine.restore_change_blocks(tmp.path(), &abs, 4, 4).is_err());
     }
 
     #[test]
-    fn restore_change_block_unstages_staged_copy_of_block() {
+    fn restore_change_blocks_reverts_all_blocks_in_selected_range() {
+        let engine = GitEngine::new();
+        let tmp = tempfile::tempdir().unwrap();
+        if !init_repo(tmp.path()) {
+            eprintln!("skipping: system git unavailable");
+            return;
+        }
+        commit_ten_line_file(tmp.path());
+        // Three separate blocks (B at 2, F at 6, J at 10); selecting lines
+        // 2-6 must revert B and F but leave J untouched.
+        std::fs::write(
+            tmp.path().join("f.txt"),
+            "a\nB\nc\nd\ne\nF\ng\nh\ni\nJ\n",
+        )
+        .unwrap();
+
+        let canon = tmp.path().canonicalize().unwrap();
+        let abs = canon.join("f.txt").to_string_lossy().to_string();
+        engine.restore_change_blocks(tmp.path(), &abs, 2, 6).unwrap();
+
+        let content = std::fs::read_to_string(tmp.path().join("f.txt")).unwrap();
+        assert_eq!(content, "a\nb\nc\nd\ne\nf\ng\nh\ni\nJ\n");
+    }
+
+    #[test]
+    fn restore_change_blocks_unstages_staged_copy_of_block() {
         let engine = GitEngine::new();
         let tmp = tempfile::tempdir().unwrap();
         if !init_repo(tmp.path()) {
@@ -2871,7 +2903,7 @@ index abc..def 100644
 
         let canon = tmp.path().canonicalize().unwrap();
         let abs = canon.join("f.txt").to_string_lossy().to_string();
-        engine.restore_change_block(tmp.path(), &abs, 2).unwrap();
+        engine.restore_change_blocks(tmp.path(), &abs, 2, 2).unwrap();
 
         let content = std::fs::read_to_string(tmp.path().join("f.txt")).unwrap();
         assert_eq!(content, "a\nb\nc\nd\ne\nf\ng\nh\ni\nj\n");
@@ -2884,7 +2916,7 @@ index abc..def 100644
     }
 
     #[test]
-    fn restore_change_block_keeps_other_staged_blocks() {
+    fn restore_change_blocks_keeps_other_staged_blocks() {
         let engine = GitEngine::new();
         let tmp = tempfile::tempdir().unwrap();
         if !init_repo(tmp.path()) {
@@ -2906,7 +2938,7 @@ index abc..def 100644
 
         let canon = tmp.path().canonicalize().unwrap();
         let abs = canon.join("f.txt").to_string_lossy().to_string();
-        engine.restore_change_block(tmp.path(), &abs, 6).unwrap();
+        engine.restore_change_blocks(tmp.path(), &abs, 6, 6).unwrap();
 
         let content = std::fs::read_to_string(tmp.path().join("f.txt")).unwrap();
         assert_eq!(content, "a\nB\nc\nd\ne\nf\ng\nh\ni\nj\n");
@@ -2921,7 +2953,7 @@ index abc..def 100644
     }
 
     #[test]
-    fn restore_change_block_discards_staged_and_worktree_versions() {
+    fn restore_change_blocks_discards_staged_and_worktree_versions() {
         let engine = GitEngine::new();
         let tmp = tempfile::tempdir().unwrap();
         if !init_repo(tmp.path()) {
@@ -2949,7 +2981,7 @@ index abc..def 100644
 
         let canon = tmp.path().canonicalize().unwrap();
         let abs = canon.join("f.txt").to_string_lossy().to_string();
-        engine.restore_change_block(tmp.path(), &abs, 2).unwrap();
+        engine.restore_change_blocks(tmp.path(), &abs, 2, 2).unwrap();
 
         let content = std::fs::read_to_string(tmp.path().join("f.txt")).unwrap();
         assert_eq!(content, "a\nb\nc\nd\ne\nf\ng\nh\ni\nj\n");

--- a/crates/arris-engines/src/git/types.rs
+++ b/crates/arris-engines/src/git/types.rs
@@ -46,6 +46,20 @@ pub struct DiffLine {
     pub text: String,
 }
 
+/// One contiguous run of added/deleted lines inside a diff, in zero-context
+/// patch coordinates (a zero count names the line BEFORE the change).
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct ChangeBlock {
+    pub(crate) old_start: u32,
+    pub(crate) old_count: u32,
+    pub(crate) new_start: u32,
+    pub(crate) new_count: u32,
+    /// True when the block ends its diff hunk with no trailing context line.
+    pub(crate) at_eof: bool,
+    /// The block as a standalone `@@ ... @@` hunk body (no file header).
+    pub(crate) hunk: String,
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct WorktreeInfo {

--- a/frontend/src/domains/editor/components/EditorPane/constants.ts
+++ b/frontend/src/domains/editor/components/EditorPane/constants.ts
@@ -2,6 +2,6 @@
 const AUTOSAVE_DEBOUNCE_MS = 500;
 // Extra pause after an autosave before redrawing the git gutter hunks, so
 // the change bands do not jump around during brief pauses while typing.
-const GIT_GUTTER_REFRESH_PAUSE_MS = 700;
+const GIT_GUTTER_REFRESH_PAUSE_MS = 200;
 
 export { AUTOSAVE_DEBOUNCE_MS, GIT_GUTTER_REFRESH_PAUSE_MS };

--- a/frontend/src/domains/editor/components/EditorPane/constants.ts
+++ b/frontend/src/domains/editor/components/EditorPane/constants.ts
@@ -1,0 +1,7 @@
+// Idle time after the last keystroke before the buffer autosaves to disk.
+const AUTOSAVE_DEBOUNCE_MS = 500;
+// Extra pause after an autosave before redrawing the git gutter hunks, so
+// the change bands do not jump around during brief pauses while typing.
+const GIT_GUTTER_REFRESH_PAUSE_MS = 700;
+
+export { AUTOSAVE_DEBOUNCE_MS, GIT_GUTTER_REFRESH_PAUSE_MS };

--- a/frontend/src/domains/editor/components/EditorPane/index.css
+++ b/frontend/src/domains/editor/components/EditorPane/index.css
@@ -59,13 +59,18 @@
   white-space: pre;
 }
 
-/* Per-hunk Stage / Restore action bar (Zed-style), shown above an expanded hunk. */
+/* Per-hunk Stage / Restore action bar (Zed-style), shown above an expanded hunk.
+   The widget is as wide as cm-content, which can exceed the visible pane when a
+   long line forces horizontal scroll; sticky keeps the buttons pinned inside the
+   viewport instead of at the content's far right edge. */
 .cm-git-hunk-actions {
+  position: sticky;
+  /* Pin right of the sticky gutters overlay, not the scrollport edge. */
+  left: var(--editor-gutters-width, 0px);
+  width: max-content;
   display: flex;
   gap: 4px;
-  justify-content: flex-end;
-  margin-left: calc(-1 * var(--git-gutter-offset, 0px));
-  padding: 2px 8px 2px 0;
+  padding: 2px 0;
 }
 .cm-git-hunk-btn {
   font-family: var(--m-font);

--- a/frontend/src/domains/editor/components/EditorPane/index.test.tsx
+++ b/frontend/src/domains/editor/components/EditorPane/index.test.tsx
@@ -49,7 +49,9 @@ import { useSqlMeshStore } from "@domains/sqlmesh/hooks";
 import { runCommand } from "@shell/utils";
 import type { KeymapAction } from "@shared/settings";
 import { useSettingsStore } from "@shared/settings";
-import { connectConnectionIPC, dbtCompileIPC, dbtDocsGenerateIPC, dbtDocsLoadIPC, dbtRunIPC, listSchemasIPC, runQueryIPC, sqlmeshPlanIPC, sqlmeshRenderIPC } from "./ipc";
+import { connectConnectionIPC, dbtCompileIPC, dbtDocsGenerateIPC, dbtDocsLoadIPC, dbtRunIPC, gitFileDiffHunksIPC, listSchemasIPC, runQueryIPC, sqlmeshPlanIPC, sqlmeshRenderIPC, writeTextFileIPC } from "./ipc";
+import { AUTOSAVE_DEBOUNCE_MS, GIT_GUTTER_REFRESH_PAUSE_MS } from "./constants";
+import { useGitStore } from "@domains/git/hooks";
 import { dbtSlimDiffIPC } from "./components/SlimDiff/ipc";
 import { SCHEMA_NODE_POINTER_DROP_EVENT } from "@domains/editor/utils/ui/schemaDrag";
 import { buildPreviewSql, NO_CONNECTION_MESSAGE } from "./utils";
@@ -1419,5 +1421,41 @@ describe("keystroke re-render guard", () => {
       useTabsStore.getState().updateTab("t1", { isRunning: true });
     });
     expect(commits).toBeGreaterThan(before);
+  });
+});
+
+describe("autosave git gutter debounce", () => {
+  it("redraws hunks only after an extra pause; a keystroke cancels the pending redraw", async () => {
+    vi.mocked(writeTextFileIPC).mockResolvedValue(undefined);
+    vi.mocked(gitFileDiffHunksIPC).mockResolvedValue([]);
+    useSettingsStore.setState({ autosave: true } as any);
+    useGitStore.setState({ repoPath: "/repo" } as any);
+    useTabsStore.setState({ tabs: [], layout: null, focusedPaneGroupId: null, activeId: null });
+    useTabsStore.getState().setTabs([{ ...tabFor("c1"), filePath: "/repo/file.sql" }]);
+
+    render(<EditorPane />);
+    await act(async () => {});
+    vi.mocked(gitFileDiffHunksIPC).mockClear();
+    vi.useFakeTimers();
+    try {
+      act(() => { useTabsStore.getState().updateTab("t1", { text: "select 1" }); });
+      await act(async () => { await vi.advanceTimersByTimeAsync(AUTOSAVE_DEBOUNCE_MS); });
+      expect(writeTextFileIPC).toHaveBeenCalledWith("/repo/file.sql", "select 1");
+      expect(gitFileDiffHunksIPC).not.toHaveBeenCalled();
+
+      // Typing again during the pause cancels the pending redraw.
+      act(() => { useTabsStore.getState().updateTab("t1", { text: "select 12" }); });
+      await act(async () => { await vi.advanceTimersByTimeAsync(GIT_GUTTER_REFRESH_PAUSE_MS); });
+      expect(gitFileDiffHunksIPC).not.toHaveBeenCalled();
+
+      // Full pause after the second save: exactly one redraw.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(AUTOSAVE_DEBOUNCE_MS + GIT_GUTTER_REFRESH_PAUSE_MS);
+      });
+      expect(gitFileDiffHunksIPC).toHaveBeenCalledTimes(1);
+      expect(gitFileDiffHunksIPC).toHaveBeenCalledWith("/repo", "/repo/file.sql");
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/frontend/src/domains/editor/components/EditorPane/index.test.tsx
+++ b/frontend/src/domains/editor/components/EditorPane/index.test.tsx
@@ -1299,6 +1299,21 @@ describe("run-status gutter", () => {
   });
 });
 
+// The bar is a CM block widget as wide as cm-content; without sticky
+// positioning its flex-end buttons sat at the CONTENT right edge, off-screen
+// whenever a long line made the content wider than the pane.
+describe("hunk action bar", () => {
+  it("pins the action bar inside the viewport, right of the gutters", () => {
+    const rule = editorPaneCss.match(/\.cm-git-hunk-actions\s*\{([\s\S]*?)\}/);
+    expect(rule, ".cm-git-hunk-actions rule").not.toBeNull();
+    const body = rule![1];
+    expect(body).toContain("position: sticky");
+    expect(body).toContain("left: var(--editor-gutters-width, 0px)");
+    expect(body).toContain("width: max-content");
+    expect(body).not.toContain("flex-end");
+  });
+});
+
 describe("statement highlight box", () => {
   it("draws the left edge with a 1px border, not a box-shadow", () => {
     const base = editorPaneCss.match(

--- a/frontend/src/domains/editor/components/EditorPane/index.tsx
+++ b/frontend/src/domains/editor/components/EditorPane/index.tsx
@@ -47,7 +47,7 @@ import {
   dbtRunIPC,
   dbtTestIPC,
   gitFileDiffHunksIPC,
-  gitRestoreHunkIPC,
+  gitRestoreChangeIPC,
   gitStageHunkIPC,
   listSchemasIPC,
   readTextFileIPC,
@@ -801,10 +801,10 @@ function PaneGroupView({ groupId }: { groupId: string }) {
           .then(() => refreshAfter(repo, filePath))
           .catch((e) => console.error("Stage hunk failed", e));
       },
-      onRestore: (hunkIndex) => {
+      onRestore: (anchorLine) => {
         const { repo, filePath, tabId, refreshToken } = gitHunkCtxRef.current;
         if (!repo || !filePath || !tabId) return;
-        gitRestoreHunkIPC(repo, filePath, hunkIndex)
+        gitRestoreChangeIPC(repo, filePath, anchorLine)
           .then(async () => {
             // Restore rewrites the working file on disk; reload it into the tab
             // and bump refreshToken so the editor remounts with fresh content.
@@ -1930,8 +1930,7 @@ function PaneGroupView({ groupId }: { groupId: string }) {
           const tab = freshActiveTab();
           if (!tab?.filePath) return;
           const line = cursorLineNumber(tab.text ?? "", tab.cursor ?? 0);
-          const hunkIndex = hunkIndexAtLine(diffHunks, line);
-          if (hunkIndex !== null) diffHunkActions.onRestore(hunkIndex);
+          if (hunkIndexAtLine(diffHunks, line) !== null) diffHunkActions.onRestore(line);
         },
         isEnabled: () => !!activeTab?.filePath && diffHunks.length > 0,
       },

--- a/frontend/src/domains/editor/components/EditorPane/index.tsx
+++ b/frontend/src/domains/editor/components/EditorPane/index.tsx
@@ -77,7 +77,7 @@ import { EditorTabRouter } from "./components/EditorTabRouter";
 import type { MarkdownViewMode } from "../MarkdownPreview/types";
 import { dbtSlimDiffIPC } from "./components/SlimDiff/ipc";
 import type { DbtDiffRunConfig } from "./components/SlimDiff/types";
-import { buildPreviewSql, resolveRunRange, resolveRunSql, resolveTabConnectionId, runErrorMessage, tabEqualIgnoringVolatile, tabsEqualIgnoringVolatile, NO_CONNECTION_MESSAGE } from "./utils";
+import { buildPreviewSql, cursorLineNumber, hunkIndexAtLine, resolveRunRange, resolveRunSql, resolveTabConnectionId, runErrorMessage, tabEqualIgnoringVolatile, tabsEqualIgnoringVolatile, NO_CONNECTION_MESSAGE } from "./utils";
 import { useStoreWithEqualityFn } from "zustand/traditional";
 
 import { Icon } from "@shared/ui/Icon";
@@ -1925,6 +1925,16 @@ function PaneGroupView({ groupId }: { groupId: string }) {
       splitLeft: { run: () => { if (activeTab) handleSplit(activeTab.id, "left"); }, isEnabled: () => !!activeTab },
       splitTop: { run: () => { if (activeTab) handleSplit(activeTab.id, "up"); }, isEnabled: () => !!activeTab },
       splitBottom: { run: () => { if (activeTab) handleSplit(activeTab.id, "down"); }, isEnabled: () => !!activeTab },
+      gitDiscardHunk: {
+        run: () => {
+          const tab = freshActiveTab();
+          if (!tab?.filePath) return;
+          const line = cursorLineNumber(tab.text ?? "", tab.cursor ?? 0);
+          const hunkIndex = hunkIndexAtLine(diffHunks, line);
+          if (hunkIndex !== null) diffHunkActions.onRestore(hunkIndex);
+        },
+        isEnabled: () => !!activeTab?.filePath && diffHunks.length > 0,
+      },
       newTerminalTab: { run: () => newTerminalTab() },
       newNotebookTab: { run: () => newNotebookTab() },
       newCanvasTab: { run: () => newCanvasTab() },

--- a/frontend/src/domains/editor/components/EditorPane/index.tsx
+++ b/frontend/src/domains/editor/components/EditorPane/index.tsx
@@ -77,7 +77,7 @@ import { EditorTabRouter } from "./components/EditorTabRouter";
 import type { MarkdownViewMode } from "../MarkdownPreview/types";
 import { dbtSlimDiffIPC } from "./components/SlimDiff/ipc";
 import type { DbtDiffRunConfig } from "./components/SlimDiff/types";
-import { buildPreviewSql, cursorLineNumber, hunkIndexAtLine, resolveRunRange, resolveRunSql, resolveTabConnectionId, runErrorMessage, tabEqualIgnoringVolatile, tabsEqualIgnoringVolatile, NO_CONNECTION_MESSAGE } from "./utils";
+import { buildPreviewSql, discardLineRange, hunkInRange, resolveRunRange, resolveRunSql, resolveTabConnectionId, runErrorMessage, tabEqualIgnoringVolatile, tabsEqualIgnoringVolatile, NO_CONNECTION_MESSAGE } from "./utils";
 import { useStoreWithEqualityFn } from "zustand/traditional";
 
 import { Icon } from "@shared/ui/Icon";
@@ -801,10 +801,10 @@ function PaneGroupView({ groupId }: { groupId: string }) {
           .then(() => refreshAfter(repo, filePath))
           .catch((e) => console.error("Stage hunk failed", e));
       },
-      onRestore: (anchorLine) => {
+      onRestore: (startLine, endLine) => {
         const { repo, filePath, tabId, refreshToken } = gitHunkCtxRef.current;
         if (!repo || !filePath || !tabId) return;
-        gitRestoreChangeIPC(repo, filePath, anchorLine)
+        gitRestoreChangeIPC(repo, filePath, startLine, endLine)
           .then(async () => {
             // Restore rewrites the working file on disk; reload it into the tab
             // and bump refreshToken so the editor remounts with fresh content.
@@ -1929,8 +1929,8 @@ function PaneGroupView({ groupId }: { groupId: string }) {
         run: () => {
           const tab = freshActiveTab();
           if (!tab?.filePath) return;
-          const line = cursorLineNumber(tab.text ?? "", tab.cursor ?? 0);
-          if (hunkIndexAtLine(diffHunks, line) !== null) diffHunkActions.onRestore(line);
+          const { startLine, endLine } = discardLineRange(tab.text ?? "", tab.cursor ?? 0, tab.selection);
+          if (hunkInRange(diffHunks, startLine, endLine)) diffHunkActions.onRestore(startLine, endLine);
         },
         isEnabled: () => !!activeTab?.filePath && diffHunks.length > 0,
       },

--- a/frontend/src/domains/editor/components/EditorPane/index.tsx
+++ b/frontend/src/domains/editor/components/EditorPane/index.tsx
@@ -78,6 +78,7 @@ import type { MarkdownViewMode } from "../MarkdownPreview/types";
 import { dbtSlimDiffIPC } from "./components/SlimDiff/ipc";
 import type { DbtDiffRunConfig } from "./components/SlimDiff/types";
 import { buildPreviewSql, discardLineRange, hunkInRange, resolveRunRange, resolveRunSql, resolveTabConnectionId, runErrorMessage, tabEqualIgnoringVolatile, tabsEqualIgnoringVolatile, NO_CONNECTION_MESSAGE } from "./utils";
+import { AUTOSAVE_DEBOUNCE_MS, GIT_GUTTER_REFRESH_PAUSE_MS } from "./constants";
 import { useStoreWithEqualityFn } from "zustand/traditional";
 
 import { Icon } from "@shared/ui/Icon";
@@ -1153,11 +1154,14 @@ function PaneGroupView({ groupId }: { groupId: string }) {
     const filePath = activeTab.filePath;
     const tabId = activeTab.id;
     let timer: ReturnType<typeof setTimeout> | null = null;
+    let hunksTimer: ReturnType<typeof setTimeout> | null = null;
     const unsubscribe = useTabsStore.subscribe((state, prev) => {
       const next = state.tabs.find((t) => t.id === tabId);
       const before = prev.tabs.find((t) => t.id === tabId);
       if (!next || !before || next.text === before.text) return;
       if (timer) clearTimeout(timer);
+      // A pending gutter redraw mid-typing is distracting; wait for a real pause.
+      if (hunksTimer) clearTimeout(hunksTimer);
       timer = setTimeout(() => {
         // Mark the write so its watcher echo isn't mistaken for an external edit.
         const content = next.text;
@@ -1167,16 +1171,19 @@ function PaneGroupView({ groupId }: { groupId: string }) {
             await useGitStore.getState().refreshFileStatuses().catch(() => {});
             const repo = gitRepoPath ?? useFilesStore.getState().rootPath;
             if (repo) {
-              gitFileDiffHunksIPC(repo, filePath)
-                .then(setDiffHunks)
-                .catch(() => setDiffHunks([]));
+              hunksTimer = setTimeout(() => {
+                gitFileDiffHunksIPC(repo, filePath)
+                  .then(setDiffHunks)
+                  .catch(() => setDiffHunks([]));
+              }, GIT_GUTTER_REFRESH_PAUSE_MS);
             }
           })
           .catch((e) => console.error("Autosave failed", e));
-      }, 500);
+      }, AUTOSAVE_DEBOUNCE_MS);
     });
     return () => {
       if (timer) clearTimeout(timer);
+      if (hunksTimer) clearTimeout(hunksTimer);
       unsubscribe();
     };
   }, [autosave, activeTab?.id, activeTab?.filePath, activeTab?.tabType, gitRepoPath]);

--- a/frontend/src/domains/editor/components/EditorPane/ipc.ts
+++ b/frontend/src/domains/editor/components/EditorPane/ipc.ts
@@ -87,8 +87,13 @@ function gitStageHunkIPC(repo: string, filePath: string, hunkIndex: number): Pro
   return invoke("cmd_git_stage_hunk", { repo, filePath, hunkIndex });
 }
 
-function gitRestoreChangeIPC(repo: string, filePath: string, line: number): Promise<void> {
-  return invoke("cmd_git_restore_change", { repo, filePath, line });
+function gitRestoreChangeIPC(
+  repo: string,
+  filePath: string,
+  startLine: number,
+  endLine: number,
+): Promise<void> {
+  return invoke("cmd_git_restore_change", { repo, filePath, startLine, endLine });
 }
 
 function listSchemasIPC(connectionId: string): Promise<SchemaNode[]> {

--- a/frontend/src/domains/editor/components/EditorPane/ipc.ts
+++ b/frontend/src/domains/editor/components/EditorPane/ipc.ts
@@ -87,8 +87,8 @@ function gitStageHunkIPC(repo: string, filePath: string, hunkIndex: number): Pro
   return invoke("cmd_git_stage_hunk", { repo, filePath, hunkIndex });
 }
 
-function gitRestoreHunkIPC(repo: string, filePath: string, hunkIndex: number): Promise<void> {
-  return invoke("cmd_git_restore_hunk", { repo, filePath, hunkIndex });
+function gitRestoreChangeIPC(repo: string, filePath: string, line: number): Promise<void> {
+  return invoke("cmd_git_restore_change", { repo, filePath, line });
 }
 
 function listSchemasIPC(connectionId: string): Promise<SchemaNode[]> {
@@ -214,7 +214,7 @@ export {
   dbtTestIPC,
   explainQueryIPC,
   gitFileDiffHunksIPC,
-  gitRestoreHunkIPC,
+  gitRestoreChangeIPC,
   gitStageHunkIPC,
   listSchemasIPC,
   readTextFileIPC,

--- a/frontend/src/domains/editor/components/EditorPane/utils.test.ts
+++ b/frontend/src/domains/editor/components/EditorPane/utils.test.ts
@@ -25,8 +25,10 @@ import { useDbtStore } from "@domains/dbt/hooks";
 import {
   buildPreviewSql,
   closeActiveTab,
+  cursorLineNumber,
   DBT_PREVIEW_ROW_LIMIT,
   executeActiveQuery,
+  hunkIndexAtLine,
   NO_CONNECTION_MESSAGE,
   openNewConsoleTab,
   resolveRunRange,
@@ -518,6 +520,43 @@ describe("resolveRunRange", () => {
     const cursor = cli.indexOf("HGETALL") + 3;
     const tab = { text: cli, kind: "rediscli", cursor } as any;
     expect(resolveRunRange(tab)).toEqual({ from: 9, to: cli.length });
+  });
+});
+
+describe("cursorLineNumber", () => {
+  it("returns 1 for offset 0", () => {
+    expect(cursorLineNumber("a\nb\nc", 0)).toBe(1);
+  });
+
+  it("maps an offset after a newline to the next line", () => {
+    expect(cursorLineNumber("a\nb\nc", 2)).toBe(2);
+    expect(cursorLineNumber("a\nb\nc", 4)).toBe(3);
+  });
+
+  it("clamps offsets beyond the text length", () => {
+    expect(cursorLineNumber("a\nb", 99)).toBe(2);
+  });
+});
+
+describe("hunkIndexAtLine", () => {
+  const hunks = [
+    { oldStart: 1, oldCount: 0, newStart: 3, newCount: 2, lines: [] },
+    { oldStart: 10, oldCount: 2, newStart: 12, newCount: 0, lines: [] },
+  ];
+
+  it("finds the hunk containing the line", () => {
+    expect(hunkIndexAtLine(hunks, 3)).toBe(0);
+    expect(hunkIndexAtLine(hunks, 4)).toBe(0);
+  });
+
+  it("treats a deletion-only hunk as occupying its anchor line", () => {
+    expect(hunkIndexAtLine(hunks, 12)).toBe(1);
+  });
+
+  it("returns null outside every hunk", () => {
+    expect(hunkIndexAtLine(hunks, 1)).toBeNull();
+    expect(hunkIndexAtLine(hunks, 8)).toBeNull();
+    expect(hunkIndexAtLine([], 1)).toBeNull();
   });
 });
 

--- a/frontend/src/domains/editor/components/EditorPane/utils.test.ts
+++ b/frontend/src/domains/editor/components/EditorPane/utils.test.ts
@@ -26,9 +26,10 @@ import {
   buildPreviewSql,
   closeActiveTab,
   cursorLineNumber,
+  discardLineRange,
   DBT_PREVIEW_ROW_LIMIT,
   executeActiveQuery,
-  hunkIndexAtLine,
+  hunkInRange,
   NO_CONNECTION_MESSAGE,
   openNewConsoleTab,
   resolveRunRange,
@@ -538,25 +539,51 @@ describe("cursorLineNumber", () => {
   });
 });
 
-describe("hunkIndexAtLine", () => {
+describe("hunkInRange", () => {
   const hunks = [
     { oldStart: 1, oldCount: 0, newStart: 3, newCount: 2, lines: [] },
     { oldStart: 10, oldCount: 2, newStart: 12, newCount: 0, lines: [] },
   ];
 
-  it("finds the hunk containing the line", () => {
-    expect(hunkIndexAtLine(hunks, 3)).toBe(0);
-    expect(hunkIndexAtLine(hunks, 4)).toBe(0);
+  it("matches a single-line range inside a hunk", () => {
+    expect(hunkInRange(hunks, 3, 3)).toBe(true);
+    expect(hunkInRange(hunks, 4, 4)).toBe(true);
+  });
+
+  it("matches a multi-line range spanning hunks and gaps", () => {
+    expect(hunkInRange(hunks, 1, 3)).toBe(true);
+    expect(hunkInRange(hunks, 5, 20)).toBe(true);
   });
 
   it("treats a deletion-only hunk as occupying its anchor line", () => {
-    expect(hunkIndexAtLine(hunks, 12)).toBe(1);
+    expect(hunkInRange(hunks, 12, 12)).toBe(true);
   });
 
-  it("returns null outside every hunk", () => {
-    expect(hunkIndexAtLine(hunks, 1)).toBeNull();
-    expect(hunkIndexAtLine(hunks, 8)).toBeNull();
-    expect(hunkIndexAtLine([], 1)).toBeNull();
+  it("returns false when the range misses every hunk", () => {
+    expect(hunkInRange(hunks, 1, 2)).toBe(false);
+    expect(hunkInRange(hunks, 5, 11)).toBe(false);
+    expect(hunkInRange([], 1, 99)).toBe(false);
+  });
+});
+
+describe("discardLineRange", () => {
+  const text = "a\nb\nc\nd\n";
+
+  it("uses the cursor line when there is no selection", () => {
+    expect(discardLineRange(text, 2, undefined)).toEqual({ startLine: 2, endLine: 2 });
+  });
+
+  it("uses the cursor line for an empty selection", () => {
+    expect(discardLineRange(text, 4, { from: 4, to: 4 })).toEqual({ startLine: 3, endLine: 3 });
+  });
+
+  it("spans the selection's lines regardless of direction", () => {
+    expect(discardLineRange(text, 0, { from: 1, to: 5 })).toEqual({ startLine: 1, endLine: 3 });
+    expect(discardLineRange(text, 0, { from: 5, to: 1 })).toEqual({ startLine: 1, endLine: 3 });
+  });
+
+  it("excludes a trailing line when the selection ends at column 0", () => {
+    expect(discardLineRange(text, 0, { from: 0, to: 4 })).toEqual({ startLine: 1, endLine: 2 });
   });
 });
 

--- a/frontend/src/domains/editor/components/EditorPane/utils.ts
+++ b/frontend/src/domains/editor/components/EditorPane/utils.ts
@@ -341,16 +341,33 @@ function cursorLineNumber(text: string, cursor: number): number {
   return line;
 }
 
-// Index of the hunk whose new-file line span contains `line`, or null. A
-// deletion-only hunk (newCount 0) occupies no new-file lines; treat its anchor
-// row (the line the deleted block sits above) as its span.
-function hunkIndexAtLine(hunks: DiffHunk[], line: number): number | null {
-  for (const [index, hunk] of hunks.entries()) {
+// 1-based line span to discard: the selection's lines when non-empty (a
+// selection ending at column 0 excludes that line), else the cursor's line.
+function discardLineRange(
+  text: string,
+  cursor: number,
+  selection: { from: number; to: number } | undefined,
+): { startLine: number; endLine: number } {
+  if (!selection || selection.from === selection.to) {
+    const line = cursorLineNumber(text, cursor);
+    return { startLine: line, endLine: line };
+  }
+  const lo = Math.min(selection.from, selection.to);
+  const hi = Math.max(selection.from, selection.to);
+  const startLine = cursorLineNumber(text, lo);
+  let endLine = cursorLineNumber(text, hi);
+  if (endLine > startLine && text.charCodeAt(hi - 1) === 10) endLine--;
+  return { startLine, endLine };
+}
+
+// Whether any hunk's new-file span intersects lines start..end. A deletion-
+// only hunk (newCount 0) spans its anchor row (the line it sits above).
+function hunkInRange(hunks: DiffHunk[], startLine: number, endLine: number): boolean {
+  return hunks.some((hunk) => {
     const start = Math.max(1, hunk.newStart);
     const end = start + Math.max(hunk.newCount, 1) - 1;
-    if (line >= start && line <= end) return index;
-  }
-  return null;
+    return start <= endLine && startLine <= end;
+  });
 }
 
 const VOLATILE_TAB_FIELDS = new Set(["text", "cursor", "selection", "scrollAnchor"]);
@@ -395,7 +412,8 @@ export {
   saveActiveFile,
   exportActiveResults,
   cursorLineNumber,
-  hunkIndexAtLine,
+  discardLineRange,
+  hunkInRange,
   tabEqualIgnoringVolatile,
   tabsEqualIgnoringVolatile,
 };

--- a/frontend/src/domains/editor/components/EditorPane/utils.ts
+++ b/frontend/src/domains/editor/components/EditorPane/utils.ts
@@ -16,7 +16,7 @@ import { useFilesStore } from "@domains/files/hooks";
 import { useDbtStore } from "@domains/dbt/hooks";
 import { exportResults, type ExportFormat } from "@domains/results";
 import { useSettingsStore } from "@shared/settings";
-import { ipcErrorMessage, type PlanResult } from "@shared";
+import { ipcErrorMessage, type DiffHunk, type PlanResult } from "@shared";
 import {
   cancelQueryIPC,
   explainQueryIPC,
@@ -331,6 +331,28 @@ function exportActiveResults(format: ExportFormat): boolean {
 // need structural tab state (id/kind/title/result/isRunning/...) compare with
 // these ignored so typing does not re-render the whole pane group; handlers
 // that need the live buffer read it from the store at invocation time.
+// 1-based line number of a character offset in the buffer.
+function cursorLineNumber(text: string, cursor: number): number {
+  const bounded = Math.max(0, Math.min(cursor, text.length));
+  let line = 1;
+  for (let i = 0; i < bounded; i++) {
+    if (text.charCodeAt(i) === 10) line++;
+  }
+  return line;
+}
+
+// Index of the hunk whose new-file line span contains `line`, or null. A
+// deletion-only hunk (newCount 0) occupies no new-file lines; treat its anchor
+// row (the line the deleted block sits above) as its span.
+function hunkIndexAtLine(hunks: DiffHunk[], line: number): number | null {
+  for (const [index, hunk] of hunks.entries()) {
+    const start = Math.max(1, hunk.newStart);
+    const end = start + Math.max(hunk.newCount, 1) - 1;
+    if (line >= start && line <= end) return index;
+  }
+  return null;
+}
+
 const VOLATILE_TAB_FIELDS = new Set(["text", "cursor", "selection", "scrollAnchor"]);
 
 function tabEqualIgnoringVolatile(
@@ -372,6 +394,8 @@ export {
   stopActiveQuery,
   saveActiveFile,
   exportActiveResults,
+  cursorLineNumber,
+  hunkIndexAtLine,
   tabEqualIgnoringVolatile,
   tabsEqualIgnoringVolatile,
 };

--- a/frontend/src/domains/editor/utils/ui/constants.ts
+++ b/frontend/src/domains/editor/utils/ui/constants.ts
@@ -19,8 +19,14 @@ const SEMANTIC_PARSE_BUDGET_MS = 50;
 // the rapid scroll-event stream into one store write once scrolling settles.
 const SCROLL_ANCHOR_DEBOUNCE_MS = 150;
 
+// Measured width of the sticky .cm-gutters strip. The hunk action bar is
+// position: sticky and must pin RIGHT of the gutters, which overlay content
+// during horizontal scroll.
+const GUTTERS_WIDTH_CSS_VAR = "--editor-gutters-width";
+
 export {
   SEMANTIC_CONTEXT_CHARS,
   SEMANTIC_PARSE_BUDGET_MS,
   SCROLL_ANCHOR_DEBOUNCE_MS,
+  GUTTERS_WIDTH_CSS_VAR,
 };

--- a/frontend/src/domains/editor/utils/ui/gitGutter.test.ts
+++ b/frontend/src/domains/editor/utils/ui/gitGutter.test.ts
@@ -301,7 +301,7 @@ describe("buildMarkers anchorHunk", () => {
 
 describe("HunkActionsWidget", () => {
   it("renders Stage and Discard buttons", () => {
-    const widget = new HunkActionsWidget(0, { onStage: () => {}, onRestore: () => {} });
+    const widget = new HunkActionsWidget(0, 1, { onStage: () => {}, onRestore: () => {} });
     const dom = widget.toDOM();
     expect(dom.className).toBe("cm-git-hunk-actions");
     expect(dom.children.length).toBe(2);
@@ -312,7 +312,7 @@ describe("HunkActionsWidget", () => {
   it("fires onStage / onRestore with the hunk index on mousedown", () => {
     let staged = -1;
     let restored = -1;
-    const widget = new HunkActionsWidget(2, {
+    const widget = new HunkActionsWidget(2, 7, {
       onStage: (i) => { staged = i; },
       onRestore: (i) => { restored = i; },
     });
@@ -320,13 +320,14 @@ describe("HunkActionsWidget", () => {
     (dom.children[0] as HTMLButtonElement).dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
     (dom.children[1] as HTMLButtonElement).dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
     expect(staged).toBe(2);
-    expect(restored).toBe(2);
+    expect(restored).toBe(7);
   });
 
-  it("eq compares by hunk index", () => {
+  it("eq compares by hunk index and anchor line", () => {
     const noop = { onStage: () => {}, onRestore: () => {} };
-    expect(new HunkActionsWidget(1, noop).eq(new HunkActionsWidget(1, noop))).toBe(true);
-    expect(new HunkActionsWidget(1, noop).eq(new HunkActionsWidget(2, noop))).toBe(false);
+    expect(new HunkActionsWidget(1, 5, noop).eq(new HunkActionsWidget(1, 5, noop))).toBe(true);
+    expect(new HunkActionsWidget(1, 5, noop).eq(new HunkActionsWidget(2, 5, noop))).toBe(false);
+    expect(new HunkActionsWidget(1, 5, noop).eq(new HunkActionsWidget(1, 6, noop))).toBe(false);
   });
 });
 

--- a/frontend/src/domains/editor/utils/ui/gitGutter.test.ts
+++ b/frontend/src/domains/editor/utils/ui/gitGutter.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { EditorState } from "@codemirror/state";
 import { EditorView } from "@codemirror/view";
 import {
@@ -355,6 +355,36 @@ describe("gitGutterExtension", () => {
 
     view.destroy();
     host.remove();
+  });
+
+  it("publishes the measured gutters width for the sticky action bar", () => {
+    const rafQueue: FrameRequestCallback[] = [];
+    const rafSpy = vi
+      .spyOn(globalThis, "requestAnimationFrame")
+      .mockImplementation((cb: FrameRequestCallback) => rafQueue.push(cb));
+    const rectSpy = vi
+      .spyOn(Element.prototype, "getBoundingClientRect")
+      .mockImplementation(function (this: Element) {
+        const width = this.classList.contains("cm-gutters") ? 44 : 0;
+        return { x: 0, y: 0, top: 0, left: 0, right: width, bottom: 0, width, height: 0, toJSON: () => ({}) } as DOMRect;
+      });
+    const host = document.createElement("div");
+    document.body.appendChild(host);
+    const view = new EditorView({
+      state: EditorState.create({
+        doc: "hello\nworld",
+        extensions: [gitGutterExtension([makeHunk()])],
+      }),
+      parent: host,
+    });
+
+    rafQueue.splice(0).forEach((cb) => cb(0));
+    expect(view.dom.style.getPropertyValue("--editor-gutters-width")).toBe("44px");
+
+    view.destroy();
+    host.remove();
+    rectSpy.mockRestore();
+    rafSpy.mockRestore();
   });
 
   it("omits the action bar when no actions are provided", () => {

--- a/frontend/src/domains/editor/utils/ui/gitGutter.test.ts
+++ b/frontend/src/domains/editor/utils/ui/gitGutter.test.ts
@@ -162,6 +162,43 @@ describe("buildMarkers", () => {
   });
 });
 
+describe("buildMarkers add-run grouping", () => {
+  const doc = EditorState.create({ doc: "l1\nl2\nl3\nl4\nl5" }).doc;
+
+  it("gives consecutive added rows one shared anchor", () => {
+    const hunk = makeHunk({
+      oldStart: 1, oldCount: 0, newStart: 2, newCount: 3,
+      lines: [
+        { kind: "add", text: "a" },
+        { kind: "add", text: "b" },
+        { kind: "add", text: "c" },
+      ],
+    });
+    const { clickAnchor, anchorHunk } = buildMarkers([hunk], doc);
+    expect(clickAnchor.get(2)).toBe(2);
+    expect(clickAnchor.get(3)).toBe(2);
+    expect(clickAnchor.get(4)).toBe(2);
+    expect(anchorHunk.size).toBe(1);
+    expect(anchorHunk.get(2)).toBe(0);
+  });
+
+  it("splits add runs separated by a context line into distinct anchors", () => {
+    const hunk = makeHunk({
+      oldStart: 1, oldCount: 1, newStart: 1, newCount: 3,
+      lines: [
+        { kind: "add", text: "a" },
+        { kind: "ctx", text: "keep" },
+        { kind: "add", text: "b" },
+      ],
+    });
+    const { clickAnchor, anchorHunk } = buildMarkers([hunk], doc);
+    expect(clickAnchor.get(1)).toBe(1);
+    expect(clickAnchor.get(3)).toBe(3);
+    expect(anchorHunk.get(1)).toBe(0);
+    expect(anchorHunk.get(3)).toBe(0);
+  });
+});
+
 describe("expandedHunksField", () => {
   it("toggles hunk expansion on/off via effects", () => {
     const state = EditorState.create({
@@ -234,6 +271,20 @@ describe("buildMarkers anchorHunk", () => {
     const result = buildMarkers(hunks, doc);
     expect(result.anchorHunk.get(1)).toBe(0);
     expect(result.anchorHunk.get(3)).toBe(1);
+  });
+
+  it("maps a hunk-trailing deletion anchor to its hunk index", () => {
+    const doc = EditorState.create({ doc: "l1\nl2\nl3" }).doc;
+    const hunk = makeHunk({
+      oldStart: 2, oldCount: 2, newStart: 2, newCount: 1,
+      lines: [
+        { kind: "ctx", text: "l2" },
+        { kind: "del", text: "gone" },
+      ],
+    });
+    const { anchorHunk, pureDelAnchors } = buildMarkers([hunk], doc);
+    expect(pureDelAnchors.has(3)).toBe(true);
+    expect(anchorHunk.get(3)).toBe(0);
   });
 
   it("maps a modification anchor to its hunk index", () => {

--- a/frontend/src/domains/editor/utils/ui/gitGutter.test.ts
+++ b/frontend/src/domains/editor/utils/ui/gitGutter.test.ts
@@ -8,6 +8,7 @@ import {
   DeletedLinesWidget,
   HunkActionsWidget,
   gitGutterExtension,
+  hunkField,
 } from "./gitGutter";
 import type { DiffHunk } from "@shared";
 
@@ -458,6 +459,61 @@ describe("gitGutterExtension", () => {
 
     view.dispatch({ effects: toggleHunkEffect.of(1) });
     expect(view.dom.querySelector(".cm-git-hunk-actions")).toBeFalsy();
+
+    view.destroy();
+    host.remove();
+  });
+});
+
+describe("hunkField mapping through edits", () => {
+  function mountWithAddAtLine3() {
+    const hunk = makeHunk({
+      oldStart: 2, oldCount: 0, newStart: 3, newCount: 1,
+      lines: [{ kind: "add", text: "line3" }],
+    });
+    const host = document.createElement("div");
+    document.body.appendChild(host);
+    const view = new EditorView({
+      state: EditorState.create({
+        doc: "line1\nline2\nline3\nline4\nline5",
+        extensions: [gitGutterExtension([hunk])],
+      }),
+      parent: host,
+    });
+    return { view, host };
+  }
+
+  function markerPositions(view: EditorView): number[] {
+    const positions: number[] = [];
+    view.state.field(hunkField).markers.between(0, view.state.doc.length, (from) => {
+      positions.push(from);
+    });
+    return positions;
+  }
+
+  it("shifts bands down with their text when a line is inserted above", () => {
+    const { view, host } = mountWithAddAtLine3();
+    view.dispatch({ changes: { from: 0, insert: "line0\n" } });
+
+    const field = view.state.field(hunkField);
+    expect(field.lineTypes.has(3)).toBe(false);
+    expect(field.lineTypes.get(4)).toBe("add");
+    expect(field.clickAnchor.get(4)).toBe(4);
+    expect(field.anchorHunk.get(4)).toBe(0);
+    expect(markerPositions(view)).toEqual([view.state.doc.line(4).from]);
+
+    view.destroy();
+    host.remove();
+  });
+
+  it("keeps bands in place when typing inside an earlier line", () => {
+    const { view, host } = mountWithAddAtLine3();
+    view.dispatch({ changes: { from: 1, insert: "x" } });
+
+    const field = view.state.field(hunkField);
+    expect(field.lineTypes.get(3)).toBe("add");
+    expect(field.clickAnchor.get(3)).toBe(3);
+    expect(markerPositions(view)).toEqual([view.state.doc.line(3).from]);
 
     view.destroy();
     host.remove();

--- a/frontend/src/domains/editor/utils/ui/gitGutter.test.ts
+++ b/frontend/src/domains/editor/utils/ui/gitGutter.test.ts
@@ -309,18 +309,18 @@ describe("HunkActionsWidget", () => {
     expect(dom.children[1].textContent).toBe("Discard");
   });
 
-  it("fires onStage / onRestore with the hunk index on mousedown", () => {
+  it("fires onStage with the hunk index and onRestore with the anchor line span", () => {
     let staged = -1;
-    let restored = -1;
+    let restored: number[] = [];
     const widget = new HunkActionsWidget(2, 7, {
       onStage: (i) => { staged = i; },
-      onRestore: (i) => { restored = i; },
+      onRestore: (start, end) => { restored = [start, end]; },
     });
     const dom = widget.toDOM();
     (dom.children[0] as HTMLButtonElement).dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
     (dom.children[1] as HTMLButtonElement).dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
     expect(staged).toBe(2);
-    expect(restored).toBe(7);
+    expect(restored).toEqual([7, 7]);
   });
 
   it("eq compares by hunk index and anchor line", () => {

--- a/frontend/src/domains/editor/utils/ui/gitGutter.ts
+++ b/frontend/src/domains/editor/utils/ui/gitGutter.ts
@@ -13,6 +13,7 @@ import {
   gutter,
 } from "@codemirror/view";
 import type { DiffHunk, DiffLine } from "@shared";
+import { GUTTERS_WIDTH_CSS_VAR } from "./constants";
 
 interface GitHunkActions {
   onStage: (hunkIndex: number) => void;
@@ -276,6 +277,13 @@ const gutterOffsetPlugin = ViewPlugin.define((view) => {
       const offset = contentLeft - gutterLeft;
       if (offset > 0) {
         view.dom.style.setProperty("--git-gutter-offset", `${offset}px`);
+      }
+    }
+    const guttersEl = view.dom.querySelector(".cm-gutters");
+    if (guttersEl) {
+      const width = guttersEl.getBoundingClientRect().width;
+      if (width > 0) {
+        view.dom.style.setProperty(GUTTERS_WIDTH_CSS_VAR, `${width}px`);
       }
     }
   }

--- a/frontend/src/domains/editor/utils/ui/gitGutter.ts
+++ b/frontend/src/domains/editor/utils/ui/gitGutter.ts
@@ -17,7 +17,9 @@ import { GUTTERS_WIDTH_CSS_VAR } from "./constants";
 
 interface GitHunkActions {
   onStage: (hunkIndex: number) => void;
-  onRestore: (hunkIndex: number) => void;
+  /// Discards the change BLOCK at this new-file line, not the whole git hunk
+  /// (git merges nearby edits into one hunk).
+  onRestore: (anchorLine: number) => void;
 }
 
 class GitAddedMarker extends GutterMarker {
@@ -236,13 +238,14 @@ class DeletedLinesWidget extends WidgetType {
 class HunkActionsWidget extends WidgetType {
   constructor(
     readonly hunkIndex: number,
+    readonly anchorLine: number,
     readonly actions: GitHunkActions,
   ) {
     super();
   }
 
   eq(other: HunkActionsWidget) {
-    return this.hunkIndex === other.hunkIndex;
+    return this.hunkIndex === other.hunkIndex && this.anchorLine === other.anchorLine;
   }
 
   toDOM() {
@@ -266,7 +269,7 @@ class HunkActionsWidget extends WidgetType {
     restore.onmousedown = (event) => {
       event.preventDefault();
       event.stopPropagation();
-      this.actions.onRestore(this.hunkIndex);
+      this.actions.onRestore(this.anchorLine);
     };
 
     bar.append(stage, restore);
@@ -346,7 +349,7 @@ function gitGutterExtension(hunks: DiffHunk[], actions?: GitHunkActions): Extens
             decos.push({
               pos,
               deco: Decoration.widget({
-                widget: new HunkActionsWidget(hunkIndex, actions),
+                widget: new HunkActionsWidget(hunkIndex, anchor, actions),
                 block: true,
                 side: -1,
               }),

--- a/frontend/src/domains/editor/utils/ui/gitGutter.ts
+++ b/frontend/src/domains/editor/utils/ui/gitGutter.ts
@@ -2,6 +2,7 @@ import {
   RangeSet,
   StateEffect,
   StateField,
+  type Transaction,
   type Extension,
 } from "@codemirror/state";
 import {
@@ -180,10 +181,54 @@ function buildMarkers(
   };
 }
 
+// Re-anchor the hunk data to the edited document so the bands stay glued to
+// their text while typing, instead of drifting until the next diff refresh.
+function mapBuiltMarkers(value: BuiltMarkers, tr: Transaction): BuiltMarkers {
+  const mapLine = (n: number): number | null => {
+    if (n < 1 || n > tr.startState.doc.lines) return null;
+    const pos = tr.changes.mapPos(tr.startState.doc.line(n).from, 1);
+    return tr.newDoc.lineAt(pos).number;
+  };
+  const inlineDiffs = new Map<number, DiffLine[]>();
+  for (const [line, dels] of value.inlineDiffs) {
+    const mapped = mapLine(line);
+    if (mapped != null) inlineDiffs.set(mapped, dels);
+  }
+  const lineTypes = new Map<number, "add" | "mod">();
+  for (const [line, type] of value.lineTypes) {
+    const mapped = mapLine(line);
+    if (mapped != null) lineTypes.set(mapped, type);
+  }
+  const clickAnchor = new Map<number, number>();
+  for (const [line, anchor] of value.clickAnchor) {
+    const mapped = mapLine(line);
+    const mappedAnchor = mapLine(anchor);
+    if (mapped != null && mappedAnchor != null) clickAnchor.set(mapped, mappedAnchor);
+  }
+  const pureDelAnchors = new Set<number>();
+  for (const anchor of value.pureDelAnchors) {
+    const mapped = mapLine(anchor);
+    if (mapped != null) pureDelAnchors.add(mapped);
+  }
+  const anchorHunk = new Map<number, number>();
+  for (const [anchor, hunkIndex] of value.anchorHunk) {
+    const mapped = mapLine(anchor);
+    if (mapped != null) anchorHunk.set(mapped, hunkIndex);
+  }
+  return {
+    markers: value.markers.map(tr.changes),
+    inlineDiffs,
+    lineTypes,
+    clickAnchor,
+    pureDelAnchors,
+    anchorHunk,
+  };
+}
+
 const hunkField = StateField.define<BuiltMarkers>({
   create: () => ({ markers: RangeSet.empty, inlineDiffs: new Map(), lineTypes: new Map(), clickAnchor: new Map(), pureDelAnchors: new Set(), anchorHunk: new Map() }),
-  update(value) {
-    return value;
+  update(value, tr) {
+    return tr.docChanged ? mapBuiltMarkers(value, tr) : value;
   },
 });
 

--- a/frontend/src/domains/editor/utils/ui/gitGutter.ts
+++ b/frontend/src/domains/editor/utils/ui/gitGutter.ts
@@ -96,6 +96,7 @@ function buildMarkers(
     let newLine = hunk.newStart;
     let pendingDels: DiffLine[] = [];
     let inModZone = false;
+    let inAddRun = false;
     let currentAnchor = -1;
 
     for (let i = 0; i < hunk.lines.length; i++) {
@@ -114,6 +115,7 @@ function buildMarkers(
           pendingDels = [];
         }
         inModZone = false;
+        inAddRun = false;
         currentAnchor = -1;
         newLine++;
       } else if (line.kind === "del") {
@@ -129,8 +131,15 @@ function buildMarkers(
             currentAnchor = newLine;
             pendingDels = [];
             inModZone = true;
+            inAddRun = false;
           } else if (inModZone) {
             entries.push({ from: doc.line(newLine).from, marker: modifiedMarker });
+            lineTypes.set(newLine, "add");
+            clickAnchor.set(newLine, currentAnchor);
+          } else if (inAddRun) {
+            // Consecutive added rows are one change: they share the run's
+            // anchor so a click expands the whole block, not a single row.
+            entries.push({ from: doc.line(newLine).from, marker: addedMarker });
             lineTypes.set(newLine, "add");
             clickAnchor.set(newLine, currentAnchor);
           } else {
@@ -138,6 +147,8 @@ function buildMarkers(
             lineTypes.set(newLine, "add");
             clickAnchor.set(newLine, newLine);
             anchorHunk.set(newLine, hunkIndex);
+            currentAnchor = newLine;
+            inAddRun = true;
           }
         }
         newLine++;
@@ -150,6 +161,7 @@ function buildMarkers(
         entries.push({ from: doc.line(anchor).from, marker: deletedMarker });
         inlineDiffs.set(anchor, [...pendingDels]);
         clickAnchor.set(anchor, anchor);
+        anchorHunk.set(anchor, hunkIndex);
         pureDelAnchors.add(anchor);
       }
     }

--- a/frontend/src/domains/editor/utils/ui/gitGutter.ts
+++ b/frontend/src/domains/editor/utils/ui/gitGutter.ts
@@ -17,9 +17,9 @@ import { GUTTERS_WIDTH_CSS_VAR } from "./constants";
 
 interface GitHunkActions {
   onStage: (hunkIndex: number) => void;
-  /// Discards the change BLOCK at this new-file line, not the whole git hunk
-  /// (git merges nearby edits into one hunk).
-  onRestore: (anchorLine: number) => void;
+  /// Discards every change BLOCK intersecting this new-file line range, not
+  /// whole git hunks (git merges nearby edits into one hunk).
+  onRestore: (startLine: number, endLine: number) => void;
 }
 
 class GitAddedMarker extends GutterMarker {
@@ -269,7 +269,7 @@ class HunkActionsWidget extends WidgetType {
     restore.onmousedown = (event) => {
       event.preventDefault();
       event.stopPropagation();
-      this.actions.onRestore(this.anchorLine);
+      this.actions.onRestore(this.anchorLine, this.anchorLine);
     };
 
     bar.append(stage, restore);

--- a/frontend/src/domains/git/components/GitChangesPane/components/GitChangesPaneContent/index.tsx
+++ b/frontend/src/domains/git/components/GitChangesPane/components/GitChangesPaneContent/index.tsx
@@ -209,25 +209,11 @@ function GitChangesPaneContent({ pane }: GitChangesPaneContentProps) {
         )}
 
         <div className="mdbc-pane-meta">
-          <span>
-            {pane.projectName} / {pane.currentBranch ?? "—"}
+          <span className="mdbc-git-branch-label" data-testid="git-branch-label">
+            <Icon name="gitBranch" size={12} />
+            <span>{pane.currentBranch ?? ""}</span>
           </span>
         </div>
-
-        {/* Every Git action reports its result here, directly under the button —
-            sync (Fetch/Pull) and push share one status region. Errors first. */}
-        {(pane.syncError || pane.pushError) && (
-          <div className="mdbc-git-change-path mdbc-git-error-text">
-            {pane.syncError ?? pane.pushError}
-          </div>
-        )}
-        {!pane.syncError &&
-          !pane.pushError &&
-          (pane.syncMessage || pane.pushMessage) && (
-            <div className="mdbc-git-change-path mdbc-git-success-text">
-              {pane.syncMessage ?? pane.pushMessage}
-            </div>
-          )}
 
         <textarea
           className="mdbc-pane-textarea mdbc-git-commit-box"

--- a/frontend/src/domains/git/components/GitChangesPane/hooks.ts
+++ b/frontend/src/domains/git/components/GitChangesPane/hooks.ts
@@ -29,8 +29,7 @@ function useGitChangesPane(): GitChangesPaneViewModel {
   const aheadBehind = useGitStore((state) => state.aheadBehind);
   const hasRemote = useGitStore((state) => state.hasRemote);
   const hasUpstream = useGitStore((state) => state.hasUpstream);
-  const pushError = useGitStore((state) => state.pushError);
-  const pushMessage = useGitStore((state) => state.pushMessage);
+  const lastPushOutput = useGitStore((state) => state.lastPushOutput);
   const remotes = useGitStore((state) => state.remotes);
   const setRemoteUrl = useGitStore((state) => state.setRemoteUrl);
   const currentBranch = useGitStore((state) => state.currentBranch);
@@ -40,13 +39,10 @@ function useGitChangesPane(): GitChangesPaneViewModel {
   const pullFrom = useGitStore((state) => state.pullFrom);
   const isFetching = useGitStore((state) => state.isFetching);
   const isPulling = useGitStore((state) => state.isPulling);
-  const syncMessage = useGitStore((state) => state.syncMessage);
-  const syncError = useGitStore((state) => state.syncError);
   const mergeInProgress = useGitStore((state) => state.mergeInProgress);
   const mergeKind = useGitStore((state) => state.mergeKind);
   const conflictedFiles = useGitStore((state) => state.conflictedFiles);
   const repoPath = useFilesStore((state) => state.rootPath) ?? "";
-  const projectName = repoPath.split("/").filter(Boolean).pop() ?? "repo";
 
   const tree = useMemo(
     () => buildTree(fileStatuses, repoPath),
@@ -67,7 +63,7 @@ function useGitChangesPane(): GitChangesPaneViewModel {
 
   // GitHub returns the new URL when a repo was renamed/moved; the default remote
   // (origin if present) is the one to repoint.
-  const movedRemoteUrl = parseMovedRemoteUrl(pushError ?? pushMessage);
+  const movedRemoteUrl = parseMovedRemoteUrl(lastPushOutput);
   const defaultRemoteName =
     remotes.find((remote) => remote.name === "origin")?.name ?? remotes[0]?.name ?? "origin";
 
@@ -217,17 +213,12 @@ function useGitChangesPane(): GitChangesPaneViewModel {
     onSelectFile,
     onToggleStage,
     movedRemoteUrl,
-    projectName,
     pushDisabled,
-    pushError,
     pushLabel,
-    pushMessage,
     hasUpstream,
     defaultRemote: defaultRemoteName,
     isFetching,
     isPulling,
-    syncMessage,
-    syncError,
     mergeInProgress,
     mergeKind,
     conflictedCount: conflictedFiles.length,

--- a/frontend/src/domains/git/components/GitChangesPane/index.css
+++ b/frontend/src/domains/git/components/GitChangesPane/index.css
@@ -275,7 +275,24 @@
 .mdbc-git-changes-actions .mdbc-btn,
 .mdbc-git-commit-row .mdbc-btn,
 .mdbc-git-commit-row .mdbc-splitbtn-primary {
-  font-size: var(--m-fs-xs);
+  font-size: var(--m-fs-xxs);
+}
+
+/* Current branch row: branch glyph + name only (repo name omitted to save
+   space). */
+.mdbc-git-branch-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  min-width: 0;
+}
+.mdbc-git-branch-label svg {
+  flex-shrink: 0;
+}
+.mdbc-git-branch-label span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 /* Footer row under the Commit button: latest commit message (truncated) on
@@ -294,7 +311,7 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   color: var(--m-fg-4);
-  font-size: var(--m-fs-xs);
+  font-size: var(--m-fs-xxs);
 }
 
 .mdbc-git-conflict-banner {

--- a/frontend/src/domains/git/components/GitChangesPane/index.test.tsx
+++ b/frontend/src/domains/git/components/GitChangesPane/index.test.tsx
@@ -144,6 +144,18 @@ describe("GitChangesPane", () => {
     expect(screen.getByTestId("git-ctx-stage").textContent).toBe("Stage File");
   });
 
+  it("shows only the branch name with the branch icon in the meta row", () => {
+    useGitStore.setState({ fileStatuses: [], currentBranch: "main" });
+
+    render(<GitChangesPane />);
+
+    const label = screen.getByTestId("git-branch-label");
+    expect(label.textContent).toBe("main");
+    // Repo name is intentionally omitted to save space.
+    expect(label.textContent).not.toContain("repo");
+    expect(label.querySelector("svg")).toBeTruthy();
+  });
+
   it("shows the repository-moved prompt with the new URL on a moved push error", () => {
     useGitStore.setState({
       fileStatuses: [],
@@ -151,7 +163,7 @@ describe("GitChangesPane", () => {
       hasUpstream: true,
       aheadBehind: [1, 0],
       remotes: [{ name: "origin", url: "https://github.com/x/old.git" }],
-      pushError:
+      lastPushOutput:
         "git push failed: remote: This repository moved. Please use the new location:\n" +
         "remote:   https://github.com/x/new.git",
     });

--- a/frontend/src/domains/git/components/GitChangesPane/types.ts
+++ b/frontend/src/domains/git/components/GitChangesPane/types.ts
@@ -103,17 +103,12 @@ interface GitChangesPaneViewModel {
   onSelectFile: (path: string) => void;
   onToggleStage: (path: string, currentlyStaged: boolean) => void;
   movedRemoteUrl: string | null;
-  projectName: string;
   pushDisabled: boolean;
-  pushError: string | null;
   pushLabel: string;
-  pushMessage: string | null;
   hasUpstream: boolean;
   defaultRemote: string;
   isFetching: boolean;
   isPulling: boolean;
-  syncMessage: string | null;
-  syncError: string | null;
   mergeInProgress: boolean;
   mergeKind: string;
   conflictedCount: number;

--- a/frontend/src/domains/git/components/GitDiffView/hooks.test.ts
+++ b/frontend/src/domains/git/components/GitDiffView/hooks.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { act, renderHook, waitFor } from "@testing-library/react";
+
+const mockFileDiffHunks = vi.hoisted(() => vi.fn());
+
+vi.mock("./ipc", () => ({
+  gitDiffViewFileDiffHunksIPC: (...args: unknown[]) => mockFileDiffHunks(...args),
+}));
+
+import { useGitDiffView } from "./hooks";
+import { useGitStore } from "../../hooks";
+import { useFilesStore } from "@domains/files/hooks";
+
+const FILE_A = { path: "/repo/a.txt", status: "M", indexStatus: " ", worktreeStatus: "M" };
+const HUNK = { header: "@@ -1 +1 @@", lines: [] };
+
+beforeEach(() => {
+  useFilesStore.setState({ rootPath: "/repo" });
+  useGitStore.setState({ fileStatuses: [FILE_A], selectedFile: null });
+  mockFileDiffHunks.mockReset();
+  mockFileDiffHunks.mockResolvedValue([HUNK]);
+});
+
+describe("useGitDiffView", () => {
+  it("loads diffs and clears the loading state", async () => {
+    const { result } = renderHook(() => useGitDiffView());
+    expect(result.current.loading).toBe(true);
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.fileDiffs).toHaveLength(1);
+    expect(result.current.fileDiffs[0].path).toBe("/repo/a.txt");
+  });
+
+  it("keeps showing previous diffs while a status change refetches (no loading flash)", async () => {
+    const { result } = renderHook(() => useGitDiffView());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    // Hold the refetch open to observe the in-flight state.
+    let resolveRefetch!: (value: unknown) => void;
+    mockFileDiffHunks.mockImplementation(
+      () => new Promise((resolve) => { resolveRefetch = resolve; }),
+    );
+
+    // Stage/unstage refreshes statuses with a new array identity.
+    act(() => {
+      useGitStore.setState({ fileStatuses: [{ ...FILE_A, indexStatus: "M" }] });
+    });
+
+    expect(result.current.loading).toBe(false);
+    expect(result.current.fileDiffs).toHaveLength(1);
+
+    await act(async () => {
+      resolveRefetch([HUNK]);
+    });
+    await waitFor(() => expect(result.current.fileDiffs).toHaveLength(1));
+    expect(result.current.loading).toBe(false);
+  });
+
+  it("preserves per-file collapsed state across refetches", async () => {
+    const { result } = renderHook(() => useGitDiffView());
+    await waitFor(() => expect(result.current.fileDiffs).toHaveLength(1));
+
+    act(() => {
+      result.current.onToggleCollapse(0);
+    });
+    expect(result.current.fileDiffs[0].collapsed).toBe(true);
+
+    act(() => {
+      useGitStore.setState({ fileStatuses: [{ ...FILE_A, indexStatus: "M" }] });
+    });
+    await waitFor(() => expect(result.current.fileDiffs[0].collapsed).toBe(true));
+  });
+});

--- a/frontend/src/domains/git/components/GitDiffView/hooks.ts
+++ b/frontend/src/domains/git/components/GitDiffView/hooks.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useFilesStore } from "@domains/files/hooks";
 import { useGitStore } from "../../hooks";
 import { gitDiffViewFileDiffHunksIPC } from "./ipc";
@@ -9,7 +9,8 @@ function useGitDiffView(): GitDiffViewViewModel {
   const selectedFile = useGitStore((state) => state.selectedFile);
   const repoPath = useFilesStore((state) => state.rootPath) ?? "";
   const [fileDiffs, setFileDiffs] = useState<FileDiff[]>([]);
-  const [loading, setLoading] = useState(false);
+  const [hasLoaded, setHasLoaded] = useState(false);
+  const requestRef = useRef(0);
 
   const filesToShow = useMemo(() => {
     if (selectedFile) {
@@ -18,12 +19,18 @@ function useGitDiffView(): GitDiffViewViewModel {
     return fileStatuses;
   }, [fileStatuses, selectedFile]);
 
+  // Stale-while-revalidate: every status change (stage/unstage/save) refetches,
+  // but the previous diffs stay on screen until the new ones land, so the view
+  // never flashes a loading state after the first load. Collapsed state is
+  // carried over by path; a request token drops out-of-order responses.
   const fetchDiffs = useCallback(async () => {
+    const requestId = requestRef.current + 1;
+    requestRef.current = requestId;
     if (!repoPath || filesToShow.length === 0) {
       setFileDiffs([]);
+      setHasLoaded(true);
       return;
     }
-    setLoading(true);
     const results: FileDiff[] = [];
     for (const file of filesToShow) {
       try {
@@ -33,8 +40,15 @@ function useGitDiffView(): GitDiffViewViewModel {
         results.push({ path: file.path, hunks: [], collapsed: false });
       }
     }
-    setFileDiffs(results);
-    setLoading(false);
+    if (requestId !== requestRef.current) return;
+    setFileDiffs((prev) => {
+      const collapsedByPath = new Map(prev.map((diff) => [diff.path, diff.collapsed]));
+      return results.map((diff) => ({
+        ...diff,
+        collapsed: collapsedByPath.get(diff.path) ?? false,
+      }));
+    });
+    setHasLoaded(true);
   }, [repoPath, filesToShow]);
 
   useEffect(() => {
@@ -52,7 +66,7 @@ function useGitDiffView(): GitDiffViewViewModel {
   return {
     fileDiffs,
     fileStatusesCount: fileStatuses.length,
-    loading,
+    loading: !hasLoaded,
     onToggleCollapse,
     repoPath,
   };

--- a/frontend/src/domains/git/constants.ts
+++ b/frontend/src/domains/git/constants.ts
@@ -1,0 +1,22 @@
+// Labels shown by the app-level notification service (status-bar spinner +
+// snackbar prefix) for each Git action.
+const GIT_TASK_LABELS = {
+  fetch: "Fetch",
+  pull: "Pull",
+  push: "Push",
+  forcePush: "Force push",
+} as const;
+
+// Fallbacks when the backend returns an empty completion message.
+const GIT_FETCH_DONE_MESSAGE = "Done.";
+const GIT_PULL_UP_TO_DATE_MESSAGE = "Already up to date.";
+const GIT_PUSHED_MESSAGE = "Pushed.";
+const GIT_FORCE_PUSHED_MESSAGE = "Force-pushed.";
+
+export {
+  GIT_FETCH_DONE_MESSAGE,
+  GIT_FORCE_PUSHED_MESSAGE,
+  GIT_PULL_UP_TO_DATE_MESSAGE,
+  GIT_PUSHED_MESSAGE,
+  GIT_TASK_LABELS,
+};

--- a/frontend/src/domains/git/hooks/store.ipc.test.ts
+++ b/frontend/src/domains/git/hooks/store.ipc.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { useGitStore } from "./store";
+import { useSnackbarStore } from "@shell/hooks/snackbarStore";
 
 const mockInvoke = vi.hoisted(() => vi.fn());
 
@@ -27,12 +28,12 @@ describe("git store IPC wiring", () => {
       isPushing: false,
       loadError: null,
       commitError: null,
-      pushError: null,
-      pushMessage: null,
+      lastPushOutput: null,
       hasRemote: false,
       hasUpstream: false,
       remotes: [],
     });
+    useSnackbarStore.setState({ snackbars: [] });
     mockInvoke.mockReset();
   });
 
@@ -141,7 +142,7 @@ describe("git store IPC wiring", () => {
     expect(state.hasUpstream).toBe(false);
   });
 
-  it("push records the push output as pushMessage and refreshes push state", async () => {
+  it("push records the push output and refreshes push state", async () => {
     useGitStore.setState({ repoPath: "/repo" });
     mockInvoke.mockImplementation((command: string) => {
       switch (command) {
@@ -161,12 +162,15 @@ describe("git store IPC wiring", () => {
     const state = useGitStore.getState();
     expect(mockInvoke).toHaveBeenCalledWith("cmd_git_push", { repo: "/repo" });
     expect(state.isPushing).toBe(false);
-    expect(state.pushError).toBeNull();
-    expect(state.pushMessage).toContain("set up to track");
+    expect(state.lastPushOutput).toContain("set up to track");
     expect(state.hasUpstream).toBe(true);
+    const { snackbars } = useSnackbarStore.getState();
+    expect(snackbars).toHaveLength(1);
+    expect(snackbars[0].kind).toBe("success");
+    expect(snackbars[0].message).toContain("set up to track");
   });
 
-  it("push records pushError when the push fails", async () => {
+  it("push surfaces an error snackbar when the push fails", async () => {
     useGitStore.setState({ repoPath: "/repo" });
     mockInvoke.mockImplementation((command: string) => {
       if (command === "cmd_git_push") {
@@ -179,14 +183,17 @@ describe("git store IPC wiring", () => {
 
     const state = useGitStore.getState();
     expect(state.isPushing).toBe(false);
-    expect(state.pushError).toContain("no remote configured");
-    expect(state.pushMessage).toBeNull();
+    expect(state.lastPushOutput).toContain("no remote configured");
+    const { snackbars } = useSnackbarStore.getState();
+    expect(snackbars).toHaveLength(1);
+    expect(snackbars[0].kind).toBe("error");
+    expect(snackbars[0].message).toContain("no remote configured");
   });
 
-  it("setRemoteUrl writes the new URL, clears the push error, and reloads remotes", async () => {
+  it("setRemoteUrl writes the new URL, clears the push output, and reloads remotes", async () => {
     useGitStore.setState({
       repoPath: "/repo",
-      pushError: "git push failed: This repository moved.",
+      lastPushOutput: "git push failed: This repository moved.",
       remotes: [{ name: "origin", url: "https://github.com/x/old.git" }],
     });
     mockInvoke.mockImplementation((command: string) => {
@@ -210,7 +217,7 @@ describe("git store IPC wiring", () => {
       name: "origin",
       url: "https://github.com/x/new.git",
     });
-    expect(state.pushError).toBeNull();
+    expect(state.lastPushOutput).toBeNull();
     expect(state.remotes).toEqual([{ name: "origin", url: "https://github.com/x/new.git" }]);
     expect(state.hasUpstream).toBe(true);
   });

--- a/frontend/src/domains/git/hooks/store.test.ts
+++ b/frontend/src/domains/git/hooks/store.test.ts
@@ -10,6 +10,7 @@ vi.mock("@domains/git/components/GitChangesPane/ipc", () => ({
   gitChangesPaneMergeStateIPC: vi
     .fn()
     .mockResolvedValue({ inProgress: false, kind: "none", conflicted: [] }),
+  gitChangesPaneFetchIPC: vi.fn().mockResolvedValue("Fetched."),
   gitChangesPanePushIPC: vi.fn().mockResolvedValue("Pushed."),
   gitChangesPanePushToIPC: vi.fn().mockResolvedValue("Pushed to."),
   gitChangesPaneForcePushIPC: vi.fn().mockResolvedValue("Force-pushed."),
@@ -25,6 +26,7 @@ vi.mock("@shell/ipc", () => ({
 
 import { useGitStore } from "./store";
 import { useTabsStore } from "@shell/hooks/tabsStore";
+import { useSnackbarStore } from "@shell/hooks/snackbarStore";
 import {
   gitChangesPaneForcePushIPC,
   gitChangesPanePullFromIPC,
@@ -102,13 +104,24 @@ describe("git store", () => {
     useGitStore.setState({ repoPath: "/repo" });
     await useGitStore.getState().pushTo("origin", "feature");
     expect(gitChangesPanePushToIPC).toHaveBeenCalledWith("/repo", "origin", "feature");
-    expect(useGitStore.getState().pushMessage).toBe("Pushed to.");
+    expect(useGitStore.getState().lastPushOutput).toBe("Pushed to.");
   });
 
   it("forcePush force-pushes the current branch and reports the result", async () => {
     useGitStore.setState({ repoPath: "/repo" });
     await useGitStore.getState().forcePush();
     expect(gitChangesPaneForcePushIPC).toHaveBeenCalledWith("/repo");
-    expect(useGitStore.getState().pushMessage).toBe("Force-pushed.");
+    expect(useGitStore.getState().lastPushOutput).toBe("Force-pushed.");
+  });
+
+  it("fetch routes through the notification service", async () => {
+    useGitStore.setState({ repoPath: "/repo" });
+    useSnackbarStore.setState({ snackbars: [] });
+    await useGitStore.getState().fetch();
+    const { snackbars } = useSnackbarStore.getState();
+    expect(snackbars).toHaveLength(1);
+    expect(snackbars[0].kind).toBe("success");
+    expect(snackbars[0].message).toBe("Fetch: Fetched.");
+    expect(useGitStore.getState().isFetching).toBe(false);
   });
 });

--- a/frontend/src/domains/git/hooks/store.ts
+++ b/frontend/src/domains/git/hooks/store.ts
@@ -2,6 +2,14 @@ import { create } from "zustand";
 import { ipcErrorMessage } from "@shared";
 import { readTextFileIPC } from "@shell/ipc";
 import { useTabsStore } from "@shell/hooks/tabsStore";
+import { runNotifiedTask } from "@shell/utils/notifiedTask";
+import {
+  GIT_FETCH_DONE_MESSAGE,
+  GIT_FORCE_PUSHED_MESSAGE,
+  GIT_PULL_UP_TO_DATE_MESSAGE,
+  GIT_PUSHED_MESSAGE,
+  GIT_TASK_LABELS,
+} from "../constants";
 import {
   gitChangesPaneAheadBehindIPC,
   gitChangesPaneCommitIPC,
@@ -56,15 +64,15 @@ interface GitState {
   isPushing: boolean;
   loadError: string | null;
   commitError: string | null;
-  pushError: string | null;
-  pushMessage: string | null;
+  /// Raw output of the last push attempt (success or failure), kept only so
+  /// the moved-remote banner can parse a new GitHub URL out of it; user-facing
+  /// results surface through the app-level notification service.
+  lastPushOutput: string | null;
   hasRemote: boolean;
   hasUpstream: boolean;
   remotes: RemoteInfo[];
   isFetching: boolean;
   isPulling: boolean;
-  syncMessage: string | null;
-  syncError: string | null;
   mergeInProgress: boolean;
   mergeKind: string;
   conflictedFiles: string[];
@@ -117,16 +125,12 @@ const useGitStore = create<GitState>((set, get) => ({
   isPushing: false,
   loadError: null,
   commitError: null,
-  pushError: null,
-  pushMessage: null,
+  lastPushOutput: null,
   hasRemote: false,
   hasUpstream: false,
   remotes: [],
   isFetching: false,
   isPulling: false,
-  pullMode: "merge",
-  syncMessage: null,
-  syncError: null,
   mergeInProgress: false,
   mergeKind: "none",
   conflictedFiles: [],
@@ -150,15 +154,12 @@ const useGitStore = create<GitState>((set, get) => ({
       isPushing: false,
       loadError: null,
       commitError: null,
-      pushError: null,
-      pushMessage: null,
+      lastPushOutput: null,
       hasRemote: false,
       hasUpstream: false,
       remotes: [],
       isFetching: false,
       isPulling: false,
-      syncMessage: null,
-      syncError: null,
       mergeInProgress: false,
       mergeKind: "none",
       conflictedFiles: [],
@@ -309,102 +310,94 @@ const useGitStore = create<GitState>((set, get) => ({
   push: async () => {
     const { repoPath } = get();
     if (!repoPath) return;
-    set({ isPushing: true, pushError: null, pushMessage: null });
-    try {
+    set({ isPushing: true });
+    const result = await runNotifiedTask(GIT_TASK_LABELS.push, async () => {
       const message = await gitChangesPanePushIPC(repoPath);
-      set({ isPushing: false, pushMessage: message.trim() || "Pushed." });
-      const [ab, pushState] = await Promise.all([
-        gitChangesPaneAheadBehindIPC(repoPath).catch((): [number, number] => [0, 0]),
-        gitChangesPanePushStateIPC(repoPath).catch(() => NO_PUSH_STATE),
-      ]);
-      set({ aheadBehind: ab, hasRemote: pushState.hasRemote, hasUpstream: pushState.hasUpstream });
-    } catch (e) {
-      set({ isPushing: false, pushError: ipcErrorMessage(e) });
-    }
+      return message.trim() || GIT_PUSHED_MESSAGE;
+    });
+    set({ isPushing: false, lastPushOutput: result.message });
+    const [ab, pushState] = await Promise.all([
+      gitChangesPaneAheadBehindIPC(repoPath).catch((): [number, number] => [0, 0]),
+      gitChangesPanePushStateIPC(repoPath).catch(() => NO_PUSH_STATE),
+    ]);
+    set({ aheadBehind: ab, hasRemote: pushState.hasRemote, hasUpstream: pushState.hasUpstream });
   },
   pushTo: async (remote, branch) => {
     const { repoPath } = get();
     if (!repoPath) return;
-    set({ isPushing: true, pushError: null, pushMessage: null });
-    try {
+    set({ isPushing: true });
+    const result = await runNotifiedTask(GIT_TASK_LABELS.push, async () => {
       const message = await gitChangesPanePushToIPC(repoPath, remote, branch);
-      set({ isPushing: false, pushMessage: message.trim() || "Pushed." });
-      const [ab, pushState] = await Promise.all([
-        gitChangesPaneAheadBehindIPC(repoPath).catch((): [number, number] => [0, 0]),
-        gitChangesPanePushStateIPC(repoPath).catch(() => NO_PUSH_STATE),
-      ]);
-      set({ aheadBehind: ab, hasRemote: pushState.hasRemote, hasUpstream: pushState.hasUpstream });
-    } catch (e) {
-      set({ isPushing: false, pushError: ipcErrorMessage(e) });
-    }
+      return message.trim() || GIT_PUSHED_MESSAGE;
+    });
+    set({ isPushing: false, lastPushOutput: result.message });
+    const [ab, pushState] = await Promise.all([
+      gitChangesPaneAheadBehindIPC(repoPath).catch((): [number, number] => [0, 0]),
+      gitChangesPanePushStateIPC(repoPath).catch(() => NO_PUSH_STATE),
+    ]);
+    set({ aheadBehind: ab, hasRemote: pushState.hasRemote, hasUpstream: pushState.hasUpstream });
   },
   forcePush: async () => {
     const { repoPath } = get();
     if (!repoPath) return;
-    set({ isPushing: true, pushError: null, pushMessage: null });
-    try {
+    set({ isPushing: true });
+    const result = await runNotifiedTask(GIT_TASK_LABELS.forcePush, async () => {
       const message = await gitChangesPaneForcePushIPC(repoPath);
-      set({ isPushing: false, pushMessage: message.trim() || "Force-pushed." });
-      const [ab, pushState] = await Promise.all([
-        gitChangesPaneAheadBehindIPC(repoPath).catch((): [number, number] => [0, 0]),
-        gitChangesPanePushStateIPC(repoPath).catch(() => NO_PUSH_STATE),
-      ]);
-      set({ aheadBehind: ab, hasRemote: pushState.hasRemote, hasUpstream: pushState.hasUpstream });
-    } catch (e) {
-      set({ isPushing: false, pushError: ipcErrorMessage(e) });
-    }
+      return message.trim() || GIT_FORCE_PUSHED_MESSAGE;
+    });
+    set({ isPushing: false, lastPushOutput: result.message });
+    const [ab, pushState] = await Promise.all([
+      gitChangesPaneAheadBehindIPC(repoPath).catch((): [number, number] => [0, 0]),
+      gitChangesPanePushStateIPC(repoPath).catch(() => NO_PUSH_STATE),
+    ]);
+    set({ aheadBehind: ab, hasRemote: pushState.hasRemote, hasUpstream: pushState.hasUpstream });
   },
   fetch: async () => {
     const { repoPath } = get();
     if (!repoPath) return;
-    set({ isFetching: true, syncError: null, syncMessage: null });
-    try {
+    set({ isFetching: true });
+    const result = await runNotifiedTask(GIT_TASK_LABELS.fetch, async () => {
       const message = await gitChangesPaneFetchIPC(repoPath);
-      set({ isFetching: false, syncMessage: message });
-      await get().refreshFileStatuses();
-    } catch (e) {
-      set({ isFetching: false, syncError: ipcErrorMessage(e) });
-    }
+      return message.trim() || GIT_FETCH_DONE_MESSAGE;
+    });
+    set({ isFetching: false });
+    if (result.ok) await get().refreshFileStatuses();
   },
   pull: async () => {
     const { repoPath } = get();
     if (!repoPath) return;
-    set({ isPulling: true, syncError: null, syncMessage: null });
-    try {
-      const result = await gitChangesPanePullIPC(repoPath, "merge");
-      set({
-        isPulling: false,
-        syncMessage: result.message || "Already up to date.",
-        conflictedFiles: result.conflicted,
-      });
-      await get().refreshFileStatuses();
-      await get().refreshMergeState();
-      // Conflicts halt the pull: surface the resolver immediately.
-      if (result.conflicted.length > 0) {
-        useTabsStore.getState().openGitConflictTab();
-      }
-    } catch (e) {
-      set({ isPulling: false, syncError: ipcErrorMessage(e) });
+    set({ isPulling: true });
+    let conflicted: string[] = [];
+    const result = await runNotifiedTask(GIT_TASK_LABELS.pull, async () => {
+      const pullResult = await gitChangesPanePullIPC(repoPath, "merge");
+      conflicted = pullResult.conflicted;
+      return pullResult.message || GIT_PULL_UP_TO_DATE_MESSAGE;
+    });
+    set({ isPulling: false, conflictedFiles: conflicted });
+    if (!result.ok) return;
+    await get().refreshFileStatuses();
+    await get().refreshMergeState();
+    // Conflicts halt the pull: surface the resolver immediately.
+    if (conflicted.length > 0) {
+      useTabsStore.getState().openGitConflictTab();
     }
   },
   pullFrom: async (remote, branch) => {
     const { repoPath } = get();
     if (!repoPath) return;
-    set({ isPulling: true, syncError: null, syncMessage: null });
-    try {
-      const result = await gitChangesPanePullFromIPC(repoPath, remote, branch, "merge");
-      set({
-        isPulling: false,
-        syncMessage: result.message || "Already up to date.",
-        conflictedFiles: result.conflicted,
-      });
-      await get().refreshFileStatuses();
-      await get().refreshMergeState();
-      if (result.conflicted.length > 0) {
-        useTabsStore.getState().openGitConflictTab();
-      }
-    } catch (e) {
-      set({ isPulling: false, syncError: ipcErrorMessage(e) });
+    set({ isPulling: true });
+    let conflicted: string[] = [];
+    const result = await runNotifiedTask(GIT_TASK_LABELS.pull, async () => {
+      const pullResult = await gitChangesPanePullFromIPC(repoPath, remote, branch, "merge");
+      conflicted = pullResult.conflicted;
+      return pullResult.message || GIT_PULL_UP_TO_DATE_MESSAGE;
+    });
+    set({ isPulling: false, conflictedFiles: conflicted });
+    if (!result.ok) return;
+    await get().refreshFileStatuses();
+    await get().refreshMergeState();
+    if (conflicted.length > 0) {
+      useTabsStore.getState().openGitConflictTab();
     }
   },
   refreshMergeState: async () => {
@@ -427,8 +420,8 @@ const useGitStore = create<GitState>((set, get) => ({
     const { repoPath } = get();
     if (!repoPath || !url.trim()) return;
     await gitChangesPaneSetRemoteUrlIPC(repoPath, name, url.trim());
-    // The stale-remote push error no longer applies once the URL is fixed.
-    set({ pushError: null });
+    // The stale-remote push output no longer applies once the URL is fixed.
+    set({ lastPushOutput: null });
     const [remotes, pushState] = await Promise.all([
       gitChangesPaneListRemotesIPC(repoPath).catch((): RemoteInfo[] => []),
       gitChangesPanePushStateIPC(repoPath).catch(() => NO_PUSH_STATE),

--- a/frontend/src/shared/settings/constants.ts
+++ b/frontend/src/shared/settings/constants.ts
@@ -83,6 +83,7 @@ export const ACTIONS = {
   gitPull: { label: "Git: Pull", category: "git", defaultShortcut: null },
   gitShowHistory: { label: "Git: Show History", category: "git", defaultShortcut: null },
   gitResolveConflicts: { label: "Git: Resolve Conflicts", category: "git", defaultShortcut: null },
+  gitDiscardHunk: { label: "Git: Discard Change at Cursor", category: "git", defaultShortcut: null },
 
   dbtRun: { label: "dbt Run", category: "dbt", defaultShortcut: { key: "Mod-Shift-r" } },
   dbtTest: { label: "dbt Test", category: "dbt", defaultShortcut: { key: "Mod-Shift-t" } },

--- a/frontend/src/shell/components/App/index.tsx
+++ b/frontend/src/shell/components/App/index.tsx
@@ -1,6 +1,7 @@
 import { ContentView } from "@shell/components/ContentView";
 import { FileSearchPopover } from "@domains/files/components/FileSearchPopover";
 import { ProjectLoadingScreen } from "@shell/components/ProjectLoadingScreen";
+import { SnackbarHost } from "@shell/components/SnackbarHost";
 import { WelcomeScreen } from "@shell/components/WelcomeScreen";
 import { useAppState } from "@shell/hooks";
 
@@ -35,6 +36,7 @@ function App() {
     <>
       <ContentView />
       <FileSearchPopover />
+      <SnackbarHost />
     </>
   );
 }

--- a/frontend/src/shell/components/SnackbarHost/constants.ts
+++ b/frontend/src/shell/components/SnackbarHost/constants.ts
@@ -1,0 +1,14 @@
+import type { IconName } from "@shared/ui/Icon";
+import type { SnackbarKind } from "../../types";
+
+const SNACKBAR_KIND_ICONS: Record<SnackbarKind, IconName> = {
+  success: "check",
+  error: "info",
+};
+
+const SNACKBAR_ICON_SIZE = 12;
+
+export {
+  SNACKBAR_ICON_SIZE,
+  SNACKBAR_KIND_ICONS,
+};

--- a/frontend/src/shell/components/SnackbarHost/index.css
+++ b/frontend/src/shell/components/SnackbarHost/index.css
@@ -1,0 +1,42 @@
+.mdbc-snackbar-host {
+  position: fixed;
+  bottom: 40px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  z-index: 1000;
+  pointer-events: none;
+}
+
+.mdbc-snackbar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  border-radius: var(--m-r-sm);
+  background: var(--m-bg-surface-2);
+  border: 1px solid var(--m-sep-strong);
+  color: var(--m-fg-2);
+  font-family: var(--m-font);
+  font-size: var(--m-fs-xs);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+  pointer-events: auto;
+}
+
+.mdbc-snackbar.success svg:first-child {
+  color: var(--m-green);
+}
+
+.mdbc-snackbar.error svg:first-child {
+  color: var(--m-red);
+}
+
+.mdbc-snackbar-msg {
+  max-width: 420px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/frontend/src/shell/components/SnackbarHost/index.css
+++ b/frontend/src/shell/components/SnackbarHost/index.css
@@ -26,12 +26,18 @@
   pointer-events: auto;
 }
 
-.mdbc-snackbar.success svg:first-child {
+/* Direct child only: the kind icon. The close button's svg is also a
+   :first-child of its parent, so an unscoped selector would tint it too. */
+.mdbc-snackbar.success > svg:first-child {
   color: var(--m-green);
 }
 
-.mdbc-snackbar.error svg:first-child {
+.mdbc-snackbar.error > svg:first-child {
   color: var(--m-red);
+}
+
+.mdbc-snackbar .mdbc-icon-btn {
+  color: var(--m-fg);
 }
 
 .mdbc-snackbar-msg {

--- a/frontend/src/shell/components/SnackbarHost/index.test.tsx
+++ b/frontend/src/shell/components/SnackbarHost/index.test.tsx
@@ -1,0 +1,33 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, fireEvent, screen } from "@testing-library/react";
+import { SnackbarHost } from ".";
+import { useSnackbarStore } from "../../hooks/snackbarStore";
+
+beforeEach(() => {
+  useSnackbarStore.setState({ snackbars: [] });
+});
+
+describe("SnackbarHost", () => {
+  it("renders nothing when there are no snackbars", () => {
+    const { container } = render(<SnackbarHost />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders queued snackbars with their messages", () => {
+    useSnackbarStore.getState().enqueue("Fetch: Already up to date", "success");
+    useSnackbarStore.getState().enqueue("Push: rejected", "error");
+    render(<SnackbarHost />);
+    expect(screen.getByText("Fetch: Already up to date")).toBeTruthy();
+    expect(screen.getByText("Push: rejected")).toBeTruthy();
+    expect(screen.getByTestId("snackbar-success")).toBeTruthy();
+    expect(screen.getByTestId("snackbar-error")).toBeTruthy();
+  });
+
+  it("close button dismisses its snackbar", () => {
+    const id = useSnackbarStore.getState().enqueue("Pull: failed", "error");
+    render(<SnackbarHost />);
+    fireEvent.click(screen.getByTestId(`snackbar-close-${id}`));
+    expect(useSnackbarStore.getState().snackbars).toHaveLength(0);
+    expect(screen.queryByText("Pull: failed")).toBeNull();
+  });
+});

--- a/frontend/src/shell/components/SnackbarHost/index.tsx
+++ b/frontend/src/shell/components/SnackbarHost/index.tsx
@@ -1,0 +1,38 @@
+import { Icon } from "@shared/ui/Icon";
+import { useSnackbarStore } from "../../hooks/snackbarStore";
+import { SNACKBAR_ICON_SIZE, SNACKBAR_KIND_ICONS } from "./constants";
+import "./index.css";
+
+function SnackbarHost() {
+  const snackbars = useSnackbarStore((state) => state.snackbars);
+  const dismiss = useSnackbarStore((state) => state.dismiss);
+
+  if (snackbars.length === 0) return null;
+
+  return (
+    <div className="mdbc-snackbar-host" data-testid="snackbar-host">
+      {snackbars.map((snackbar) => (
+        <div
+          key={snackbar.id}
+          className={`mdbc-snackbar ${snackbar.kind}`}
+          role="status"
+          data-testid={`snackbar-${snackbar.kind}`}
+        >
+          <Icon name={SNACKBAR_KIND_ICONS[snackbar.kind]} size={SNACKBAR_ICON_SIZE} />
+          <span className="mdbc-snackbar-msg">{snackbar.message}</span>
+          <button
+            type="button"
+            className="mdbc-icon-btn"
+            onClick={() => dismiss(snackbar.id)}
+            aria-label="Dismiss notification"
+            data-testid={`snackbar-close-${snackbar.id}`}
+          >
+            <Icon name="x" size={SNACKBAR_ICON_SIZE} />
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export { SnackbarHost };

--- a/frontend/src/shell/constants.ts
+++ b/frontend/src/shell/constants.ts
@@ -10,7 +10,23 @@ const FS_WATCH_REFRESH_DEBOUNCE_MS = 150;
 const MAX_RECENTS = 8;
 const RECENTS_STORAGE_KEY = "arris.recents";
 
+// App-level notification service: status-bar spinner while a task runs, then a
+// snackbar with the outcome. Success snackbars auto-dismiss; errors stay until
+// closed. At most SNACKBAR_MAX_VISIBLE stack (oldest evicted first).
+const SNACKBAR_AUTO_DISMISS_MS = 4000;
+const SNACKBAR_MAX_VISIBLE = 3;
+const SNACKBAR_ID_PREFIX = "snackbar-";
+const SNACKBAR_MESSAGE_SEPARATOR = ": ";
+const NOTIFIED_TASK_ID_PREFIX = "notified-task-";
+const TASK_LABEL_RUNNING_SUFFIX = "…";
+
 export {
+  NOTIFIED_TASK_ID_PREFIX,
+  SNACKBAR_AUTO_DISMISS_MS,
+  SNACKBAR_ID_PREFIX,
+  SNACKBAR_MAX_VISIBLE,
+  SNACKBAR_MESSAGE_SEPARATOR,
+  TASK_LABEL_RUNNING_SUFFIX,
   APP_FOCUS_REFRESH_DEBOUNCE_MS,
   FS_WATCH_REFRESH_DEBOUNCE_MS,
   MAX_RECENTS,

--- a/frontend/src/shell/hooks/index.ts
+++ b/frontend/src/shell/hooks/index.ts
@@ -12,3 +12,4 @@ export { useRecentsStore } from "./recentsStore";
 export { useTabsStore } from "./tabsStore";
 export { useCommandRegistryStore } from "./commandRegistryStore";
 export { useBackgroundTasksStore } from "./backgroundTasksStore";
+export { useSnackbarStore } from "./snackbarStore";

--- a/frontend/src/shell/hooks/snackbarStore.test.ts
+++ b/frontend/src/shell/hooks/snackbarStore.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { useSnackbarStore } from ".";
+import {
+  SNACKBAR_AUTO_DISMISS_MS,
+  SNACKBAR_MAX_VISIBLE,
+} from "../constants";
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  useSnackbarStore.setState({ snackbars: [] });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("useSnackbarStore", () => {
+  it("enqueues a snackbar", () => {
+    useSnackbarStore.getState().enqueue("Fetch: Already up to date", "success");
+    const { snackbars } = useSnackbarStore.getState();
+    expect(snackbars).toHaveLength(1);
+    expect(snackbars[0].message).toBe("Fetch: Already up to date");
+    expect(snackbars[0].kind).toBe("success");
+  });
+
+  it("auto-dismisses success snackbars", () => {
+    useSnackbarStore.getState().enqueue("Done", "success");
+    expect(useSnackbarStore.getState().snackbars).toHaveLength(1);
+    vi.advanceTimersByTime(SNACKBAR_AUTO_DISMISS_MS);
+    expect(useSnackbarStore.getState().snackbars).toHaveLength(0);
+  });
+
+  it("keeps error snackbars until dismissed", () => {
+    const id = useSnackbarStore.getState().enqueue("Push failed", "error");
+    vi.advanceTimersByTime(SNACKBAR_AUTO_DISMISS_MS * 2);
+    expect(useSnackbarStore.getState().snackbars).toHaveLength(1);
+    useSnackbarStore.getState().dismiss(id);
+    expect(useSnackbarStore.getState().snackbars).toHaveLength(0);
+  });
+
+  it("dismiss removes only the targeted snackbar", () => {
+    const first = useSnackbarStore.getState().enqueue("one", "error");
+    useSnackbarStore.getState().enqueue("two", "error");
+    useSnackbarStore.getState().dismiss(first);
+    const { snackbars } = useSnackbarStore.getState();
+    expect(snackbars).toHaveLength(1);
+    expect(snackbars[0].message).toBe("two");
+  });
+
+  it("evicts the oldest beyond the max (FIFO)", () => {
+    for (let index = 0; index <= SNACKBAR_MAX_VISIBLE; index += 1) {
+      useSnackbarStore.getState().enqueue(`msg-${index}`, "error");
+    }
+    const { snackbars } = useSnackbarStore.getState();
+    expect(snackbars).toHaveLength(SNACKBAR_MAX_VISIBLE);
+    expect(snackbars[0].message).toBe("msg-1");
+    expect(snackbars[snackbars.length - 1].message).toBe(`msg-${SNACKBAR_MAX_VISIBLE}`);
+  });
+
+  it("late auto-dismiss of an evicted snackbar is a no-op", () => {
+    useSnackbarStore.getState().enqueue("evicted", "success");
+    for (let index = 0; index < SNACKBAR_MAX_VISIBLE; index += 1) {
+      useSnackbarStore.getState().enqueue(`keep-${index}`, "error");
+    }
+    vi.advanceTimersByTime(SNACKBAR_AUTO_DISMISS_MS);
+    expect(useSnackbarStore.getState().snackbars).toHaveLength(SNACKBAR_MAX_VISIBLE);
+  });
+});

--- a/frontend/src/shell/hooks/snackbarStore.ts
+++ b/frontend/src/shell/hooks/snackbarStore.ts
@@ -1,0 +1,43 @@
+import { create } from "zustand";
+import {
+  SNACKBAR_AUTO_DISMISS_MS,
+  SNACKBAR_ID_PREFIX,
+  SNACKBAR_MAX_VISIBLE,
+} from "../constants";
+import type { Snackbar, SnackbarKind } from "../types";
+
+interface SnackbarState {
+  snackbars: Snackbar[];
+  enqueue: (message: string, kind: SnackbarKind) => string;
+  dismiss: (id: string) => void;
+}
+
+// Module-local so ids stay unique even if the store state is reset in tests.
+let nextSnackbarId = 0;
+
+const useSnackbarStore = create<SnackbarState>((set) => ({
+  snackbars: [],
+  enqueue: (message, kind) => {
+    nextSnackbarId += 1;
+    const id = `${SNACKBAR_ID_PREFIX}${nextSnackbarId}`;
+    set((state) => ({
+      snackbars: [...state.snackbars, { id, message, kind }].slice(-SNACKBAR_MAX_VISIBLE),
+    }));
+    if (kind === "success") {
+      setTimeout(() => {
+        set((state) => ({
+          snackbars: state.snackbars.filter((item) => item.id !== id),
+        }));
+      }, SNACKBAR_AUTO_DISMISS_MS);
+    }
+    return id;
+  },
+  dismiss: (id) =>
+    set((state) => ({
+      snackbars: state.snackbars.filter((item) => item.id !== id),
+    })),
+}));
+
+export {
+  useSnackbarStore,
+};

--- a/frontend/src/shell/types.ts
+++ b/frontend/src/shell/types.ts
@@ -19,6 +19,19 @@ interface BackgroundTask {
   label: string;
 }
 
+type SnackbarKind = "success" | "error";
+
+interface Snackbar {
+  id: string;
+  message: string;
+  kind: SnackbarKind;
+}
+
+interface NotifiedTaskResult {
+  ok: boolean;
+  message: string;
+}
+
 type ResultPane = "results" | "plan";
 
 interface EditorTab extends PersistedTab {
@@ -78,6 +91,9 @@ export type {
   AppViewModel,
   BackgroundTask,
   EditorTab,
+  NotifiedTaskResult,
+  Snackbar,
+  SnackbarKind,
   PaneGroup,
   PaneNode,
   PaneSplit,

--- a/frontend/src/shell/utils/index.ts
+++ b/frontend/src/shell/utils/index.ts
@@ -4,3 +4,4 @@ export * from "./app";
 export * from "./keymap";
 export * from "./commands";
 export { findLeaf, findLeafWithTab, firstLeaf, leavesOf, planTabDrop } from "./paneTree";
+export { runNotifiedTask } from "./notifiedTask";

--- a/frontend/src/shell/utils/notifiedTask.test.ts
+++ b/frontend/src/shell/utils/notifiedTask.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { runNotifiedTask } from "./notifiedTask";
+import { useBackgroundTasksStore } from "../hooks/backgroundTasksStore";
+import { useSnackbarStore } from "../hooks/snackbarStore";
+
+beforeEach(() => {
+  useBackgroundTasksStore.setState({ tasks: new Map() });
+  useSnackbarStore.setState({ snackbars: [] });
+});
+
+describe("runNotifiedTask", () => {
+  it("shows the running label in background tasks while the task runs", async () => {
+    let resolve!: (value: string) => void;
+    const pending = runNotifiedTask("Fetch", () => new Promise((r) => { resolve = r; }));
+    expect(useBackgroundTasksStore.getState().activeTasks()).toEqual([
+      expect.objectContaining({ label: "Fetch…" }),
+    ]);
+    resolve("Already up to date");
+    await pending;
+    expect(useBackgroundTasksStore.getState().tasks.size).toBe(0);
+  });
+
+  it("enqueues a success snackbar with the task message", async () => {
+    const result = await runNotifiedTask("Fetch", async () => "Already up to date");
+    expect(result).toEqual({ ok: true, message: "Already up to date" });
+    const { snackbars } = useSnackbarStore.getState();
+    expect(snackbars).toHaveLength(1);
+    expect(snackbars[0].kind).toBe("success");
+    expect(snackbars[0].message).toBe("Fetch: Already up to date");
+  });
+
+  it("enqueues an error snackbar and resolves ok=false on failure", async () => {
+    const result = await runNotifiedTask("Push", async () => {
+      throw new Error("rejected by remote");
+    });
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain("rejected by remote");
+    const { snackbars } = useSnackbarStore.getState();
+    expect(snackbars).toHaveLength(1);
+    expect(snackbars[0].kind).toBe("error");
+    expect(snackbars[0].message).toContain("Push: ");
+  });
+
+  it("always clears the background task, even on failure", async () => {
+    await runNotifiedTask("Pull", async () => {
+      throw new Error("boom");
+    });
+    expect(useBackgroundTasksStore.getState().tasks.size).toBe(0);
+  });
+
+  it("runs concurrent tasks under distinct ids", async () => {
+    const resolvers: Array<(value: string) => void> = [];
+    const first = runNotifiedTask("A", () => new Promise((r) => resolvers.push(r)));
+    const second = runNotifiedTask("B", () => new Promise((r) => resolvers.push(r)));
+    expect(useBackgroundTasksStore.getState().tasks.size).toBe(2);
+    resolvers.forEach((r) => r("done"));
+    await Promise.all([first, second]);
+    expect(useBackgroundTasksStore.getState().tasks.size).toBe(0);
+    expect(useSnackbarStore.getState().snackbars).toHaveLength(2);
+  });
+});

--- a/frontend/src/shell/utils/notifiedTask.ts
+++ b/frontend/src/shell/utils/notifiedTask.ts
@@ -1,0 +1,41 @@
+import { ipcErrorMessage } from "@shared";
+import {
+  NOTIFIED_TASK_ID_PREFIX,
+  SNACKBAR_MESSAGE_SEPARATOR,
+  TASK_LABEL_RUNNING_SUFFIX,
+} from "../constants";
+import { useBackgroundTasksStore } from "../hooks/backgroundTasksStore";
+import { useSnackbarStore } from "../hooks/snackbarStore";
+import type { NotifiedTaskResult } from "../types";
+
+let nextTaskId = 0;
+
+/// Status-bar spinner while running, outcome snackbar when done. Never
+/// rejects; callers branch on `ok`.
+async function runNotifiedTask(
+  label: string,
+  task: () => Promise<string>,
+): Promise<NotifiedTaskResult> {
+  nextTaskId += 1;
+  const id = `${NOTIFIED_TASK_ID_PREFIX}${nextTaskId}`;
+  useBackgroundTasksStore.getState().startTask(id, `${label}${TASK_LABEL_RUNNING_SUFFIX}`);
+  try {
+    const message = await task();
+    useSnackbarStore
+      .getState()
+      .enqueue(`${label}${SNACKBAR_MESSAGE_SEPARATOR}${message}`, "success");
+    return { ok: true, message };
+  } catch (error) {
+    const message = ipcErrorMessage(error);
+    useSnackbarStore
+      .getState()
+      .enqueue(`${label}${SNACKBAR_MESSAGE_SEPARATOR}${message}`, "error");
+    return { ok: false, message };
+  } finally {
+    useBackgroundTasksStore.getState().endTask(id);
+  }
+}
+
+export {
+  runNotifiedTask,
+};

--- a/src-tauri/src/commands/git.rs
+++ b/src-tauri/src/commands/git.rs
@@ -137,14 +137,14 @@ pub async fn cmd_git_stage_hunk(
 }
 
 #[tauri::command]
-pub async fn cmd_git_restore_hunk(
+pub async fn cmd_git_restore_change(
     env: State<'_, Arc<AppEnvironment>>,
     repo: PathBuf,
     file_path: String,
-    hunk_index: usize,
+    line: u32,
 ) -> Result<(), IpcError> {
     let env = env.inner().clone();
-    tokio::task::spawn_blocking(move || env.git.restore_hunk(&repo, &file_path, hunk_index))
+    tokio::task::spawn_blocking(move || env.git.restore_change_block(&repo, &file_path, line))
         .await
         .map_err(ipc_err)?
         .map_err(ipc_err)

--- a/src-tauri/src/commands/git.rs
+++ b/src-tauri/src/commands/git.rs
@@ -141,13 +141,16 @@ pub async fn cmd_git_restore_change(
     env: State<'_, Arc<AppEnvironment>>,
     repo: PathBuf,
     file_path: String,
-    line: u32,
+    start_line: u32,
+    end_line: u32,
 ) -> Result<(), IpcError> {
     let env = env.inner().clone();
-    tokio::task::spawn_blocking(move || env.git.restore_change_block(&repo, &file_path, line))
-        .await
-        .map_err(ipc_err)?
-        .map_err(ipc_err)
+    tokio::task::spawn_blocking(move || {
+        env.git.restore_change_blocks(&repo, &file_path, start_line, end_line)
+    })
+    .await
+    .map_err(ipc_err)?
+    .map_err(ipc_err)
 }
 
 #[tauri::command]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -224,7 +224,7 @@ fn main() {
             cmd_git_file_statuses,
             cmd_git_file_diff_hunks,
             cmd_git_stage_hunk,
-            cmd_git_restore_hunk,
+            cmd_git_restore_change,
             cmd_git_stage_files,
             cmd_git_unstage_files,
             cmd_git_discard_files,


### PR DESCRIPTION
## What does this PR do?

This PR adds an app-level notification service and reworks the in-editor git change workflow so hunks can be staged and discarded precisely, without visual churn while typing.

- Notifications: app-level task service (status-bar spinner + snackbars); git fetch/pull/push routed through it; Source Control pane polish (no diff blink, compact branch row, smaller fonts).
- Hunk action bar: Stage/Discard buttons pinned in viewport (were off-screen with long lines); consecutive added rows grouped into one expandable block.
- Precise discard: reverts only the change block at the cursor, not the whole merged git hunk; also unstages the block's staged copy from the index; new `gitDiscardHunk` shortcut works on cursor line or multi-line selection (discards all blocks in range).
- Calm gutter while typing: change bands stay glued to their text through edits; diff redraw waits ~200ms after last keystroke.

## Checklist

- [ ] I opened an issue first for non-trivial changes, or this is a small fix.
- [x] Tests added/updated for my change.
- [x] **I license my contribution under the MIT License**, per [CONTRIBUTING.md](../CONTRIBUTING.md). I confirm this is my original work, or that I have the right to submit it.
