### PR TITLE
[Feature] Streaming ingestion for DuckDB and SQLite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,9 @@ __pycache__/
 # Generated SSL test certs for the postgres-ssl compose service
 fixtures/initdb/postgres-ssl/certs/
 
+# Generated embedded-engine fixture databases (see fixtures/embedded-init.sh)
+fixtures/embedded/
+
 # Release artifacts
 release/
 

--- a/crates/arris-engines/src/drivers/duckdb/mod.rs
+++ b/crates/arris-engines/src/drivers/duckdb/mod.rs
@@ -8,20 +8,22 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use duckdb::Connection;
-use tokio::sync::Mutex;
+use futures::StreamExt;
+use tokio::sync::{mpsc, oneshot, Mutex};
 use tokio::task;
 
 use crate::{
     ConnectionConfig, DriverError, ExplainMode, MutationResult, PlanAttribute, PlanNode,
-    PlanResult, QueryLanguage, QueryResult, QueryValue, RowDelete, RowInsert, SchemaNode,
-    TableRef,
+    PlanResult, QueryLanguage, QueryResult, QueryStream, QueryValue, RowChunkStream, RowDelete,
+    RowInsert, SchemaNode, TableRef,
 };
+use crate::drivers::constants::STREAM_CHUNK_CHANNEL_CAPACITY;
 use crate::drivers::errors::Result;
 
 use crate::drivers::DatabaseDriver;
 use crate::drivers::sql_builder::SqlBuilder;
 
-use query::{run_exec, run_select};
+use query::{run_exec, run_select, stream_select};
 use schema::{build_schema_nodes, primary_key_columns};
 
 #[derive(Default)]
@@ -132,6 +134,43 @@ impl DatabaseDriver for DuckdbDriver {
         } else {
             self.with_conn(move |c| run_exec(c, &sql, &p)).await
         }
+    }
+
+    async fn run_query_stream(
+        &self,
+        text: &str,
+        params: &[QueryValue],
+        language: QueryLanguage,
+    ) -> Result<QueryStream> {
+        // A background drain must not hold the single connection's lock inside
+        // a manual transaction, and non-SELECTs have no rows: both materialize.
+        if !self.looks_like_select(text) || self.in_transaction().await {
+            return Ok(QueryStream::from_materialized(
+                self.run_query(text, params, language).await?,
+            ));
+        }
+        let sql = text.to_owned();
+        let p = params.to_vec();
+        let inner = self.inner.clone();
+        let (col_tx, col_rx) = oneshot::channel();
+        let (chunk_tx, chunk_rx) = mpsc::channel(STREAM_CHUNK_CHANNEL_CAPACITY);
+        task::spawn_blocking(move || {
+            let guard = inner.blocking_lock();
+            match guard.as_ref() {
+                Some(conn) => stream_select(conn, &sql, &p, col_tx, chunk_tx),
+                None => {
+                    let _ = col_tx.send(Err(DriverError::NotConnected));
+                }
+            }
+        });
+        let columns = col_rx
+            .await
+            .map_err(|_| DriverError::other("streaming task exited before returning columns"))??;
+        let chunks = futures::stream::unfold(chunk_rx, |mut rx| async move {
+            rx.recv().await.map(|item| (item, rx))
+        })
+        .boxed();
+        Ok(QueryStream::Rows(RowChunkStream { columns, chunks }))
     }
 
     fn select_like_keywords(&self) -> &'static [&'static str] {
@@ -674,5 +713,128 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(r.rows[0][0], QueryValue::Data(vec![0xde, 0xad]));
+    }
+
+    // ── run_query_stream ─────────────────────────────────────────────────────
+
+    use crate::ColumnSpec;
+    use crate::drivers::constants::STREAM_CHUNK_ROWS;
+
+    async fn drain(
+        stream: QueryStream,
+    ) -> (
+        Vec<ColumnSpec>,
+        Vec<std::result::Result<Vec<Vec<QueryValue>>, DriverError>>,
+    ) {
+        match stream {
+            QueryStream::Rows(rs) => (rs.columns, rs.chunks.collect().await),
+            QueryStream::Arrow(_) => panic!("expected a row stream"),
+        }
+    }
+
+    async fn seed_range(d: &DuckdbDriver, total: usize) {
+        d.run_query(
+            &format!("CREATE TABLE t AS SELECT range AS n FROM range({total})"),
+            &[],
+            QueryLanguage::Native,
+        )
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn run_query_stream_chunks_a_large_select_in_order() {
+        let d = DuckdbDriver::new();
+        d.connect(&cfg(":memory:")).await.unwrap();
+        let total = STREAM_CHUNK_ROWS + 5;
+        seed_range(&d, total).await;
+
+        let stream = d
+            .run_query_stream("SELECT n FROM t ORDER BY n", &[], QueryLanguage::Native)
+            .await
+            .unwrap();
+        let (columns, chunks) = drain(stream).await;
+
+        assert_eq!(columns.len(), 1);
+        assert_eq!(columns[0].name, "n");
+        assert_eq!(columns[0].type_hint, "BIGINT");
+        assert_eq!(chunks.len(), 2);
+        let first = chunks[0].as_ref().unwrap();
+        assert_eq!(first.len(), STREAM_CHUNK_ROWS);
+        assert_eq!(first[0][0], QueryValue::Int(0));
+        let last = chunks[1].as_ref().unwrap();
+        assert_eq!(last.len(), 5);
+        assert_eq!(last[4][0], QueryValue::Int(total as i64 - 1));
+    }
+
+    #[tokio::test]
+    async fn run_query_stream_materializes_non_select() {
+        let d = DuckdbDriver::new();
+        d.connect(&cfg(":memory:")).await.unwrap();
+        d.run_query("CREATE TABLE m (n INTEGER)", &[], QueryLanguage::Native)
+            .await
+            .unwrap();
+
+        let stream = d
+            .run_query_stream("INSERT INTO m VALUES (7)", &[], QueryLanguage::Native)
+            .await
+            .unwrap();
+        let (_, chunks) = drain(stream).await;
+        assert_eq!(chunks.len(), 1);
+        assert!(chunks[0].as_ref().unwrap().is_empty());
+
+        let r = d
+            .run_query("SELECT COUNT(*) FROM m", &[], QueryLanguage::Native)
+            .await
+            .unwrap();
+        assert_eq!(r.rows[0][0], QueryValue::Int(1));
+    }
+
+    #[tokio::test]
+    async fn run_query_stream_materializes_inside_a_manual_transaction() {
+        let d = DuckdbDriver::new();
+        d.connect(&cfg(":memory:")).await.unwrap();
+        let total = STREAM_CHUNK_ROWS + 5;
+        seed_range(&d, total).await;
+
+        d.begin_transaction(crate::IsolationLevel::Default)
+            .await
+            .unwrap();
+        let stream = d
+            .run_query_stream("SELECT n FROM t", &[], QueryLanguage::Native)
+            .await
+            .unwrap();
+        let (_, chunks) = drain(stream).await;
+        // Materialized results arrive as one chunk regardless of size.
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].as_ref().unwrap().len(), total);
+        d.rollback_transaction().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn dropping_the_stream_frees_the_connection() {
+        let d = DuckdbDriver::new();
+        d.connect(&cfg(":memory:")).await.unwrap();
+        seed_range(&d, 100_000).await;
+
+        let stream = d
+            .run_query_stream("SELECT n FROM t", &[], QueryLanguage::Native)
+            .await
+            .unwrap();
+        let QueryStream::Rows(mut rs) = stream else {
+            panic!("expected a row stream")
+        };
+        rs.chunks.next().await.unwrap().unwrap();
+        drop(rs);
+
+        // Hangs here (and times out) if the abandoned stream kept the lock.
+        let r = tokio::time::timeout(
+            std::time::Duration::from_secs(10),
+            d.run_query("SELECT 1", &[], QueryLanguage::Native),
+        )
+        .await
+        .expect("connection stayed locked after the stream was dropped")
+        .unwrap();
+        assert_eq!(r.rows[0][0], QueryValue::Int(1));
     }
 }

