### PR TITLE
[Feature] Streaming ingestion for Clickhouse

### DIFF
--- a/crates/arris-engines/src/drivers/clickhouse/constants.rs
+++ b/crates/arris-engines/src/drivers/clickhouse/constants.rs
@@ -1,0 +1,3 @@
+/// Streaming fetch format: line 1 is the column names array, line 2 the ClickHouse
+/// types array, then one JSON row array per line, so results parse as they arrive.
+pub(super) const STREAM_FORMAT: &str = "JSONCompactEachRowWithNamesAndTypes";

--- a/crates/arris-engines/src/drivers/clickhouse/mod.rs
+++ b/crates/arris-engines/src/drivers/clickhouse/mod.rs
@@ -15,6 +15,7 @@
 //! - Staged edits map to ClickHouse mutations: `INSERT`, and `ALTER TABLE …
 //!   UPDATE/DELETE … SETTINGS mutations_sync = 2` so they complete synchronously.
 
+mod constants;
 mod explain;
 mod query;
 mod values;
@@ -29,8 +30,8 @@ use crate::drivers::sql_builder::SqlBuilder;
 use crate::drivers::DatabaseDriver;
 use crate::{
     ConnectionConfig, DriverError, ExplainMode, MutationResult, PlanResult, QueryLanguage,
-    QueryResult, QueryValue, RowDelete, RowInsert, SchemaNode, SchemaNodeKind, TableRef,
-    ValueMap,
+    QueryResult, QueryStream, QueryValue, RowDelete, RowInsert, SchemaNode, SchemaNodeKind,
+    TableRef, ValueMap,
 };
 
 use explain::walk_explain;
@@ -282,6 +283,23 @@ impl DatabaseDriver for ClickhouseDriver {
                 ..Default::default()
             })
         }
+    }
+
+    async fn run_query_stream(
+        &self,
+        text: &str,
+        params: &[QueryValue],
+        language: QueryLanguage,
+    ) -> Result<QueryStream> {
+        // HTTP is stateless (no manual transaction to fence), so only SELECT-shape
+        // statements stream; everything else has no rows and materializes.
+        if !self.looks_like_select(text) {
+            return Ok(QueryStream::from_materialized(
+                self.run_query(text, params, language).await?,
+            ));
+        }
+        let client = self.client().await?;
+        Ok(QueryStream::Rows(query::stream_select(&client, text).await?))
     }
 
     async fn explain_query(

--- a/crates/arris-engines/src/drivers/clickhouse/query.rs
+++ b/crates/arris-engines/src/drivers/clickhouse/query.rs
@@ -11,11 +11,16 @@
 //! [`ColumnSpec`]s from `meta` (the ClickHouse type string is kept verbatim as
 //! the `type_hint`) and decoding each cell against its column type.
 
+use clickhouse::Client;
+use clickhouse::query::BytesCursor;
+use futures::stream::{self, BoxStream, StreamExt};
 use serde::Deserialize;
 
+use crate::drivers::constants::STREAM_CHUNK_ROWS;
 use crate::drivers::errors::{DriverError, Result};
-use crate::{ColumnSpec, QueryResult, QueryValue};
+use crate::{ColumnSpec, QueryResult, QueryValue, RowChunkStream};
 
+use super::constants::STREAM_FORMAT;
 use super::values::decode_cell;
 
 #[derive(Deserialize)]
@@ -64,6 +69,137 @@ pub(super) fn parse_jsoncompact(body: &[u8], elapsed: f64) -> Result<QueryResult
     })
 }
 
