### PR TITLE
[Feature] Streaming ingestion for Mongodb

### DIFF
--- a/crates/arris-engines/src/canvas/impl_canvas_engine.rs
+++ b/crates/arris-engines/src/canvas/impl_canvas_engine.rs
@@ -360,7 +360,7 @@ impl CanvasEngine {
     /// Phase 1 for a row stream: read chunks (appending each to the cache) until
     /// the page fills, the stream ends, or the cap is reached.
     async fn start_rows(
-        mut rows: RowChunkStream,
+        rows: RowChunkStream,
         mut writer: CellCacheWriter,
         cancel: Option<&CancellationToken>,
         row_cap: Option<u64>,
@@ -429,7 +429,7 @@ impl CanvasEngine {
 
     /// Phase 1 for an Arrow stream (no row DTO involved).
     async fn start_arrow(
-        mut batches: BoxStream<'static, Result<RecordBatch, DriverError>>,
+        batches: BoxStream<'static, Result<RecordBatch, DriverError>>,
         mut writer: CellCacheWriter,
         cancel: Option<&CancellationToken>,
         row_cap: Option<u64>,

--- a/crates/arris-engines/src/canvas/impl_canvas_engine.rs
+++ b/crates/arris-engines/src/canvas/impl_canvas_engine.rs
@@ -365,12 +365,15 @@ impl CanvasEngine {
         cancel: Option<&CancellationToken>,
         row_cap: Option<u64>,
     ) -> Result<(QueryResult, CellIngestContinuation), CanvasError> {
+        // Fuse so a re-poll after the stream ends (empty result: phase 1 hits
+        // `None`, then `finish` still drains) yields `None` instead of panicking.
+        let mut chunks = rows.chunks.fuse().boxed();
         let mut builder = ArrowChunkBuilder::new(&rows.columns);
-        let columns = rows.columns.clone();
+        let columns = rows.columns;
         let mut page: Vec<Vec<QueryValue>> = Vec::new();
         let mut complete = true;
         while page.len() < CELL_RESULT_PAGE_ROWS {
-            let next = match Self::next_or_cancelled(&mut rows.chunks, cancel).await {
+            let next = match Self::next_or_cancelled(&mut chunks, cancel).await {
                 Ok(n) => n,
                 Err(e) => {
                     writer.abort();
@@ -417,10 +420,7 @@ impl CanvasEngine {
         };
         let cont = CellIngestContinuation {
             writer,
-            source: IngestSource::Rows {
-                chunks: rows.chunks,
-                builder,
-            },
+            source: IngestSource::Rows { chunks, builder },
             complete,
             row_cap,
         };
@@ -434,6 +434,8 @@ impl CanvasEngine {
         cancel: Option<&CancellationToken>,
         row_cap: Option<u64>,
     ) -> Result<(QueryResult, CellIngestContinuation), CanvasError> {
+        // Fuse: same reason as `start_rows` (re-poll after end must not panic).
+        let mut batches = batches.fuse().boxed();
         let mut page: Vec<RecordBatch> = Vec::new();
         let mut page_rows = 0usize;
         let mut complete = true;
@@ -836,6 +838,31 @@ mod tests {
             .unwrap();
         assert_eq!(int_at(&agg.result, 0, 0), 900);
         assert_eq!(int_at(&agg.result, 0, 1), (0..900).sum::<i64>());
+    }
+
+    #[tokio::test]
+    async fn terminal_empty_unfold_stream_finishes_without_panicking() {
+        // Regression: an unfold stream that ends immediately (empty result, e.g.
+        // a Mongo find on a missing collection) is polled by phase 1 (page fill)
+        // AND again by finish's drain. Without a fuse the second poll panics
+        // ("Unfold must not be polled after it returned None"), the ingest task
+        // dies, and the cell spins forever.
+        let engine = engine();
+        let stream = QueryStream::Rows(RowChunkStream {
+            columns: vec![col("n", "int64")],
+            chunks: futures::stream::unfold((), |_| async {
+                None::<(std::result::Result<Vec<Vec<QueryValue>>, DriverError>, ())>
+            })
+            .boxed(),
+        });
+        let (page, cont) = engine
+            .start_cell_ingest(BOARD, "empty", stream, None, CELL_INGEST_BYTE_BUDGET, None)
+            .await
+            .unwrap();
+        assert_eq!(page.rows.len(), 0);
+        let done = cont.finish(None).await.unwrap();
+        assert!(done.complete);
+        assert_eq!(done.total_rows, 0);
     }
 
     #[tokio::test]

--- a/crates/arris-engines/src/canvas/impl_canvas_engine.rs
+++ b/crates/arris-engines/src/canvas/impl_canvas_engine.rs
@@ -344,9 +344,12 @@ impl CanvasEngine {
         cancel: Option<&CancellationToken>,
     ) -> Result<Option<T>, CanvasError> {
         match cancel {
+            // Biased: a cancelled token wins over an already-ready chunk (a
+            // synchronously-buffered first chunk would otherwise race the token).
             Some(token) => tokio::select! {
-                item = stream.next() => Ok(item),
+                biased;
                 _ = token.cancelled() => Err(CanvasError::Cancelled),
+                item = stream.next() => Ok(item),
             },
             None => Ok(stream.next().await),
         }

--- a/crates/arris-engines/src/drivers/mongodb/mod.rs
+++ b/crates/arris-engines/src/drivers/mongodb/mod.rs
@@ -36,7 +36,7 @@ use mongodb::Client;
 
 use crate::{
     ConnectionConfig, DriverError, ExplainMode, MutationResult,
-    QueryLanguage, QueryResult, QueryValue, RowDelete, RowInsert, SchemaNode,
+    QueryLanguage, QueryResult, QueryStream, QueryValue, RowDelete, RowInsert, SchemaNode,
     SchemaNodeKind, TableRef,
 };
 use crate::drivers::errors::Result;
@@ -46,7 +46,7 @@ use mutation::{changes_to_set_doc, insert_doc_from, primary_key_filter};
 use parser::Verb;
 use query::{
     build_explain_command, execute_aggregate, execute_count, execute_delete, execute_find,
-    execute_insert, execute_update, parse_request,
+    execute_insert, execute_update, parse_request, stream_find,
 };
 use schema::{collection_detail, collection_node_kind, fields_from_docs, index_nodes};
 
@@ -173,6 +173,28 @@ impl DatabaseDriver for MongoDriver {
         let started = Instant::now();
         self.dispatch_request(request, || started.elapsed().as_secs_f64())
             .await
+    }
+
+    async fn run_query_stream(
+        &self,
+        text: &str,
+        params: &[QueryValue],
+        language: QueryLanguage,
+    ) -> Result<QueryStream> {
+        let request = parse_request(text, language)?;
+        // Only many-document `find` streams; find-one, aggregate, count, and
+        // writes are bounded or single-doc, so the materialized path is fine.
+        if !matches!(request.verb, Verb::Find) {
+            return Ok(QueryStream::from_materialized(
+                self.run_query(text, params, language).await?,
+            ));
+        }
+        let (client, default_db) = self.state().await?;
+        let db_name = request.database.as_deref().unwrap_or(&default_db);
+        let coll = client
+            .database(db_name)
+            .collection::<Document>(&request.collection);
+        Ok(QueryStream::Rows(stream_find(coll, &request).await?))
     }
 
     async fn explain_query(

--- a/crates/arris-engines/src/drivers/mongodb/query.rs
+++ b/crates/arris-engines/src/drivers/mongodb/query.rs
@@ -112,49 +112,67 @@ where
     Ok(result)
 }
 
-/// Stream a `find` result with guaranteed column completeness. Pass 1 scans the
-/// whole cursor to accumulate the top-level field union (rows discarded, so
-/// memory stays flat over huge collections); pass 2 re-issues the same find and
-/// streams rows chunked onto the fixed columns. Reads the collection twice.
+/// Stream a `find` in one cursor pass: buffer the first chunk to fix columns
+/// from its field union (`_id` first), emit it, then stream the rest onto those
+/// columns. Fields appearing only beyond the first chunk get no column.
 pub(super) async fn stream_find(
     coll: Collection<Document>,
     request: &MongoRequest,
 ) -> Result<RowChunkStream> {
     let params = find_params(request)?;
+    let mut cursor = build_find_cursor(&coll, &params).await?;
 
-    let mut scan = build_find_cursor(&coll, &params).await?;
+    let mut first: Vec<Document> = Vec::new();
     let mut union: IndexMap<String, ColumnSpec> = IndexMap::new();
-    while let Some(item) = scan.next().await {
-        let doc = item.map_err(|e| DriverError::QueryFailed(e.to_string()))?;
-        accumulate_columns(&mut union, &doc);
+    while first.len() < STREAM_CHUNK_ROWS {
+        match cursor.next().await {
+            Some(item) => {
+                let doc = item.map_err(|e| DriverError::QueryFailed(e.to_string()))?;
+                accumulate_columns(&mut union, &doc);
+                first.push(doc);
+            }
+            None => break,
+        }
     }
     let columns = finalize_columns(union);
     let order: Vec<String> = columns.iter().map(|c| c.name.clone()).collect();
+    let first_rows: Vec<Vec<QueryValue>> =
+        first.iter().map(|d| row_from_doc(d, &order)).collect();
 
-    let cursor = build_find_cursor(&coll, &params).await?;
     let chunks: BoxStream<'static, std::result::Result<Vec<Vec<QueryValue>>, DriverError>> =
-        stream::unfold((cursor, order), |(mut cursor, order)| async move {
-            let mut chunk: Vec<Vec<QueryValue>> = Vec::new();
-            loop {
-                match cursor.next().await {
-                    Some(Ok(doc)) => {
-                        chunk.push(row_from_doc(&doc, &order));
-                        if chunk.len() >= STREAM_CHUNK_ROWS {
-                            break;
-                        }
+        stream::unfold(
+            (Some(first_rows), cursor, order),
+            |(first_opt, mut cursor, order)| async move {
+                if let Some(rows) = first_opt {
+                    if !rows.is_empty() {
+                        return Some((Ok(rows), (None, cursor, order)));
                     }
-                    Some(Err(e)) => {
-                        return Some((Err(DriverError::QueryFailed(e.to_string())), (cursor, order)));
-                    }
-                    None => break,
                 }
-            }
-            if chunk.is_empty() {
-                None
-            } else {
-                Some((Ok(chunk), (cursor, order)))
-            }
-        })
+                let mut chunk: Vec<Vec<QueryValue>> = Vec::new();
+                loop {
+                    match cursor.next().await {
+                        Some(Ok(doc)) => {
+                            chunk.push(row_from_doc(&doc, &order));
+                            if chunk.len() >= STREAM_CHUNK_ROWS {
+                                break;
+                            }
+                        }
+                        Some(Err(e)) => {
+                            return Some((
+                                Err(DriverError::QueryFailed(e.to_string())),
+                                (None, cursor, order),
+                            ));
+                        }
+                        None => break,
+                    }
+                }
+                if chunk.is_empty() {
+                    None
+                } else {
+                    Some((Ok(chunk), (None, cursor, order)))
+                }
+            },
+        )
         .boxed();
 
     Ok(RowChunkStream { columns, chunks })

--- a/crates/arris-engines/src/drivers/mongodb/query.rs
+++ b/crates/arris-engines/src/drivers/mongodb/query.rs
@@ -1,16 +1,20 @@
-use futures_util::stream::StreamExt;
+use futures_util::stream::{self, BoxStream, StreamExt};
+use indexmap::IndexMap;
 use mongodb::bson::Document;
 use mongodb::options::{
     AggregateOptions, CountOptions, FindOneOptions, FindOptions,
 };
+use mongodb::{Collection, Cursor};
 
+use crate::drivers::constants::STREAM_CHUNK_ROWS;
 use crate::{
-    ColumnSpec, DriverError, QueryLanguage, QueryResult, QueryValue,
+    ColumnSpec, DriverError, QueryLanguage, QueryResult, QueryValue, RowChunkStream,
 };
 use crate::drivers::errors::Result;
 
 use super::mutation::{json_to_doc, json_to_pipeline};
 use super::parser::{Chain, MongoRequest, Verb};
+use super::tabular::{accumulate_columns, finalize_columns, row_from_doc};
 
 pub(super) fn parse_request(text: &str, language: QueryLanguage) -> Result<MongoRequest> {
     match language {
@@ -21,44 +25,72 @@ pub(super) fn parse_request(text: &str, language: QueryLanguage) -> Result<Mongo
     }
 }
 
+/// Filter, projection, and chain (limit/skip/sort) shared by the find and
+/// find-one paths.
+struct FindParams {
+    filter: Document,
+    projection: Option<Document>,
+    limit: Option<i64>,
+    skip: Option<u64>,
+    sort: Option<Document>,
+}
+
+fn find_params(request: &MongoRequest) -> Result<FindParams> {
+    let filter = match request.args.first() {
+        Some(v) if !v.is_null() => json_to_doc(v, "find filter")?,
+        _ => Document::new(),
+    };
+    let mut projection = match request.args.get(1) {
+        Some(v) if !v.is_null() => Some(json_to_doc(v, "find projection")?),
+        _ => None,
+    };
+    let mut limit = None;
+    let mut skip = None;
+    let mut sort = None;
+    for c in &request.chain {
+        match c {
+            Chain::Limit(n) => limit = Some(*n),
+            Chain::Skip(n) => skip = Some((*n).max(0) as u64),
+            Chain::Sort(v) => sort = Some(json_to_doc(v, "sort")?),
+            Chain::Project(v) => projection = Some(json_to_doc(v, "project")?),
+        }
+    }
+    Ok(FindParams { filter, projection, limit, skip, sort })
+}
+
+async fn build_find_cursor(
+    coll: &Collection<Document>,
+    params: &FindParams,
+) -> Result<Cursor<Document>> {
+    let opts = FindOptions::builder()
+        .projection(params.projection.clone())
+        .sort(params.sort.clone())
+        .limit(params.limit)
+        .skip(params.skip)
+        .build();
+    coll.find(params.filter.clone())
+        .with_options(opts)
+        .await
+        .map_err(|e| DriverError::QueryFailed(e.to_string()))
+}
+
 pub(super) async fn execute_find<F>(
-    coll: &mongodb::Collection<Document>,
+    coll: &Collection<Document>,
     request: &MongoRequest,
     elapsed: F,
 ) -> Result<QueryResult>
 where
     F: Fn() -> f64,
 {
-    let filter: Document = match request.args.first() {
-        Some(v) if !v.is_null() => json_to_doc(v, "find filter")?,
-        _ => Document::new(),
-    };
-    let projection: Option<Document> = match request.args.get(1) {
-        Some(v) if !v.is_null() => Some(json_to_doc(v, "find projection")?),
-        _ => None,
-    };
-    let mut limit: Option<i64> = None;
-    let mut skip: Option<u64> = None;
-    let mut sort: Option<Document> = None;
-    let mut chain_projection: Option<Document> = None;
-    for c in &request.chain {
-        match c {
-            Chain::Limit(n) => limit = Some(*n),
-            Chain::Skip(n) => skip = Some((*n).max(0) as u64),
-            Chain::Sort(v) => sort = Some(json_to_doc(v, "sort")?),
-            Chain::Project(v) => chain_projection = Some(json_to_doc(v, "project")?),
-        }
-    }
-    let projection = projection.or(chain_projection);
-
+    let params = find_params(request)?;
     let docs: Vec<Document> = if matches!(request.verb, Verb::FindOne) {
         let opts = FindOneOptions::builder()
-            .projection(projection)
-            .sort(sort)
-            .skip(skip)
+            .projection(params.projection)
+            .sort(params.sort)
+            .skip(params.skip)
             .build();
         match coll
-            .find_one(filter)
+            .find_one(params.filter)
             .with_options(opts)
             .await
             .map_err(|e| DriverError::QueryFailed(e.to_string()))?
@@ -67,17 +99,7 @@ where
             None => Vec::new(),
         }
     } else {
-        let opts = FindOptions::builder()
-            .projection(projection)
-            .sort(sort)
-            .limit(limit)
-            .skip(skip)
-            .build();
-        let mut cursor = coll
-            .find(filter)
-            .with_options(opts)
-            .await
-            .map_err(|e| DriverError::QueryFailed(e.to_string()))?;
+        let mut cursor = build_find_cursor(coll, &params).await?;
         let mut out = Vec::new();
         while let Some(item) = cursor.next().await {
             out.push(item.map_err(|e| DriverError::QueryFailed(e.to_string()))?);
@@ -88,6 +110,54 @@ where
     let mut result = super::tabular::tabularize(&docs);
     result.elapsed = elapsed();
     Ok(result)
+}
+
+/// Stream a `find` result with guaranteed column completeness. Pass 1 scans the
+/// whole cursor to accumulate the top-level field union (rows discarded, so
+/// memory stays flat over huge collections); pass 2 re-issues the same find and
+/// streams rows chunked onto the fixed columns. Reads the collection twice.
+pub(super) async fn stream_find(
+    coll: Collection<Document>,
+    request: &MongoRequest,
+) -> Result<RowChunkStream> {
+    let params = find_params(request)?;
+
+    let mut scan = build_find_cursor(&coll, &params).await?;
+    let mut union: IndexMap<String, ColumnSpec> = IndexMap::new();
+    while let Some(item) = scan.next().await {
+        let doc = item.map_err(|e| DriverError::QueryFailed(e.to_string()))?;
+        accumulate_columns(&mut union, &doc);
+    }
+    let columns = finalize_columns(union);
+    let order: Vec<String> = columns.iter().map(|c| c.name.clone()).collect();
+
+    let cursor = build_find_cursor(&coll, &params).await?;
+    let chunks: BoxStream<'static, std::result::Result<Vec<Vec<QueryValue>>, DriverError>> =
+        stream::unfold((cursor, order), |(mut cursor, order)| async move {
+            let mut chunk: Vec<Vec<QueryValue>> = Vec::new();
+            loop {
+                match cursor.next().await {
+                    Some(Ok(doc)) => {
+                        chunk.push(row_from_doc(&doc, &order));
+                        if chunk.len() >= STREAM_CHUNK_ROWS {
+                            break;
+                        }
+                    }
+                    Some(Err(e)) => {
+                        return Some((Err(DriverError::QueryFailed(e.to_string())), (cursor, order)));
+                    }
+                    None => break,
+                }
+            }
+            if chunk.is_empty() {
+                None
+            } else {
+                Some((Ok(chunk), (cursor, order)))
+            }
+        })
+        .boxed();
+
+    Ok(RowChunkStream { columns, chunks })
 }
 
 pub(super) async fn execute_aggregate<F>(

--- a/crates/arris-engines/src/drivers/mongodb/query.rs
+++ b/crates/arris-engines/src/drivers/mongodb/query.rs
@@ -1,11 +1,12 @@
-use futures_util::stream::{self, BoxStream, StreamExt};
+use futures_util::stream::{self, StreamExt};
 use indexmap::IndexMap;
-use mongodb::bson::Document;
+use mongodb::bson::{Document, RawDocumentBuf};
 use mongodb::options::{
     AggregateOptions, CountOptions, FindOneOptions, FindOptions,
 };
 use mongodb::{Collection, Cursor};
 
+use crate::drivers::common::RowChunkPump;
 use crate::drivers::constants::STREAM_CHUNK_ROWS;
 use crate::{
     ColumnSpec, DriverError, QueryLanguage, QueryResult, QueryValue, RowChunkStream,
@@ -14,7 +15,7 @@ use crate::drivers::errors::Result;
 
 use super::mutation::{json_to_doc, json_to_pipeline};
 use super::parser::{Chain, MongoRequest, Verb};
-use super::tabular::{accumulate_columns, finalize_columns, row_from_doc};
+use super::tabular::{accumulate_columns_raw, column_index, finalize_columns, project_row_raw};
 
 pub(super) fn parse_request(text: &str, language: QueryLanguage) -> Result<MongoRequest> {
     match language {
@@ -58,10 +59,10 @@ fn find_params(request: &MongoRequest) -> Result<FindParams> {
     Ok(FindParams { filter, projection, limit, skip, sort })
 }
 
-async fn build_find_cursor(
-    coll: &Collection<Document>,
-    params: &FindParams,
-) -> Result<Cursor<Document>> {
+async fn build_find_cursor<T>(coll: &Collection<T>, params: &FindParams) -> Result<Cursor<T>>
+where
+    T: serde::de::DeserializeOwned + Send + Sync + Unpin + 'static,
+{
     let opts = FindOptions::builder()
         .projection(params.projection.clone())
         .sort(params.sort.clone())
@@ -113,69 +114,42 @@ where
 }
 
 /// Stream a `find` in one cursor pass: buffer the first chunk to fix columns
-/// from its field union (`_id` first), emit it, then stream the rest onto those
-/// columns. Fields appearing only beyond the first chunk get no column.
+/// from its field union (`_id` first), then hand the sampled docs plus the rest
+/// of the cursor to `RowChunkPump`, which maps bson to rows on a spawned task
+/// (overlapping deserialize/convert with the consumer's Arrow build + spill).
+/// Fields appearing only beyond the first chunk get no column.
 pub(super) async fn stream_find(
     coll: Collection<Document>,
     request: &MongoRequest,
 ) -> Result<RowChunkStream> {
     let params = find_params(request)?;
+    let coll = coll.clone_with_type::<RawDocumentBuf>();
     let mut cursor = build_find_cursor(&coll, &params).await?;
 
-    let mut first: Vec<Document> = Vec::new();
+    let mut first: Vec<RawDocumentBuf> = Vec::new();
     let mut union: IndexMap<String, ColumnSpec> = IndexMap::new();
     while first.len() < STREAM_CHUNK_ROWS {
         match cursor.next().await {
             Some(item) => {
                 let doc = item.map_err(|e| DriverError::QueryFailed(e.to_string()))?;
-                accumulate_columns(&mut union, &doc);
+                accumulate_columns_raw(&mut union, &doc);
                 first.push(doc);
             }
             None => break,
         }
     }
     let columns = finalize_columns(union);
-    let order: Vec<String> = columns.iter().map(|c| c.name.clone()).collect();
-    let first_rows: Vec<Vec<QueryValue>> =
-        first.iter().map(|d| row_from_doc(d, &order)).collect();
+    let index = column_index(&columns);
+    let width = columns.len();
 
-    let chunks: BoxStream<'static, std::result::Result<Vec<Vec<QueryValue>>, DriverError>> =
-        stream::unfold(
-            (Some(first_rows), cursor, order),
-            |(first_opt, mut cursor, order)| async move {
-                if let Some(rows) = first_opt {
-                    if !rows.is_empty() {
-                        return Some((Ok(rows), (None, cursor, order)));
-                    }
-                }
-                let mut chunk: Vec<Vec<QueryValue>> = Vec::new();
-                loop {
-                    match cursor.next().await {
-                        Some(Ok(doc)) => {
-                            chunk.push(row_from_doc(&doc, &order));
-                            if chunk.len() >= STREAM_CHUNK_ROWS {
-                                break;
-                            }
-                        }
-                        Some(Err(e)) => {
-                            return Some((
-                                Err(DriverError::QueryFailed(e.to_string())),
-                                (None, cursor, order),
-                            ));
-                        }
-                        None => break,
-                    }
-                }
-                if chunk.is_empty() {
-                    None
-                } else {
-                    Some((Ok(chunk), (None, cursor, order)))
-                }
-            },
-        )
-        .boxed();
+    let rest = cursor.map(|r| r.map_err(|e| DriverError::QueryFailed(e.to_string())));
+    let rows = stream::iter(first.into_iter().map(Ok::<_, DriverError>)).chain(rest);
 
-    Ok(RowChunkStream { columns, chunks })
+    Ok(RowChunkPump::spawn(
+        columns,
+        move || async move { Ok(rows) },
+        move |doc: RawDocumentBuf| project_row_raw(&doc, &index, width),
+    ))
 }
 
 pub(super) async fn execute_aggregate<F>(

--- a/crates/arris-engines/src/drivers/mongodb/tabular.rs
+++ b/crates/arris-engines/src/drivers/mongodb/tabular.rs
@@ -3,8 +3,10 @@
 //! first column (mirrors the Swift `MongoBSON.flattenTopLevel +
 //! MongoDriver.tabularize` pair).
 
+use std::collections::HashMap;
+
 use indexmap::IndexMap;
-use mongodb::bson::{Bson, Document};
+use mongodb::bson::{Bson, Document, RawBsonRef, RawDocument};
 
 use crate::{ColumnSpec, QueryResult, QueryValue};
 
@@ -30,12 +32,29 @@ pub(super) fn finalize_columns(columns: IndexMap<String, ColumnSpec>) -> Vec<Col
     out
 }
 
-/// Project one document onto a fixed column order; absent fields render `Null`.
-pub(super) fn row_from_doc(doc: &Document, order: &[String]) -> Vec<QueryValue> {
-    order
+/// Map each column name to its row position, for O(fields) projection.
+pub(super) fn column_index(columns: &[ColumnSpec]) -> HashMap<String, usize> {
+    columns
         .iter()
-        .map(|col| doc.get(col).map_or(QueryValue::Null, bson_to_value))
+        .enumerate()
+        .map(|(i, c)| (c.name.clone(), i))
         .collect()
+}
+
+/// Project one document onto the fixed columns in a single pass over its fields
+/// (absent columns stay `Null`), instead of a per-column lookup.
+pub(super) fn project_row(
+    doc: &Document,
+    index: &HashMap<String, usize>,
+    width: usize,
+) -> Vec<QueryValue> {
+    let mut row = vec![QueryValue::Null; width];
+    for (k, v) in doc {
+        if let Some(&i) = index.get(k.as_str()) {
+            row[i] = bson_to_value(v);
+        }
+    }
+    row
 }
 
 /// Build a `QueryResult` from MongoDB documents. Top-level fields become
@@ -48,8 +67,9 @@ pub fn tabularize(docs: &[Document]) -> QueryResult {
         accumulate_columns(&mut columns, doc);
     }
     let columns = finalize_columns(columns);
-    let order: Vec<String> = columns.iter().map(|c| c.name.clone()).collect();
-    let rows = docs.iter().map(|doc| row_from_doc(doc, &order)).collect();
+    let index = column_index(&columns);
+    let width = columns.len();
+    let rows = docs.iter().map(|doc| project_row(doc, &index, width)).collect();
 
     QueryResult {
         columns,
@@ -111,6 +131,86 @@ pub fn bson_to_value(v: &Bson) -> QueryValue {
         Bson::MinKey => QueryValue::Text("MinKey".into()),
         Bson::DbPointer(_) => QueryValue::Text("DBPointer".into()),
     }
+}
+
+// ── raw BSON (streaming) ────────────────────────────────────────────────────
+// Streaming fetches `RawDocumentBuf` and converts field refs straight to
+// `QueryValue`, skipping the ~4x-costlier `Document` (per-field String/Bson) alloc.
+
+fn raw_type_hint(v: RawBsonRef) -> &'static str {
+    match v {
+        RawBsonRef::Double(_) => "double",
+        RawBsonRef::String(_) => "string",
+        RawBsonRef::Array(_) => "array",
+        RawBsonRef::Document(_) => "object",
+        RawBsonRef::Boolean(_) => "bool",
+        RawBsonRef::Null => "null",
+        RawBsonRef::RegularExpression(_) => "regex",
+        RawBsonRef::JavaScriptCode(_) | RawBsonRef::JavaScriptCodeWithScope(_) => "javascript",
+        RawBsonRef::Int32(_) => "int32",
+        RawBsonRef::Int64(_) => "int64",
+        RawBsonRef::Timestamp(_) => "timestamp",
+        RawBsonRef::Binary(_) => "binary",
+        RawBsonRef::ObjectId(_) => "ObjectId",
+        RawBsonRef::DateTime(_) => "date",
+        RawBsonRef::Symbol(_) => "symbol",
+        RawBsonRef::Decimal128(_) => "decimal",
+        RawBsonRef::Undefined => "undefined",
+        RawBsonRef::MaxKey => "maxKey",
+        RawBsonRef::MinKey => "minKey",
+        RawBsonRef::DbPointer(_) => "dbPointer",
+    }
+}
+
+fn raw_to_value(v: RawBsonRef) -> QueryValue {
+    match v {
+        RawBsonRef::Null | RawBsonRef::Undefined => QueryValue::Null,
+        RawBsonRef::Boolean(b) => QueryValue::Bool(b),
+        RawBsonRef::Int32(n) => QueryValue::Int(i64::from(n)),
+        RawBsonRef::Int64(n) => QueryValue::Int(n),
+        RawBsonRef::Double(f) => QueryValue::Double(f),
+        RawBsonRef::String(s) => QueryValue::Text(s.to_owned()),
+        RawBsonRef::ObjectId(oid) => QueryValue::Text(oid.to_hex()),
+        RawBsonRef::DateTime(dt) => {
+            QueryValue::Text(dt.try_to_rfc3339_string().unwrap_or_else(|_| dt.to_string()))
+        }
+        RawBsonRef::Binary(b) => QueryValue::Data(b.bytes.to_vec()),
+        RawBsonRef::Decimal128(d) => QueryValue::Text(d.to_string()),
+        RawBsonRef::Symbol(s) => QueryValue::Text(s.to_owned()),
+        RawBsonRef::JavaScriptCode(c) => QueryValue::Text(c.to_owned()),
+        RawBsonRef::Timestamp(t) => QueryValue::Text(format!("Timestamp({}, {})", t.time, t.increment)),
+        RawBsonRef::MaxKey => QueryValue::Text("MaxKey".into()),
+        RawBsonRef::MinKey => QueryValue::Text("MinKey".into()),
+        // Nested docs/arrays/regex/etc. are rare: own them and reuse the Bson path.
+        other => Bson::try_from(other).map_or(QueryValue::Null, |b| bson_to_value(&b)),
+    }
+}
+
+/// Fold a raw document's top-level fields into the running column union
+/// (malformed fields skipped). Raw counterpart of [`accumulate_columns`].
+pub(super) fn accumulate_columns_raw(columns: &mut IndexMap<String, ColumnSpec>, doc: &RawDocument) {
+    for (k, v) in doc.iter().flatten() {
+        let k = k.as_str();
+        columns
+            .entry(k.to_owned())
+            .or_insert_with(|| ColumnSpec::new(k, raw_type_hint(v)));
+    }
+}
+
+/// Project a raw document onto the fixed columns in one pass. Raw counterpart of
+/// [`project_row`].
+pub(super) fn project_row_raw(
+    doc: &RawDocument,
+    index: &HashMap<String, usize>,
+    width: usize,
+) -> Vec<QueryValue> {
+    let mut row = vec![QueryValue::Null; width];
+    for (k, v) in doc.iter().flatten() {
+        if let Some(&i) = index.get(k.as_str()) {
+            row[i] = raw_to_value(v);
+        }
+    }
+    row
 }
 
 #[cfg(test)]
@@ -181,9 +281,14 @@ mod tests {
     }
 
     #[test]
-    fn row_from_doc_projects_onto_order_with_nulls() {
-        let order = vec!["_id".to_owned(), "a".to_owned(), "b".to_owned()];
-        let row = row_from_doc(&doc! { "_id": 1, "b": 5 }, &order);
+    fn project_row_places_fields_by_index_with_nulls() {
+        let cols = vec![
+            ColumnSpec::new("_id", "ObjectId"),
+            ColumnSpec::new("a", "int32"),
+            ColumnSpec::new("b", "int32"),
+        ];
+        let index = column_index(&cols);
+        let row = project_row(&doc! { "_id": 1, "b": 5 }, &index, cols.len());
         assert_eq!(row, vec![QueryValue::Int(1), QueryValue::Null, QueryValue::Int(5)]);
     }
 

--- a/crates/arris-engines/src/drivers/mongodb/tabular.rs
+++ b/crates/arris-engines/src/drivers/mongodb/tabular.rs
@@ -8,44 +8,51 @@ use mongodb::bson::{Bson, Document};
 
 use crate::{ColumnSpec, QueryResult, QueryValue};
 
+/// Fold one document's top-level fields into the running column union,
+/// preserving first-seen order (`_id` is reordered to the front by
+/// [`finalize_columns`]).
+pub(super) fn accumulate_columns(columns: &mut IndexMap<String, ColumnSpec>, doc: &Document) {
+    for (k, v) in doc {
+        columns
+            .entry(k.clone())
+            .or_insert_with(|| ColumnSpec::new(k, bson_type_hint(v)));
+    }
+}
+
+/// Freeze the accumulated union into column order: `_id` first (typed as
+/// `ObjectId` to match Mongo's implicit PK), then the rest in first-seen order.
+pub(super) fn finalize_columns(columns: IndexMap<String, ColumnSpec>) -> Vec<ColumnSpec> {
+    let mut out = Vec::with_capacity(columns.len());
+    if columns.contains_key("_id") {
+        out.push(ColumnSpec::new("_id", "ObjectId"));
+    }
+    out.extend(columns.into_iter().filter(|(k, _)| k != "_id").map(|(_, v)| v));
+    out
+}
+
+/// Project one document onto a fixed column order; absent fields render `Null`.
+pub(super) fn row_from_doc(doc: &Document, order: &[String]) -> Vec<QueryValue> {
+    order
+        .iter()
+        .map(|col| doc.get(col).map_or(QueryValue::Null, bson_to_value))
+        .collect()
+}
+
 /// Build a `QueryResult` from MongoDB documents. Top-level fields become
 /// columns (union across docs, `_id` first) and each cell is rendered as
 /// the closest `QueryValue` variant. Nested objects/arrays are encoded as
 /// extended-JSON strings so the grid can render them as `Json`.
 pub fn tabularize(docs: &[Document]) -> QueryResult {
-    // Collect column order: `_id` first (if present anywhere), then every
-    // other key in first-seen order.
     let mut columns: IndexMap<String, ColumnSpec> = IndexMap::new();
-    let has_id = docs.iter().any(|d| d.contains_key("_id"));
-    if has_id {
-        columns.insert("_id".to_owned(), ColumnSpec::new("_id", "ObjectId"));
-    }
     for doc in docs {
-        for (k, v) in doc {
-            if k == "_id" {
-                continue;
-            }
-            columns
-                .entry(k.clone())
-                .or_insert_with(|| ColumnSpec::new(k, bson_type_hint(v)));
-        }
+        accumulate_columns(&mut columns, doc);
     }
-
-    let column_order: Vec<String> = columns.keys().cloned().collect();
-    let mut rows: Vec<Vec<QueryValue>> = Vec::with_capacity(docs.len());
-    for doc in docs {
-        let mut row = Vec::with_capacity(column_order.len());
-        for col in &column_order {
-            row.push(match doc.get(col) {
-                Some(v) => bson_to_value(v),
-                None => QueryValue::Null,
-            });
-        }
-        rows.push(row);
-    }
+    let columns = finalize_columns(columns);
+    let order: Vec<String> = columns.iter().map(|c| c.name.clone()).collect();
+    let rows = docs.iter().map(|doc| row_from_doc(doc, &order)).collect();
 
     QueryResult {
-        columns: columns.into_values().collect(),
+        columns,
         rows,
         rows_affected: None,
         elapsed: 0.0,
@@ -160,6 +167,24 @@ mod tests {
             r.rows[0][0],
             QueryValue::Text("507f1f77bcf86cd799439011".into())
         );
+    }
+
+    #[test]
+    fn accumulate_then_finalize_unions_disjoint_docs_with_id_first() {
+        // A field appearing only in a later doc still earns a column: this is
+        // the completeness guarantee the streaming pass-1 scan relies on.
+        let mut cols = IndexMap::new();
+        accumulate_columns(&mut cols, &doc! { "a": 1, "b": 2 });
+        accumulate_columns(&mut cols, &doc! { "_id": 9, "c": 3 });
+        let names: Vec<String> = finalize_columns(cols).into_iter().map(|c| c.name).collect();
+        assert_eq!(names, vec!["_id", "a", "b", "c"]);
+    }
+
+    #[test]
+    fn row_from_doc_projects_onto_order_with_nulls() {
+        let order = vec!["_id".to_owned(), "a".to_owned(), "b".to_owned()];
+        let row = row_from_doc(&doc! { "_id": 1, "b": 5 }, &order);
+        assert_eq!(row, vec![QueryValue::Int(1), QueryValue::Null, QueryValue::Int(5)]);
     }
 
     #[test]

--- a/crates/arris-engines/tests/mongodb_integration.rs
+++ b/crates/arris-engines/tests/mongodb_integration.rs
@@ -974,3 +974,198 @@ async fn sql_dml_errors_surface_cleanly() {
         );
     }
 }
+
+// ── streaming ingestion (canvas cell path) ──────────────────────────────────
+// MongoDB is the first schemaless streaming source. `run_query_stream` on a
+// many-document `find` uses a two-pass scan: pass 1 accumulates the full column
+// union (guaranteed completeness), pass 2 streams rows onto those columns. These
+// tests drive the same `CanvasEngine::ingest_cell_stream` path the app uses.
+
+mod streaming_scenario;
+use streaming_scenario::BOARD;
+
+use arris_engines::{
+    CanvasEngine, CanvasError, QueryEngine, CELL_INGEST_BYTE_BUDGET, CELL_RESULT_PAGE_ROWS,
+};
+use tokio_util::sync::CancellationToken;
+
+fn canvas_engine() -> CanvasEngine {
+    streaming_scenario::canvas_engine("mongodb")
+}
+
+/// Insert `count` docs `{n, label}` into `testdb.src` via the raw client, in
+/// bounded batches (Mongo has no server-side row generator).
+async fn seed_src(client: &Client, count: i64) {
+    let coll = client.database(DB).collection::<Document>("src");
+    let batch: i64 = 10_000;
+    let mut start = 1;
+    while start <= count {
+        let end = (start + batch - 1).min(count);
+        let docs: Vec<Document> = (start..=end)
+            .map(|n| doc! { "n": n, "label": format!("row-{n}") })
+            .collect();
+        coll.insert_many(docs).await.expect("seed insert");
+        start = end + 1;
+    }
+}
+
+#[tokio::test]
+async fn streaming_ingests_100k_docs_with_exact_totals_and_page() {
+    let (_c, driver, client) = start_mongo().await;
+    seed_src(&client, 100_000).await;
+    let engine = canvas_engine();
+
+    let stream = driver
+        .run_query_stream(r#"db.src.find({}).sort({"n":1})"#, &[], QueryLanguage::Native)
+        .await
+        .expect("open stream");
+    let out = engine
+        .ingest_cell_stream(BOARD, "big", stream, None, CELL_INGEST_BYTE_BUDGET, None)
+        .await
+        .expect("ingest stream");
+
+    assert_eq!(out.total_rows, 100_000);
+    assert!(out.complete);
+    assert_eq!(out.result.rows.len(), CELL_RESULT_PAGE_ROWS);
+    let names: Vec<&str> = out.result.columns.iter().map(|c| c.name.as_str()).collect();
+    assert_eq!(names, vec!["_id", "n", "label"]);
+    assert_eq!(out.result.rows[0][1], QueryValue::Int(1));
+    assert_eq!(out.result.rows[0][2], QueryValue::Text("row-1".into()));
+    assert_eq!(out.result.rows[499][1], QueryValue::Int(500));
+
+    // A chained cell aggregates the FULL cached result, not the 500-row page.
+    let agg = engine
+        .run_cell(BOARD, "sums", "SELECT COUNT(*) AS c, SUM(n) AS s FROM big")
+        .await
+        .expect("chained aggregate");
+    assert_eq!(agg.result.rows[0][0], QueryValue::Int(100_000));
+    assert_eq!(agg.result.rows[0][1], QueryValue::Int(5_000_050_000));
+}
+
+#[tokio::test]
+async fn streaming_columns_are_complete_beyond_the_first_page() {
+    // The completeness guarantee: a field present only on a document past the
+    // 500-row page still earns a column, because pass 1 scans the whole result.
+    let (_c, driver, client) = start_mongo().await;
+    let coll = client.database(DB).collection::<Document>("src");
+    let head: Vec<Document> = (1..=500).map(|n| doc! { "a": n }).collect();
+    coll.insert_many(head).await.expect("seed head");
+    coll.insert_one(doc! { "a": 501_i64, "late": "surfaced" })
+        .await
+        .expect("seed tail");
+    let engine = canvas_engine();
+
+    let stream = driver
+        .run_query_stream(r#"db.src.find({}).sort({"a":1})"#, &[], QueryLanguage::Native)
+        .await
+        .expect("open stream");
+    let out = engine
+        .ingest_cell_stream(BOARD, "wide", stream, None, CELL_INGEST_BYTE_BUDGET, None)
+        .await
+        .expect("ingest stream");
+
+    assert_eq!(out.total_rows, 501);
+    assert!(out.complete);
+    assert_eq!(out.result.rows.len(), CELL_RESULT_PAGE_ROWS);
+    let names: Vec<&str> = out.result.columns.iter().map(|c| c.name.as_str()).collect();
+    assert!(names.contains(&"late"), "late field must have a column: {names:?}");
+
+    // The page never shows `late` (it's on row 501), yet the cache holds it.
+    let agg = engine
+        .run_cell(BOARD, "late_row", "SELECT late FROM wide WHERE late IS NOT NULL")
+        .await
+        .expect("chained select");
+    assert_eq!(agg.result.rows.len(), 1);
+    assert_eq!(agg.result.rows[0][0], QueryValue::Text("surfaced".into()));
+}
+
+#[tokio::test]
+async fn streaming_cancel_registers_no_cache_entry() {
+    let (_c, driver, client) = start_mongo().await;
+    seed_src(&client, 5_000).await;
+    let engine = canvas_engine();
+
+    let stream = driver
+        .run_query_stream(r#"db.src.find({})"#, &[], QueryLanguage::Native)
+        .await
+        .expect("open stream");
+
+    // A pre-cancelled token exercises the abort path deterministically.
+    let token = CancellationToken::new();
+    token.cancel();
+
+    let err = engine
+        .ingest_cell_stream(BOARD, "huge", stream, Some(&token), CELL_INGEST_BYTE_BUDGET, None)
+        .await
+        .expect_err("cancel must fail the ingest");
+    assert!(matches!(err, CanvasError::Cancelled), "got {err:?}");
+
+    // The aborted cell was never registered, so downstream cannot read it.
+    let chained = engine.run_cell(BOARD, "agg", "SELECT COUNT(*) FROM huge").await;
+    assert!(chained.is_err(), "cancelled cell must not be queryable");
+
+    // The driver is healthy for new queries after the aborted stream drops.
+    let r = driver
+        .run_query(r#"db.src.countDocuments({})"#, &[], QueryLanguage::Native)
+        .await
+        .expect("query after cancel");
+    assert_eq!(r.rows[0][0], QueryValue::Int(5_000));
+}
+
+#[tokio::test]
+async fn streaming_byte_budget_truncates_and_reports_incomplete() {
+    let (_c, driver, client) = start_mongo().await;
+    seed_src(&client, 100_000).await;
+    let engine = canvas_engine();
+
+    let stream = driver
+        .run_query_stream(r#"db.src.find({}).sort({"n":1})"#, &[], QueryLanguage::Native)
+        .await
+        .expect("open stream");
+    // A ~1 MiB budget admits a few chunks, then stops.
+    let out = engine
+        .ingest_cell_stream(BOARD, "capped", stream, None, 1 << 20, None)
+        .await
+        .expect("ingest stream");
+
+    assert!(!out.complete, "budget stop must be surfaced, never silent");
+    assert!(out.total_rows >= CELL_RESULT_PAGE_ROWS as u64);
+    assert!(out.total_rows < 100_000, "budget must truncate the run");
+    assert_eq!(out.result.rows.len(), CELL_RESULT_PAGE_ROWS);
+
+    let agg = engine
+        .run_cell(BOARD, "agg", "SELECT COUNT(*) AS c FROM capped")
+        .await
+        .expect("chained count");
+    assert_eq!(agg.result.rows[0][0], QueryValue::Int(out.total_rows as i64));
+}
+
+#[tokio::test]
+async fn streaming_cell_limit_caps_to_500() {
+    let (_c, driver, client) = start_mongo().await;
+    seed_src(&client, 10_000).await;
+    let engine = canvas_engine();
+
+    // Mongo has no SQL LIMIT wrap (PaginationStrategy::None), so the per-cell
+    // limit becomes an ingest-side row cap and the query text is untouched.
+    let (sql, row_cap) = QueryEngine::apply_cell_limit(
+        r#"db.src.find({}).sort({"n":1})"#,
+        &driver.pagination_strategy(),
+        Some(500),
+    );
+    assert_eq!(sql, r#"db.src.find({}).sort({"n":1})"#);
+    assert_eq!(row_cap, Some(500));
+
+    let stream = driver
+        .run_query_stream(&sql, &[], QueryLanguage::Native)
+        .await
+        .expect("open stream");
+    let out = engine
+        .ingest_cell_stream(BOARD, "lim", stream, None, 1 << 30, row_cap)
+        .await
+        .expect("ingest stream");
+
+    assert_eq!(out.total_rows, 500);
+    assert!(out.complete, "a row-capped run is a complete result");
+    assert_eq!(out.result.rows.len(), 500);
+}

--- a/crates/arris-engines/tests/mongodb_integration.rs
+++ b/crates/arris-engines/tests/mongodb_integration.rs
@@ -976,10 +976,8 @@ async fn sql_dml_errors_surface_cleanly() {
 }
 
 // ── streaming ingestion (canvas cell path) ──────────────────────────────────
-// MongoDB is the first schemaless streaming source. `run_query_stream` on a
-// many-document `find` uses a two-pass scan: pass 1 accumulates the full column
-// union (guaranteed completeness), pass 2 streams rows onto those columns. These
-// tests drive the same `CanvasEngine::ingest_cell_stream` path the app uses.
+// `run_query_stream` on a `find` fixes columns from the first chunk's field
+// union, then streams the rest. Drives the app's `ingest_cell_stream` path.
 
 mod streaming_scenario;
 use streaming_scenario::BOARD;
@@ -1043,9 +1041,9 @@ async fn streaming_ingests_100k_docs_with_exact_totals_and_page() {
 }
 
 #[tokio::test]
-async fn streaming_columns_are_complete_beyond_the_first_page() {
-    // The completeness guarantee: a field present only on a document past the
-    // 500-row page still earns a column, because pass 1 scans the whole result.
+async fn streaming_columns_cover_the_whole_first_chunk_not_just_the_page() {
+    // Columns come from the first chunk's union, not the 500-row page: a field
+    // on doc 501 (past the page, within the chunk) still earns a column.
     let (_c, driver, client) = start_mongo().await;
     let coll = client.database(DB).collection::<Document>("src");
     let head: Vec<Document> = (1..=500).map(|n| doc! { "a": n }).collect();

--- a/fixtures/initdb/mongo.js
+++ b/fixtures/initdb/mongo.js
@@ -169,4 +169,33 @@ db.sales_transactions.createIndex({ sale_date: 1 });
 db.sales_transactions.createIndex({ region: 1 });
 db.sales_transactions.createIndex({ category: 1 });
 
+// -----------------------------------------------------------------
+// events_10m (10M documents) - streaming-ingest perf testing.
+// Schema matches the mysql/starrocks/clickhouse `events_10m` fixture.
+// -----------------------------------------------------------------
+const eventTypes = ["view", "click", "purchase", "signup", "logout", "share"];
+const devices    = ["ios", "android", "web", "desktop"];
+const countries  = ["US", "UK", "Canada", "Germany", "France", "Japan", "Australia", "Brazil", "India", "Mexico"];
+
+const EVENTS_TOTAL = 10000000;
+const EVENTS_BASE_DATE = new Date("2024-01-01").getTime();
+const YEAR_MS = 31536000000;
+
+for (let start = 0; start < EVENTS_TOTAL; start += BATCH) {
+  const batch = [];
+  for (let j = 0; j < BATCH; j++) {
+    const i = start + j;
+    batch.push({
+      _id:        i + 1,
+      user_id:    (Math.floor(Math.random() * 1000000)) + 1,
+      event_type: eventTypes[Math.floor(Math.random() * eventTypes.length)],
+      event_time: new Date(EVENTS_BASE_DATE + Math.floor(Math.random() * YEAR_MS)),
+      device:     devices[Math.floor(Math.random() * devices.length)],
+      country:    countries[Math.floor(Math.random() * countries.length)],
+      amount:     round2(Math.random() * 1000),
+    });
+  }
+  db.events_10m.insertMany(batch, { ordered: false });
+}
+
 print("MongoDB sample data seeded: appdb");

--- a/src-tauri/src/commands/canvas.rs
+++ b/src-tauri/src/commands/canvas.rs
@@ -4,13 +4,27 @@ use std::sync::Arc;
 use arris_engines::{
     AppEnvironment, CanvasCellRun, CanvasCellSpec, CanvasEngine, CanvasError,
     CELL_INGEST_BYTE_BUDGET, ErrorCode, IngestedCell, IpcError, ProjectState, QueryEngine,
-    QueryResult, QueryValue,
+    QueryLanguage, QueryResult, QueryValue,
 };
 use tauri::{Emitter, State};
 use uuid::Uuid;
 
-use crate::commands::constants::{CANVAS_CELL_INGESTED_EVENT, CANVAS_RUN_CANCELLED_MESSAGE};
+use crate::commands::constants::{
+    CANVAS_CELL_INGESTED_EVENT, CANVAS_RUN_CANCELLED_MESSAGE, MONGO_SHELL_STMT_PREFIX,
+};
 use crate::helpers::ipc_err;
+
+/// Canvas cells author SQL against each source's SQL frontend (mongo/es/redis
+/// translate it); the one exception is a native Mongo shell statement, which no
+/// SQL frontend parses. Route those to the native language, everything else SQL.
+/// This mirrors the console's SQL-vs-native dialect switch, resolved per cell.
+fn cell_query_language(sql: &str) -> QueryLanguage {
+    if sql.trim_start().starts_with(MONGO_SHELL_STMT_PREFIX) {
+        QueryLanguage::Native
+    } else {
+        QueryLanguage::Sql
+    }
+}
 
 /// Payload for `CANVAS_CELL_INGESTED_EVENT`: a terminal cell's full-ingest
 /// totals, emitted once its background drain completes.
@@ -62,7 +76,7 @@ async fn run_streamed_cell(
             proj,
             cell.sql.clone(),
             cell.limit,
-            None,
+            Some(cell_query_language(&cell.sql)),
             Some(query_id.to_string()),
         )
         .await;
@@ -233,7 +247,7 @@ pub async fn cmd_run_canvas_cell(
                                 proj.as_ref(),
                                 cell.sql.clone(),
                                 Vec::<QueryValue>::new(),
-                                None,
+                                Some(cell_query_language(&cell.sql)),
                                 None,
                                 None,
                                 Some(query_id.clone()),
@@ -334,4 +348,24 @@ pub async fn cmd_fetch_canvas_cell_page(
     env.canvas
         .fetch_page(&board_id, &title, offset, limit)
         .map_err(ipc_err)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sql_cells_use_the_sql_frontend() {
+        assert_eq!(cell_query_language("SELECT * FROM appdb.events_10m"), QueryLanguage::Sql);
+        assert_eq!(cell_query_language("  select 1"), QueryLanguage::Sql);
+        // `database.table` in a FROM clause is SQL, not a shell statement.
+        assert_eq!(cell_query_language("SELECT * FROM db.events"), QueryLanguage::Sql);
+        assert_eq!(cell_query_language("INSERT INTO t VALUES (1)"), QueryLanguage::Sql);
+    }
+
+    #[test]
+    fn native_mongo_shell_statements_use_the_native_language() {
+        assert_eq!(cell_query_language("db.events_10m.find({})"), QueryLanguage::Native);
+        assert_eq!(cell_query_language("  db.orders.aggregate([])"), QueryLanguage::Native);
+    }
 }

--- a/src-tauri/src/commands/constants.rs
+++ b/src-tauri/src/commands/constants.rs
@@ -13,3 +13,7 @@ pub const CANVAS_RUN_CANCELLED_MESSAGE: &str = "Query cancelled";
 /// Tauri event carrying a canvas cell's full-ingest totals once the background
 /// drain finishes (the UI page was already returned synchronously).
 pub const CANVAS_CELL_INGESTED_EVENT: &str = "canvas://cell-ingested";
+
+/// A canvas cell beginning with this is a native Mongo shell statement
+/// (`db.<coll>.<verb>(...)`); no SQL frontend parses it. Everything else is SQL.
+pub const MONGO_SHELL_STMT_PREFIX: &str = "db.";


### PR DESCRIPTION
## What does this PR do?

Extends chunked streaming ingestion to MongoDB so canvas cells render their first page immediately and drain the full result in the background. Fetches raw BSON and pipelines conversion to keep large-collection ingest fast.

Changes"
- `run_query_stream` for `find`: schemaless columns are sampled from the first chunk's field union (`_id` first), then rows stream onto them (find-one / aggregate / count / writes keep the materialized fallback). Mirrors the schema browser's sampling; a field only past the first chunk gets no column.
- Performance (~2x): fetch `RawDocumentBuf` and convert field refs straight to `QueryValue`, skipping the costly BSON→`Document` allocation (profiled at ~87% of ingest time); conversion runs on a `RowChunkPump` task overlapping the consumer's Arrow build + encrypt + spill; row projection uses a name => index map.
- Canvas SQL frontend fix: canvas cells resolve query language per cell (native `db.<coll>.<verb>` → Native, else the source's SQL frontend), so `SELECT` on a Mongo cell works instead of hitting the mongosh parser.
- Empty/sub-page result fix: fuse the cell-ingest streams so a result shorter than one page no longer panics the ingest task (`Unfold ... polled after None`), which had left the cell spinning; cancel is now biased to win over a ready chunk.

## Checklist

- [ ] I opened an issue first for non-trivial changes, or this is a small fix.
- [x] Tests added/updated for my change.
- [x] **I license my contribution under the MIT License**, per [CONTRIBUTING.md](../CONTRIBUTING.md). I confirm this is my original work, or that I have the right to submit it.