--- a/crates/arris-engines/src/drivers/duckdb/query.rs
+++ b/crates/arris-engines/src/drivers/duckdb/query.rs
@@ -3,8 +3,10 @@ use std::time::Instant;
 use duckdb::arrow::datatypes::DataType;
 use duckdb::types::Value as DuckValue;
 use duckdb::{params_from_iter, Connection};
+use tokio::sync::{mpsc, oneshot};
 
 use crate::{ColumnSpec, DriverError, QueryResult, QueryValue};
+use crate::drivers::constants::STREAM_CHUNK_ROWS;
 use crate::drivers::errors::Result;
 
 use super::values::{map_query_value, map_value_ref};
@@ -90,6 +92,84 @@ pub(super) fn run_select(conn: &Connection, sql: &str, params: &[QueryValue]) ->
             elapsed: started.elapsed().as_secs_f64(),
             ..Default::default()
         })
+    }
+}
+
+/// Send columns over `col_tx`, then row chunks over `chunk_tx`. Holds the
+/// connection lock; a dropped receiver ends the query and frees the conn.
+pub(super) fn stream_select(
+    conn: &Connection,
+    sql: &str,
+    params: &[QueryValue],
+    col_tx: oneshot::Sender<Result<Vec<ColumnSpec>>>,
+    chunk_tx: mpsc::Sender<std::result::Result<Vec<Vec<QueryValue>>, DriverError>>,
+) {
+    let mut stmt = match conn.prepare(sql) {
+        Ok(s) => s,
+        Err(e) => {
+            let _ = col_tx.send(Err(DriverError::QueryFailed(e.to_string())));
+            return;
+        }
+    };
+    let bound: Vec<DuckValue> = params.iter().map(map_query_value).collect();
+    let mut rows = match stmt.query(params_from_iter(bound)) {
+        Ok(r) => r,
+        Err(e) => {
+            let _ = col_tx.send(Err(DriverError::QueryFailed(e.to_string())));
+            return;
+        }
+    };
+    // Rows::as_ref exposes the executed statement's result schema without a
+    // borrow conflict against the live row iterator.
+    let (columns, col_count) = match rows.as_ref() {
+        Some(s) => {
+            let n = s.column_count();
+            let cols = (0..n)
+                .map(|i| {
+                    let name = s.column_name(i).map_or("?", |v| v).to_owned();
+                    ColumnSpec::new(name, duck_type_label(&s.column_type(i)))
+                })
+                .collect();
+            (cols, n)
+        }
+        None => (Vec::new(), 0),
+    };
+    if col_tx.send(Ok(columns)).is_err() {
+        return;
+    }
+    let mut chunk: Vec<Vec<QueryValue>> = Vec::with_capacity(STREAM_CHUNK_ROWS);
+    loop {
+        match rows.next() {
+            Ok(Some(row)) => {
+                let mut r = Vec::with_capacity(col_count);
+                for i in 0..col_count {
+                    match row.get_ref(i) {
+                        Ok(v) => r.push(map_value_ref(v)),
+                        Err(e) => {
+                            let _ = chunk_tx
+                                .blocking_send(Err(DriverError::QueryFailed(e.to_string())));
+                            return;
+                        }
+                    }
+                }
+                chunk.push(r);
+                if chunk.len() >= STREAM_CHUNK_ROWS {
+                    let full =
+                        std::mem::replace(&mut chunk, Vec::with_capacity(STREAM_CHUNK_ROWS));
+                    if chunk_tx.blocking_send(Ok(full)).is_err() {
+                        return;
+                    }
+                }
+            }
+            Ok(None) => break,
+            Err(e) => {
+                let _ = chunk_tx.blocking_send(Err(DriverError::QueryFailed(e.to_string())));
+                return;
+            }
+        }
+    }
+    if !chunk.is_empty() {
+        let _ = chunk_tx.blocking_send(Ok(chunk));
     }
 }
 