+// ── streaming (JSONCompactEachRowWithNamesAndTypes) ─────────────────────────
+
+/// Owns the byte cursor plus a buffer of not-yet-split bytes for the stream's
+/// life. Dropping it drops the cursor, which aborts the ClickHouse HTTP request.
+struct StreamState {
+    cursor: BytesCursor,
+    buf: Vec<u8>,
+    types: Vec<String>,
+    cursor_done: bool,
+}
+
+/// Pops the next newline-delimited line out of `buf`; on `cursor_done` the
+/// trailing unterminated bytes count as the final line.
+fn take_line(buf: &mut Vec<u8>, cursor_done: bool) -> Option<Vec<u8>> {
+    if let Some(pos) = buf.iter().position(|&b| b == b'\n') {
+        let line = buf[..pos].to_vec();
+        buf.drain(..=pos);
+        Some(line)
+    } else if cursor_done && !buf.is_empty() {
+        Some(std::mem::take(buf))
+    } else {
+        None
+    }
+}
+
+/// Reads the next line, refilling from the cursor until one is complete or the
+/// response ends.
+async fn read_line(
+    cursor: &mut BytesCursor,
+    buf: &mut Vec<u8>,
+    cursor_done: &mut bool,
+) -> Result<Option<Vec<u8>>> {
+    loop {
+        if let Some(line) = take_line(buf, *cursor_done) {
+            return Ok(Some(line));
+        }
+        if *cursor_done {
+            return Ok(None);
+        }
+        match cursor
+            .next()
+            .await
+            .map_err(|e| DriverError::QueryFailed(e.to_string()))?
+        {
+            Some(chunk) => buf.extend_from_slice(&chunk),
+            None => *cursor_done = true,
+        }
+    }
+}
+
+/// A header line (names or types) is a JSON array of strings.
+fn parse_string_array(line: &[u8]) -> Result<Vec<String>> {
+    serde_json::from_slice(line).map_err(DriverError::Serde)
+}
+
+/// Decodes one JSON row array against the column types.
+fn decode_row(line: &[u8], types: &[String]) -> Result<Vec<QueryValue>> {
+    let cells: Vec<serde_json::Value> = serde_json::from_slice(line).map_err(DriverError::Serde)?;
+    Ok(cells
+        .iter()
+        .enumerate()
+        .map(|(i, cell)| decode_cell(types.get(i).map(String::as_str).unwrap_or("String"), cell))
+        .collect())
+}
+
+/// Fetches a `SELECT`-shape statement in a row-per-line format, reading the two
+/// header lines up front for columns, then streaming row chunks as they arrive.
+pub(super) async fn stream_select(client: &Client, sql: &str) -> Result<RowChunkStream> {
+    let mut cursor = client
+        .query(sql)
+        .fetch_bytes(STREAM_FORMAT)
+        .map_err(|e| DriverError::QueryFailed(e.to_string()))?;
+    let mut buf: Vec<u8> = Vec::new();
+    let mut cursor_done = false;
+
+    let header_err = || DriverError::QueryFailed("clickhouse stream missing header".into());
+    let names = read_line(&mut cursor, &mut buf, &mut cursor_done)
+        .await?
+        .ok_or_else(header_err)?;
+    let types_line = read_line(&mut cursor, &mut buf, &mut cursor_done)
+        .await?
+        .ok_or_else(header_err)?;
+    let names = parse_string_array(&names)?;
+    let types = parse_string_array(&types_line)?;
+    let columns: Vec<ColumnSpec> = names
+        .iter()
+        .zip(types.iter())
+        .map(|(n, t)| ColumnSpec::new(n, t))
+        .collect();
+
+    let state = StreamState { cursor, buf, types, cursor_done };
+    let chunks: BoxStream<'static, std::result::Result<Vec<Vec<QueryValue>>, DriverError>> =
+        stream::unfold(state, |mut st| async move {
+            let mut chunk: Vec<Vec<QueryValue>> = Vec::new();
+            loop {
+                match read_line(&mut st.cursor, &mut st.buf, &mut st.cursor_done).await {
+                    Ok(Some(line)) => {
+                        if line.is_empty() {
+                            continue;
+                        }
+                        match decode_row(&line, &st.types) {
+                            Ok(row) => {
+                                chunk.push(row);
+                                if chunk.len() >= STREAM_CHUNK_ROWS {
+                                    break;
+                                }
+                            }
+                            Err(e) => {
+                                st.cursor_done = true;
+                                return Some((Err(e), st));
+                            }
+                        }
+                    }
+                    Ok(None) => break,
+                    Err(e) => {
+                        st.cursor_done = true;
+                        return Some((Err(e), st));
+                    }
+                }
+            }
+            if chunk.is_empty() {
+                None
+            } else {
+                Some((Ok(chunk), st))
+            }
+        })
+        .boxed();
+
+    Ok(RowChunkStream { columns, chunks })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -99,5 +235,39 @@ mod tests {
         let r = parse_jsoncompact(body, 0.0).unwrap();
         assert_eq!(r.columns.len(), 1);
         assert!(r.rows.is_empty());
+    }
+
+    #[test]
+    fn take_line_splits_on_newline_and_keeps_remainder() {
+        let mut buf = b"one\ntwo\nthr".to_vec();
+        assert_eq!(take_line(&mut buf, false), Some(b"one".to_vec()));
+        assert_eq!(take_line(&mut buf, false), Some(b"two".to_vec()));
+        // No trailing newline and more may come: hold the partial line.
+        assert_eq!(take_line(&mut buf, false), None);
+        // Cursor drained: the partial line is the last line.
+        assert_eq!(take_line(&mut buf, true), Some(b"thr".to_vec()));
+        assert_eq!(take_line(&mut buf, true), None);
+    }
+
+    #[test]
+    fn parse_string_array_reads_header() {
+        assert_eq!(
+            parse_string_array(br#"["id","name"]"#).unwrap(),
+            vec!["id".to_owned(), "name".to_owned()]
+        );
+    }
+
+    #[test]
+    fn decode_row_uses_column_types() {
+        let types = vec!["UInt64".to_owned(), "String".to_owned(), "Float64".to_owned()];
+        let row = decode_row(br#"["1","alice",9.5]"#, &types).unwrap();
+        assert_eq!(
+            row,
+            vec![
+                QueryValue::Int(1),
+                QueryValue::Text("alice".into()),
+                QueryValue::Double(9.5),
+            ]
+        );
     }
 }

--- a/crates/arris-engines/tests/clickhouse_integration.rs
+++ b/crates/arris-engines/tests/clickhouse_integration.rs
@@ -548,3 +548,159 @@ async fn slim_diff_keyless_and_keyed() {
     dbt_diff_scenario::assert_keyless(driver.as_ref(), DiffDialect::Backtick, prod, new_select).await;
     dbt_diff_scenario::assert_keyed(driver.as_ref(), DiffDialect::Backtick, prod, new_select).await;
 }
+
+// ── streaming ingestion (canvas path) ───────────────────────────────────────
+
+mod streaming_scenario;
+use streaming_scenario::BOARD;
+
+use arris_engines::{
+    CanvasEngine, CanvasError, QueryEngine, CELL_INGEST_BYTE_BUDGET, CELL_RESULT_PAGE_ROWS,
+};
+use tokio_util::sync::CancellationToken;
+
+fn canvas_engine() -> CanvasEngine {
+    streaming_scenario::canvas_engine("clickhouse")
+}
+
+/// Seed `src(n UInt64, label String)` with rows 1..=count via `numbers`.
+async fn seed_numbers(driver: &dyn DatabaseDriver, count: u64) {
+    run(driver, "CREATE TABLE src (n UInt64, label String) ENGINE = MergeTree ORDER BY n").await;
+    run(
+        driver,
+        &format!(
+            "INSERT INTO src SELECT number + 1, concat('row-', toString(number + 1)) \
+             FROM numbers({count})"
+        ),
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn streaming_ingests_100k_rows_with_exact_totals_and_page() {
+    let (_c, driver, ..) = start_clickhouse().await;
+    seed_numbers(driver.as_ref(), 100_000).await;
+    let engine = canvas_engine();
+
+    let stream = driver
+        .run_query_stream("SELECT n, label FROM src ORDER BY n", &[], QueryLanguage::Native)
+        .await
+        .expect("open stream");
+    let out = engine
+        .ingest_cell_stream(BOARD, "big", stream, None, CELL_INGEST_BYTE_BUDGET, None)
+        .await
+        .expect("ingest stream");
+
+    assert_eq!(out.total_rows, 100_000);
+    assert!(out.complete);
+    assert_eq!(out.result.rows.len(), CELL_RESULT_PAGE_ROWS);
+    let names: Vec<&str> = out.result.columns.iter().map(|c| c.name.as_str()).collect();
+    assert_eq!(names, vec!["n", "label"]);
+    assert_eq!(out.result.columns[0].type_hint, "UInt64");
+    assert_eq!(out.result.columns[1].type_hint, "String");
+    assert_eq!(out.result.rows[0][0], QueryValue::Int(1));
+    assert_eq!(out.result.rows[0][1], QueryValue::Text("row-1".into()));
+    assert_eq!(out.result.rows[499][0], QueryValue::Int(500));
+
+    // A chained cell aggregates the FULL cached result, not the 500-row page.
+    let agg = engine
+        .run_cell(BOARD, "sums", "SELECT COUNT(*) AS c, SUM(n) AS s FROM big")
+        .await
+        .expect("chained aggregate");
+    assert_eq!(agg.result.rows[0][0], QueryValue::Int(100_000));
+    assert_eq!(agg.result.rows[0][1], QueryValue::Int(5_000_050_000));
+}
+
+#[tokio::test]
+async fn streaming_cancel_registers_no_cache_entry() {
+    let (_c, driver, ..) = start_clickhouse().await;
+    seed_numbers(driver.as_ref(), 1_000_000).await;
+    let engine = canvas_engine();
+
+    let stream = driver
+        .run_query_stream("SELECT n FROM src", &[], QueryLanguage::Native)
+        .await
+        .expect("open stream");
+
+    // A pre-cancelled token exercises the abort path deterministically.
+    let token = CancellationToken::new();
+    token.cancel();
+
+    let err = engine
+        .ingest_cell_stream(BOARD, "huge", stream, Some(&token), CELL_INGEST_BYTE_BUDGET, None)
+        .await
+        .expect_err("cancel must fail the ingest");
+    assert!(matches!(err, CanvasError::Cancelled), "got {err:?}");
+
+    // The aborted cell was never registered, so downstream cannot read it.
+    let chained = engine.run_cell(BOARD, "agg", "SELECT COUNT(*) FROM huge").await;
+    assert!(chained.is_err(), "cancelled cell must not be queryable");
+
+    // Dropping the aborted stream leaves the HTTP client healthy for new queries.
+    let r = driver
+        .run_query("SELECT 1", &[], QueryLanguage::Native)
+        .await
+        .expect("query after cancel");
+    assert_eq!(r.rows[0][0], QueryValue::Int(1));
+}
+
+#[tokio::test]
+async fn streaming_byte_budget_truncates_and_reports_incomplete() {
+    let (_c, driver, ..) = start_clickhouse().await;
+    seed_numbers(driver.as_ref(), 1_000_000).await;
+    let engine = canvas_engine();
+
+    let stream = driver
+        .run_query_stream("SELECT n FROM src ORDER BY n", &[], QueryLanguage::Native)
+        .await
+        .expect("open stream");
+    // A ~1 MiB budget admits a handful of 8k-row chunks, then stops.
+    let out = engine
+        .ingest_cell_stream(BOARD, "capped", stream, None, 1 << 20, None)
+        .await
+        .expect("ingest stream");
+
+    assert!(!out.complete, "budget stop must be surfaced, never silent");
+    assert!(out.total_rows >= CELL_RESULT_PAGE_ROWS as u64);
+    assert!(out.total_rows < 1_000_000, "budget must truncate the run");
+    assert_eq!(out.result.rows.len(), CELL_RESULT_PAGE_ROWS);
+
+    // The cached prefix stays queryable and matches the reported total.
+    let agg = engine
+        .run_cell(BOARD, "agg", "SELECT COUNT(*) AS c FROM capped")
+        .await
+        .expect("chained count");
+    assert_eq!(agg.result.rows[0][0], QueryValue::Int(out.total_rows as i64));
+}
+
+#[tokio::test]
+async fn streaming_cell_limit_wraps_sql_and_caps_to_500() {
+    let (_c, driver, ..) = start_clickhouse().await;
+    seed_numbers(driver.as_ref(), 10_000).await;
+    let engine = canvas_engine();
+
+    // ClickHouse wraps via SubqueryOffset, so the database itself stops at 500
+    // and no ingest-side row cap is needed.
+    let (sql, row_cap) = QueryEngine::apply_cell_limit(
+        "SELECT n FROM src ORDER BY n",
+        &driver.pagination_strategy(),
+        Some(500),
+    );
+    assert!(sql.contains("LIMIT 500"), "wrapped SQL:\n{sql}");
+    assert_eq!(row_cap, None);
+
+    let stream = driver
+        .run_query_stream(&sql, &[], QueryLanguage::Native)
+        .await
+        .expect("open stream");
+    let out = engine
+        .ingest_cell_stream(BOARD, "lim", stream, None, 1 << 30, row_cap)
+        .await
+        .expect("ingest stream");
+
+    assert_eq!(out.total_rows, 500);
+    assert!(out.complete, "a LIMIT-capped run is a complete result");
+    assert_eq!(out.result.rows.len(), 500);
+    assert_eq!(out.result.rows[0][0], QueryValue::Int(1));
+    assert_eq!(out.result.rows[499][0], QueryValue::Int(500));
+}

--- a/fixtures/initdb/clickhouse.sql
+++ b/fixtures/initdb/clickhouse.sql
@@ -162,3 +162,33 @@ AS SELECT customer_id, sum(amount) AS total
    FROM demo.orders
    WHERE status = 'completed'
    GROUP BY customer_id;
+
+-- =================================================================
+-- Large table (10,000,000 rows) to exercise streaming ingestion from
+-- the app. Schema matches the mysql/starrocks `events_10m` fixture.
+-- Distinct rand() nonces keep the generated columns independent.
+-- =================================================================
+
+CREATE TABLE IF NOT EXISTS demo.events_10m
+(
+    id          UInt64,
+    user_id     UInt32,
+    event_type  LowCardinality(String),
+    event_time  DateTime,
+    device      LowCardinality(String),
+    country     LowCardinality(String),
+    amount      Decimal(10, 2)
+)
+ENGINE = MergeTree
+ORDER BY id;
+
+INSERT INTO demo.events_10m
+SELECT
+    number + 1,
+    (rand() % 1000000) + 1,
+    ['view', 'click', 'purchase', 'signup', 'logout', 'share'][(rand(1) % 6) + 1],
+    toDateTime('2024-01-01 00:00:00') + toIntervalSecond(rand(2) % 31536000),
+    ['ios', 'android', 'web', 'desktop'][(rand(3) % 4) + 1],
+    ['US', 'UK', 'Canada', 'Germany', 'France', 'Japan', 'Australia', 'Brazil', 'India', 'Mexico'][(rand(4) % 10) + 1],
+    toDecimal64(round((rand(5) % 100000) / 100.0, 2), 2)
+FROM numbers(10000000);


### PR DESCRIPTION
## What does this PR do?

Extends chunked streaming ingestion to ClickHouse so canvas cells render their first page immediately and drain the full result in the background instead of materializing every row up front. Streams through the same engine path already used by Postgres, MySQL, StarRocks, DuckDB, and SQLite.

Changes:
- `run_query_stream` override: SELECT-shape statements stream over HTTP in `JSONCompactEachRowWithNamesAndTypes` (names + types header lines up front for columns, then one JSON row array per line); non-SELECTs keep the materialized fallback.
- Streaming mechanics: no spawn or channel. Read the two header lines eagerly for columns, then `stream::unfold` over the `BytesCursor` yields row chunks as they arrive. Dropping the stream drops the cursor, which aborts the HTTP request (drop-to-cancel). Gate is `looks_like_select` only (HTTP is stateless, no manual transaction to fence).
- Fixture: 10M-row `demo.events_10m` MergeTree seeded in `fixtures/initdb/clickhouse.sql` (schema matches the mysql/starrocks fixture).

## Checklist

- [ ] I opened an issue first for non-trivial changes, or this is a small fix.
- [x] Tests added/updated for my change.
- [x] **I license my contribution under the MIT License**, per [CONTRIBUTING.md](../CONTRIBUTING.md). I confirm this is my original work, or that I have the right to submit it.