--- a/crates/arris-engines/src/drivers/sqlite/mod.rs
+++ b/crates/arris-engines/src/drivers/sqlite/mod.rs
@@ -17,21 +17,23 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use futures::StreamExt;
 use rusqlite::{Connection, OpenFlags};
-use tokio::sync::Mutex;
+use tokio::sync::{mpsc, oneshot, Mutex};
 use tokio::task;
 
 use crate::{
     ConnectionConfig, DriverError, ExplainMode, MutationResult, PlanAttribute, PlanNode,
-    PlanResult, QueryLanguage, QueryResult, QueryValue, RowDelete, RowInsert, SchemaNode,
-    TableRef,
+    PlanResult, QueryLanguage, QueryResult, QueryStream, QueryValue, RowChunkStream, RowDelete,
+    RowInsert, SchemaNode, TableRef,
 };
+use crate::drivers::constants::STREAM_CHUNK_CHANNEL_CAPACITY;
 use crate::drivers::errors::Result;
 
 use crate::drivers::DatabaseDriver;
 use crate::drivers::sql_builder::SqlBuilder;
 
-use query::{run_exec, run_select};
+use query::{run_exec, run_select, stream_select};
 use schema::{build_schema_nodes, primary_key_columns};
 
 #[derive(Default)]
@@ -144,6 +146,43 @@ impl DatabaseDriver for SqliteDriver {
         } else {
             self.with_conn(move |c| run_exec(c, &sql, &p)).await
         }
+    }
+
+    async fn run_query_stream(
+        &self,
+        text: &str,
+        params: &[QueryValue],
+        language: QueryLanguage,
+    ) -> Result<QueryStream> {
+        // A background drain must not hold the single connection's lock inside
+        // a manual transaction, and non-SELECTs have no rows: both materialize.
+        if !self.looks_like_select(text) || self.in_transaction().await {
+            return Ok(QueryStream::from_materialized(
+                self.run_query(text, params, language).await?,
+            ));
+        }
+        let sql = text.to_owned();
+        let p = params.to_vec();
+        let inner = self.inner.clone();
+        let (col_tx, col_rx) = oneshot::channel();
+        let (chunk_tx, chunk_rx) = mpsc::channel(STREAM_CHUNK_CHANNEL_CAPACITY);
+        task::spawn_blocking(move || {
+            let guard = inner.blocking_lock();
+            match guard.as_ref() {
+                Some(conn) => stream_select(conn, &sql, &p, col_tx, chunk_tx),
+                None => {
+                    let _ = col_tx.send(Err(DriverError::NotConnected));
+                }
+            }
+        });
+        let columns = col_rx
+            .await
+            .map_err(|_| DriverError::other("streaming task exited before returning columns"))??;
+        let chunks = futures::stream::unfold(chunk_rx, |mut rx| async move {
+            rx.recv().await.map(|item| (item, rx))
+        })
+        .boxed();
+        Ok(QueryStream::Rows(RowChunkStream { columns, chunks }))
     }
 
     fn select_like_keywords(&self) -> &'static [&'static str] {
@@ -591,5 +630,137 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(r.rows[0][0], QueryValue::Data(vec![0xde, 0xad]));
+    }
+
+    // ── run_query_stream ─────────────────────────────────────────────────────
+
+    use futures::StreamExt;
+
+    use crate::ColumnSpec;
+    use crate::drivers::constants::STREAM_CHUNK_ROWS;
+
+    async fn drain(
+        stream: QueryStream,
+    ) -> (
+        Vec<ColumnSpec>,
+        Vec<std::result::Result<Vec<Vec<QueryValue>>, DriverError>>,
+    ) {
+        match stream {
+            QueryStream::Rows(rs) => (rs.columns, rs.chunks.collect().await),
+            QueryStream::Arrow(_) => panic!("expected a row stream"),
+        }
+    }
+
+    async fn seed_range(d: &SqliteDriver, total: usize) {
+        d.run_query("CREATE TABLE t (n INTEGER PRIMARY KEY)", &[], QueryLanguage::Native)
+            .await
+            .unwrap();
+        d.run_query(
+            &format!(
+                "INSERT INTO t WITH RECURSIVE seq(n) AS \
+                 (SELECT 0 UNION ALL SELECT n+1 FROM seq WHERE n < {}) SELECT n FROM seq",
+                total - 1
+            ),
+            &[],
+            QueryLanguage::Native,
+        )
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn run_query_stream_chunks_a_large_select_in_order() {
+        let d = SqliteDriver::new();
+        d.connect(&cfg(":memory:")).await.unwrap();
+        let total = STREAM_CHUNK_ROWS + 5;
+        seed_range(&d, total).await;
+
+        let stream = d
+            .run_query_stream("SELECT n FROM t ORDER BY n", &[], QueryLanguage::Native)
+            .await
+            .unwrap();
+        let (columns, chunks) = drain(stream).await;
+
+        assert_eq!(columns.len(), 1);
+        assert_eq!(columns[0].name, "n");
+        assert_eq!(columns[0].type_hint, "INTEGER");
+        assert_eq!(chunks.len(), 2);
+        let first = chunks[0].as_ref().unwrap();
+        assert_eq!(first.len(), STREAM_CHUNK_ROWS);
+        assert_eq!(first[0][0], QueryValue::Int(0));
+        let last = chunks[1].as_ref().unwrap();
+        assert_eq!(last.len(), 5);
+        assert_eq!(last[4][0], QueryValue::Int(total as i64 - 1));
+    }
+
+    #[tokio::test]
+    async fn run_query_stream_materializes_non_select() {
+        let d = SqliteDriver::new();
+        d.connect(&cfg(":memory:")).await.unwrap();
+        d.run_query("CREATE TABLE m (n INTEGER)", &[], QueryLanguage::Native)
+            .await
+            .unwrap();
+
+        let stream = d
+            .run_query_stream("INSERT INTO m VALUES (7)", &[], QueryLanguage::Native)
+            .await
+            .unwrap();
+        let (_, chunks) = drain(stream).await;
+        assert_eq!(chunks.len(), 1);
+        assert!(chunks[0].as_ref().unwrap().is_empty());
+
+        let r = d
+            .run_query("SELECT COUNT(*) FROM m", &[], QueryLanguage::Native)
+            .await
+            .unwrap();
+        assert_eq!(r.rows[0][0], QueryValue::Int(1));
+    }
+
+    #[tokio::test]
+    async fn run_query_stream_materializes_inside_a_manual_transaction() {
+        let d = SqliteDriver::new();
+        d.connect(&cfg(":memory:")).await.unwrap();
+        let total = STREAM_CHUNK_ROWS + 5;
+        seed_range(&d, total).await;
+
+        d.begin_transaction(crate::IsolationLevel::Default)
+            .await
+            .unwrap();
+        let stream = d
+            .run_query_stream("SELECT n FROM t", &[], QueryLanguage::Native)
+            .await
+            .unwrap();
+        let (_, chunks) = drain(stream).await;
+        // Materialized results arrive as one chunk regardless of size.
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].as_ref().unwrap().len(), total);
+        d.rollback_transaction().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn dropping_the_stream_frees_the_connection() {
+        let d = SqliteDriver::new();
+        d.connect(&cfg(":memory:")).await.unwrap();
+        seed_range(&d, 100_000).await;
+
+        let stream = d
+            .run_query_stream("SELECT n FROM t", &[], QueryLanguage::Native)
+            .await
+            .unwrap();
+        let QueryStream::Rows(mut rs) = stream else {
+            panic!("expected a row stream")
+        };
+        rs.chunks.next().await.unwrap().unwrap();
+        drop(rs);
+
+        // Hangs here (and times out) if the abandoned stream kept the lock.
+        let r = tokio::time::timeout(
+            std::time::Duration::from_secs(10),
+            d.run_query("SELECT 1", &[], QueryLanguage::Native),
+        )
+        .await
+        .expect("connection stayed locked after the stream was dropped")
+        .unwrap();
+        assert_eq!(r.rows[0][0], QueryValue::Int(1));
     }
 }

--- a/crates/arris-engines/src/drivers/sqlite/query.rs
+++ b/crates/arris-engines/src/drivers/sqlite/query.rs
@@ -2,8 +2,10 @@ use std::time::Instant;
 
 use rusqlite::types::Value as SqlValue;
 use rusqlite::{Connection, params_from_iter};
+use tokio::sync::{mpsc, oneshot};
 
 use crate::{ColumnSpec, DriverError, QueryResult, QueryValue};
+use crate::drivers::constants::STREAM_CHUNK_ROWS;
 use crate::drivers::errors::Result;
 
 use super::values::{map_query_value, map_value_ref};
@@ -57,6 +59,75 @@ pub(super) fn run_select(conn: &Connection, sql: &str, params: &[QueryValue]) ->
         elapsed: started.elapsed().as_secs_f64(),
         ..Default::default()
     })
+}
+
+/// Send columns over `col_tx`, then row chunks over `chunk_tx`. Holds the
+/// connection lock; a dropped receiver ends the query and frees the conn.
+pub(super) fn stream_select(
+    conn: &Connection,
+    sql: &str,
+    params: &[QueryValue],
+    col_tx: oneshot::Sender<Result<Vec<ColumnSpec>>>,
+    chunk_tx: mpsc::Sender<std::result::Result<Vec<Vec<QueryValue>>, DriverError>>,
+) {
+    let mut stmt = match conn.prepare(sql) {
+        Ok(s) => s,
+        Err(e) => {
+            let _ = col_tx.send(Err(DriverError::QueryFailed(e.to_string())));
+            return;
+        }
+    };
+    let columns: Vec<ColumnSpec> = stmt
+        .columns()
+        .iter()
+        .map(|c| ColumnSpec::new(c.name().to_owned(), c.decl_type().unwrap_or("").to_owned()))
+        .collect();
+    let col_count = columns.len();
+    let bound: Vec<SqlValue> = params.iter().map(map_query_value).collect();
+    let mut rows = match stmt.query(params_from_iter(bound)) {
+        Ok(r) => r,
+        Err(e) => {
+            let _ = col_tx.send(Err(DriverError::QueryFailed(e.to_string())));
+            return;
+        }
+    };
+    if col_tx.send(Ok(columns)).is_err() {
+        return;
+    }
+    let mut chunk: Vec<Vec<QueryValue>> = Vec::with_capacity(STREAM_CHUNK_ROWS);
+    loop {
+        match rows.next() {
+            Ok(Some(row)) => {
+                let mut r = Vec::with_capacity(col_count);
+                for i in 0..col_count {
+                    match row.get_ref(i) {
+                        Ok(v) => r.push(map_value_ref(v)),
+                        Err(e) => {
+                            let _ = chunk_tx
+                                .blocking_send(Err(DriverError::QueryFailed(e.to_string())));
+                            return;
+                        }
+                    }
+                }
+                chunk.push(r);
+                if chunk.len() >= STREAM_CHUNK_ROWS {
+                    let full =
+                        std::mem::replace(&mut chunk, Vec::with_capacity(STREAM_CHUNK_ROWS));
+                    if chunk_tx.blocking_send(Ok(full)).is_err() {
+                        return;
+                    }
+                }
+            }
+            Ok(None) => break,
+            Err(e) => {
+                let _ = chunk_tx.blocking_send(Err(DriverError::QueryFailed(e.to_string())));
+                return;
+            }
+        }
+    }
+    if !chunk.is_empty() {
+        let _ = chunk_tx.blocking_send(Ok(chunk));
+    }
 }
 
 pub(super) fn run_exec(conn: &Connection, sql: &str, params: &[QueryValue]) -> Result<QueryResult> {

--- a/crates/arris-engines/tests/duckdb_integration.rs
+++ b/crates/arris-engines/tests/duckdb_integration.rs
@@ -940,3 +940,162 @@ async fn object_definition_missing_object_errors() {
         .unwrap_err();
     assert!(matches!(err, DriverError::QueryFailed(_)), "{err:?}");
 }
+
+// ── streaming ingestion (canvas path) ───────────────────────────────────────
+
+mod streaming_scenario;
+use streaming_scenario::BOARD;
+
+use arris_engines::{
+    CanvasEngine, CanvasError, QueryEngine, CELL_INGEST_BYTE_BUDGET, CELL_RESULT_PAGE_ROWS,
+};
+use tokio_util::sync::CancellationToken;
+
+fn canvas_engine() -> CanvasEngine {
+    streaming_scenario::canvas_engine("duckdb")
+}
+
+/// Seed `src(n BIGINT, label VARCHAR)` with rows 1..=count.
+async fn seed_numbers(driver: &dyn DatabaseDriver, count: u64) {
+    run(
+        driver,
+        &format!(
+            "CREATE TABLE src AS \
+             SELECT range + 1 AS n, 'row-' || (range + 1) AS label FROM range({count})"
+        ),
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn streaming_ingests_100k_rows_with_exact_totals_and_page() {
+    let driver = start_duckdb().await;
+    seed_numbers(driver.as_ref(), 100_000).await;
+    let engine = canvas_engine();
+
+    let stream = driver
+        .run_query_stream("SELECT n, label FROM src ORDER BY n", &[], QueryLanguage::Native)
+        .await
+        .expect("open stream");
+    let out = engine
+        .ingest_cell_stream(BOARD, "big", stream, None, CELL_INGEST_BYTE_BUDGET, None)
+        .await
+        .expect("ingest stream");
+
+    assert_eq!(out.total_rows, 100_000);
+    assert!(out.complete);
+    assert_eq!(out.result.rows.len(), CELL_RESULT_PAGE_ROWS);
+    let names: Vec<&str> = out.result.columns.iter().map(|c| c.name.as_str()).collect();
+    assert_eq!(names, vec!["n", "label"]);
+    assert_eq!(out.result.columns[0].type_hint, "BIGINT");
+    assert_eq!(out.result.columns[1].type_hint, "VARCHAR");
+    assert_eq!(out.result.rows[0][0], QueryValue::Int(1));
+    assert_eq!(out.result.rows[0][1], QueryValue::Text("row-1".into()));
+    assert_eq!(out.result.rows[499][0], QueryValue::Int(500));
+
+    // A chained cell aggregates the FULL cached result, not the 500-row page.
+    let agg = engine
+        .run_cell(BOARD, "sums", "SELECT COUNT(*) AS c, SUM(n) AS s FROM big")
+        .await
+        .expect("chained aggregate");
+    assert_eq!(agg.result.rows[0][0], QueryValue::Int(100_000));
+    assert_eq!(agg.result.rows[0][1], QueryValue::Int(5_000_050_000));
+}
+
+#[tokio::test]
+async fn streaming_cancel_registers_no_cache_entry_and_frees_the_connection() {
+    let driver = start_duckdb().await;
+    seed_numbers(driver.as_ref(), 1_000_000).await;
+    let engine = canvas_engine();
+
+    let stream = driver
+        .run_query_stream("SELECT n FROM src", &[], QueryLanguage::Native)
+        .await
+        .expect("open stream");
+
+    // Embedded engines finish 1M rows too fast to race a timer; a
+    // pre-cancelled token exercises the same abort path deterministically.
+    let token = CancellationToken::new();
+    token.cancel();
+
+    let err = engine
+        .ingest_cell_stream(BOARD, "huge", stream, Some(&token), CELL_INGEST_BYTE_BUDGET, None)
+        .await
+        .expect_err("cancel must fail the ingest");
+    assert!(matches!(err, CanvasError::Cancelled), "got {err:?}");
+
+    // The aborted cell was never registered, so downstream cannot read it.
+    let chained = engine.run_cell(BOARD, "agg", "SELECT COUNT(*) FROM huge").await;
+    assert!(chained.is_err(), "cancelled cell must not be queryable");
+
+    // Dropping the aborted stream must release the single connection.
+    let r = tokio::time::timeout(
+        std::time::Duration::from_secs(10),
+        driver.run_query("SELECT 1", &[], QueryLanguage::Native),
+    )
+    .await
+    .expect("connection stayed locked after the cancelled ingest")
+    .expect("query after cancel");
+    assert_eq!(r.rows[0][0], QueryValue::Int(1));
+}
+
+#[tokio::test]
+async fn streaming_byte_budget_truncates_and_reports_incomplete() {
+    let driver = start_duckdb().await;
+    seed_numbers(driver.as_ref(), 1_000_000).await;
+    let engine = canvas_engine();
+
+    let stream = driver
+        .run_query_stream("SELECT n FROM src ORDER BY n", &[], QueryLanguage::Native)
+        .await
+        .expect("open stream");
+    // A ~1 MiB budget admits a handful of 8k-row chunks, then stops.
+    let out = engine
+        .ingest_cell_stream(BOARD, "capped", stream, None, 1 << 20, None)
+        .await
+        .expect("ingest stream");
+
+    assert!(!out.complete, "budget stop must be surfaced, never silent");
+    assert!(out.total_rows >= CELL_RESULT_PAGE_ROWS as u64);
+    assert!(out.total_rows < 1_000_000, "budget must truncate the run");
+    assert_eq!(out.result.rows.len(), CELL_RESULT_PAGE_ROWS);
+
+    // The cached prefix stays queryable and matches the reported total.
+    let agg = engine
+        .run_cell(BOARD, "agg", "SELECT COUNT(*) AS c FROM capped")
+        .await
+        .expect("chained count");
+    assert_eq!(agg.result.rows[0][0], QueryValue::Int(out.total_rows as i64));
+}
+
+#[tokio::test]
+async fn streaming_cell_limit_wraps_sql_and_caps_to_500() {
+    let driver = start_duckdb().await;
+    seed_numbers(driver.as_ref(), 10_000).await;
+    let engine = canvas_engine();
+
+    // DuckDB wraps via SubqueryOffset, so the database itself stops at 500 and
+    // no ingest-side row cap is needed.
+    let (sql, row_cap) = QueryEngine::apply_cell_limit(
+        "SELECT n FROM src ORDER BY n",
+        &driver.pagination_strategy(),
+        Some(500),
+    );
+    assert!(sql.contains("LIMIT 500"), "wrapped SQL:\n{sql}");
+    assert_eq!(row_cap, None);
+
+    let stream = driver
+        .run_query_stream(&sql, &[], QueryLanguage::Native)
+        .await
+        .expect("open stream");
+    let out = engine
+        .ingest_cell_stream(BOARD, "lim", stream, None, 1 << 30, row_cap)
+        .await
+        .expect("ingest stream");
+
+    assert_eq!(out.total_rows, 500);
+    assert!(out.complete, "a LIMIT-capped run is a complete result");
+    assert_eq!(out.result.rows.len(), 500);
+    assert_eq!(out.result.rows[0][0], QueryValue::Int(1));
+    assert_eq!(out.result.rows[499][0], QueryValue::Int(500));
+}

--- a/crates/arris-engines/tests/sqlite_integration.rs
+++ b/crates/arris-engines/tests/sqlite_integration.rs
@@ -839,3 +839,164 @@ async fn slim_diff_keyless_and_keyed() {
     dbt_diff_scenario::assert_keyless(&*d, DiffDialect::Standard, prod, new_select).await;
     dbt_diff_scenario::assert_keyed(&*d, DiffDialect::Standard, prod, new_select).await;
 }
+
+// ── streaming ingestion (canvas path) ───────────────────────────────────────
+
+mod streaming_scenario;
+use streaming_scenario::BOARD;
+
+use arris_engines::{
+    CanvasEngine, CanvasError, QueryEngine, CELL_INGEST_BYTE_BUDGET, CELL_RESULT_PAGE_ROWS,
+};
+use tokio_util::sync::CancellationToken;
+
+fn canvas_engine() -> CanvasEngine {
+    streaming_scenario::canvas_engine("sqlite")
+}
+
+/// Seed `src(n INTEGER PK, label TEXT)` with rows 1..=count.
+async fn seed_numbers(driver: &dyn DatabaseDriver, count: u64) {
+    run(driver, "CREATE TABLE src (n INTEGER PRIMARY KEY, label TEXT)").await;
+    run(
+        driver,
+        &format!(
+            "INSERT INTO src WITH RECURSIVE seq(n) AS \
+             (SELECT 1 UNION ALL SELECT n+1 FROM seq WHERE n < {count}) \
+             SELECT n, 'row-' || n FROM seq"
+        ),
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn streaming_ingests_100k_rows_with_exact_totals_and_page() {
+    let driver = start_sqlite().await;
+    seed_numbers(driver.as_ref(), 100_000).await;
+    let engine = canvas_engine();
+
+    let stream = driver
+        .run_query_stream("SELECT n, label FROM src ORDER BY n", &[], QueryLanguage::Native)
+        .await
+        .expect("open stream");
+    let out = engine
+        .ingest_cell_stream(BOARD, "big", stream, None, CELL_INGEST_BYTE_BUDGET, None)
+        .await
+        .expect("ingest stream");
+
+    assert_eq!(out.total_rows, 100_000);
+    assert!(out.complete);
+    assert_eq!(out.result.rows.len(), CELL_RESULT_PAGE_ROWS);
+    let names: Vec<&str> = out.result.columns.iter().map(|c| c.name.as_str()).collect();
+    assert_eq!(names, vec!["n", "label"]);
+    assert_eq!(out.result.columns[0].type_hint, "INTEGER");
+    assert_eq!(out.result.columns[1].type_hint, "TEXT");
+    assert_eq!(out.result.rows[0][0], QueryValue::Int(1));
+    assert_eq!(out.result.rows[0][1], QueryValue::Text("row-1".into()));
+    assert_eq!(out.result.rows[499][0], QueryValue::Int(500));
+
+    // A chained cell aggregates the FULL cached result, not the 500-row page.
+    let agg = engine
+        .run_cell(BOARD, "sums", "SELECT COUNT(*) AS c, SUM(n) AS s FROM big")
+        .await
+        .expect("chained aggregate");
+    assert_eq!(agg.result.rows[0][0], QueryValue::Int(100_000));
+    assert_eq!(agg.result.rows[0][1], QueryValue::Int(5_000_050_000));
+}
+
+#[tokio::test]
+async fn streaming_cancel_registers_no_cache_entry_and_frees_the_connection() {
+    let driver = start_sqlite().await;
+    seed_numbers(driver.as_ref(), 1_000_000).await;
+    let engine = canvas_engine();
+
+    let stream = driver
+        .run_query_stream("SELECT n FROM src", &[], QueryLanguage::Native)
+        .await
+        .expect("open stream");
+
+    // Embedded engines finish 1M rows too fast to race a timer; a
+    // pre-cancelled token exercises the same abort path deterministically.
+    let token = CancellationToken::new();
+    token.cancel();
+
+    let err = engine
+        .ingest_cell_stream(BOARD, "huge", stream, Some(&token), CELL_INGEST_BYTE_BUDGET, None)
+        .await
+        .expect_err("cancel must fail the ingest");
+    assert!(matches!(err, CanvasError::Cancelled), "got {err:?}");
+
+    // The aborted cell was never registered, so downstream cannot read it.
+    let chained = engine.run_cell(BOARD, "agg", "SELECT COUNT(*) FROM huge").await;
+    assert!(chained.is_err(), "cancelled cell must not be queryable");
+
+    // Dropping the aborted stream must release the single connection.
+    let r = tokio::time::timeout(
+        std::time::Duration::from_secs(10),
+        driver.run_query("SELECT 1", &[], QueryLanguage::Native),
+    )
+    .await
+    .expect("connection stayed locked after the cancelled ingest")
+    .expect("query after cancel");
+    assert_eq!(r.rows[0][0], QueryValue::Int(1));
+}
+
+#[tokio::test]
+async fn streaming_byte_budget_truncates_and_reports_incomplete() {
+    let driver = start_sqlite().await;
+    seed_numbers(driver.as_ref(), 1_000_000).await;
+    let engine = canvas_engine();
+
+    let stream = driver
+        .run_query_stream("SELECT n FROM src ORDER BY n", &[], QueryLanguage::Native)
+        .await
+        .expect("open stream");
+    // A ~1 MiB budget admits a handful of 8k-row chunks, then stops.
+    let out = engine
+        .ingest_cell_stream(BOARD, "capped", stream, None, 1 << 20, None)
+        .await
+        .expect("ingest stream");
+
+    assert!(!out.complete, "budget stop must be surfaced, never silent");
+    assert!(out.total_rows >= CELL_RESULT_PAGE_ROWS as u64);
+    assert!(out.total_rows < 1_000_000, "budget must truncate the run");
+    assert_eq!(out.result.rows.len(), CELL_RESULT_PAGE_ROWS);
+
+    // The cached prefix stays queryable and matches the reported total.
+    let agg = engine
+        .run_cell(BOARD, "agg", "SELECT COUNT(*) AS c FROM capped")
+        .await
+        .expect("chained count");
+    assert_eq!(agg.result.rows[0][0], QueryValue::Int(out.total_rows as i64));
+}
+
+#[tokio::test]
+async fn streaming_cell_limit_wraps_sql_and_caps_to_500() {
+    let driver = start_sqlite().await;
+    seed_numbers(driver.as_ref(), 10_000).await;
+    let engine = canvas_engine();
+
+    // SQLite wraps via SubqueryOffset, so the database itself stops at 500 and
+    // no ingest-side row cap is needed.
+    let (sql, row_cap) = QueryEngine::apply_cell_limit(
+        "SELECT n FROM src ORDER BY n",
+        &driver.pagination_strategy(),
+        Some(500),
+    );
+    assert!(sql.contains("LIMIT 500"), "wrapped SQL:\n{sql}");
+    assert_eq!(row_cap, None);
+
+    let stream = driver
+        .run_query_stream(&sql, &[], QueryLanguage::Native)
+        .await
+        .expect("open stream");
+    let out = engine
+        .ingest_cell_stream(BOARD, "lim", stream, None, 1 << 30, row_cap)
+        .await
+        .expect("ingest stream");
+
+    assert_eq!(out.total_rows, 500);
+    assert!(out.complete, "a LIMIT-capped run is a complete result");
+    assert_eq!(out.result.rows.len(), 500);
+    assert_eq!(out.result.rows[0][0], QueryValue::Int(1));
+    assert_eq!(out.result.rows[499][0], QueryValue::Int(500));
+}

--- a/fixtures/embedded-init.sh
+++ b/fixtures/embedded-init.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Seeds the embedded-engine fixture databases (no container, unlike initdb/):
+#   fixtures/embedded/events.duckdb  (DuckDB)
+#   fixtures/embedded/events.db      (SQLite)
+# Each gets a 10,000,000-row events_10m table matching the mysql/starrocks
+# fixture schema, used to exercise streaming ingestion from the app.
+# Requires the duckdb and sqlite3 CLIs (brew install duckdb; sqlite3 ships
+# with macOS). Safe to re-run: the table is dropped and rebuilt.
+set -euo pipefail
+cd "$(dirname "$0")"
+mkdir -p embedded
+
+command -v duckdb >/dev/null || { echo "duckdb CLI not found (brew install duckdb)" >&2; exit 1; }
+command -v sqlite3 >/dev/null || { echo "sqlite3 CLI not found" >&2; exit 1; }
+
+echo "Seeding embedded/events.duckdb (10M rows)..."
+duckdb embedded/events.duckdb <<'SQL'
+CREATE OR REPLACE TABLE events_10m AS
+SELECT
+    range + 1 AS id,
+    (1 + floor(random() * 1000000))::INTEGER AS user_id,
+    ['view','click','purchase','signup','logout','share'][(1 + floor(random() * 6))::INT] AS event_type,
+    TIMESTAMP '2024-01-01 00:00:00' + to_seconds((floor(random() * 31536000))::BIGINT) AS event_time,
+    ['ios','android','web','desktop'][(1 + floor(random() * 4))::INT] AS device,
+    ['US','UK','Canada','Germany','France','Japan','Australia','Brazil','India','Mexico'][(1 + floor(random() * 10))::INT] AS country,
+    round(random() * 1000, 2)::DECIMAL(10,2) AS amount
+FROM range(10000000);
+SELECT 'duckdb events_10m rows: ' || COUNT(*) FROM events_10m;
+SQL
+
+echo "Seeding embedded/events.db (10M rows)..."
+sqlite3 embedded/events.db <<'SQL'
+PRAGMA journal_mode = OFF;
+PRAGMA synchronous = OFF;
+DROP TABLE IF EXISTS events_10m;
+CREATE TABLE events_10m (
+    id          INTEGER PRIMARY KEY,
+    user_id     INTEGER NOT NULL,
+    event_type  TEXT NOT NULL,
+    event_time  TEXT NOT NULL,
+    device      TEXT NOT NULL,
+    country     TEXT NOT NULL,
+    amount      REAL NOT NULL
+);
+INSERT INTO events_10m (id, user_id, event_type, event_time, device, country, amount)
+WITH RECURSIVE seq(n) AS (SELECT 1 UNION ALL SELECT n + 1 FROM seq WHERE n < 10000000)
+SELECT
+    n,
+    1 + abs(random()) % 1000000,
+    CASE abs(random()) % 6
+        WHEN 0 THEN 'view' WHEN 1 THEN 'click' WHEN 2 THEN 'purchase'
+        WHEN 3 THEN 'signup' WHEN 4 THEN 'logout' ELSE 'share' END,
+    datetime('2024-01-01 00:00:00', '+' || (abs(random()) % 31536000) || ' seconds'),
+    CASE abs(random()) % 4
+        WHEN 0 THEN 'ios' WHEN 1 THEN 'android' WHEN 2 THEN 'web' ELSE 'desktop' END,
+    CASE abs(random()) % 10
+        WHEN 0 THEN 'US' WHEN 1 THEN 'UK' WHEN 2 THEN 'Canada' WHEN 3 THEN 'Germany'
+        WHEN 4 THEN 'France' WHEN 5 THEN 'Japan' WHEN 6 THEN 'Australia'
+        WHEN 7 THEN 'Brazil' WHEN 8 THEN 'India' ELSE 'Mexico' END,
+    round((abs(random()) % 100000) / 100.0, 2)
+FROM seq;
+SELECT 'sqlite events_10m rows: ' || COUNT(*) FROM events_10m;
+SQL
+
+echo "Done. Connect with file paths:"
+echo "  DuckDB: $(pwd)/embedded/events.duckdb"
+echo "  SQLite: $(pwd)/embedded/events.db"


### PR DESCRIPTION
## What does this PR do?

Extends chunked streaming ingestion to the two embedded engines, DuckDB and SQLite, so canvas cells render their first page immediately and drain the full result in the background instead of materializing every row up front. Both drivers stream through the same engine path already used by Postgres, MySQL, and StarRocks.

Changes:
- DuckDB + SQLite `run_query_stream`: `SELECT` (outside a manual transaction) streams as backpressured row chunks; non-SELECTs and in-transaction reads keep the materialized fallback.
- A `spawn_blocking` task holds the connection lock, sends result columns over a `oneshot`, then row chunks over a bounded channel. Dropping the stream fails the next send, ending the query and freeing the connection (drop-to-cancel). Columns come from the executed statement (DuckDB `Rows::as_ref()`, SQLite `stmt.columns()`).
- Fixture: `fixtures/embedded-init.sh` seeds gitignored 10M-row `events_10m` DuckDB and SQLite databases matching the mysql/starrocks fixture schema.

## Checklist

- [ ] I opened an issue first for non-trivial changes, or this is a small fix.
- [x] Tests added/updated for my change.
- [x] **I license my contribution under the MIT License**, per [CONTRIBUTING.md](../CONTRIBUTING.md). I confirm this is my original work, or that I have the right to submit it.
