### PR TITLE
[Feature] Streaming ingestion for Elasticsearch

### DIFF
--- a/crates/arris-engines/Cargo.toml
+++ b/crates/arris-engines/Cargo.toml
@@ -134,6 +134,9 @@ nix = { version = "0.31", features = ["signal"] }
 [dev-dependencies]
 tempfile = "3.27"
 rcgen = "0.13"
+# Raw HTTP for bulk-seeding the Elasticsearch streaming tests (the engine's
+# native path trims the trailing newline the _bulk API requires).
+reqwest = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tokio-util = "0.7"
 testcontainers = "0.27"

--- a/crates/arris-engines/src/drivers/elasticsearch/constants.rs
+++ b/crates/arris-engines/src/drivers/elasticsearch/constants.rs
@@ -1,0 +1,6 @@
+//! Constants for the Elasticsearch driver.
+
+/// `_sql` cursor page size. Larger pages mean fewer HTTP round trips when
+/// draining a big result through the cursor; both the buffered and streamed
+/// SQL paths use it.
+pub(super) const ES_SQL_FETCH_SIZE: usize = 10_000;

--- a/crates/arris-engines/src/drivers/elasticsearch/mod.rs
+++ b/crates/arris-engines/src/drivers/elasticsearch/mod.rs
@@ -1,3 +1,4 @@
+mod constants;
 mod query;
 mod schema;
 
@@ -11,7 +12,7 @@ use tokio::sync::Mutex;
 
 use crate::{
     ColumnSpec, ConnectionConfig, DriverError, ExplainMode, MutationResult, PlanResult,
-    QueryLanguage, QueryResult, QueryValue, RowDelete, RowInsert, SchemaNode,
+    QueryLanguage, QueryResult, QueryStream, QueryValue, RowDelete, RowInsert, SchemaNode,
     SchemaNodeKind, TableRef,
 };
 use crate::drivers::errors::Result;
@@ -19,7 +20,8 @@ use crate::drivers::errors::Result;
 use crate::drivers::DatabaseDriver;
 
 use query::{
-    encode_path_part, es_value_to_query, flatten_source, parse_request, query_value_to_json,
+    encode_path_part, es_value_to_query, flatten_source, parse_request, post_sql_page,
+    query_value_to_json, sql_columns, sql_cursor, sql_first_payload, sql_rows, stream_sql,
 };
 use schema::{
     alias_nodes, data_stream_nodes, field_nodes_from_mapping, index_template_nodes, schema_path,
@@ -145,90 +147,23 @@ impl ElasticsearchDriver {
         ))
     }
 
-    /// POST a payload to the `_sql` endpoint and return the parsed JSON body,
-    /// surfacing Elasticsearch's structured error on a non-2xx status.
-    async fn post_sql(st: &EsState, payload: &Value) -> Result<Value> {
-        let url = format!("{}/_sql", st.base_url);
-        let resp = st
-            .client
-            .post(&url)
-            .header("content-type", "application/json")
-            .body(payload.to_string())
-            .send()
-            .await
-            .map_err(|e| DriverError::QueryFailed(e.to_string()))?;
-
-        let status = resp.status();
-        let body: Value = resp
-            .json()
-            .await
-            .map_err(|e| DriverError::QueryFailed(e.to_string()))?;
-
-        if !status.is_success() {
-            let err_msg = body["error"]["reason"]
-                .as_str()
-                .or_else(|| body["error"]["root_cause"][0]["reason"].as_str())
-                .or_else(|| body["error"].as_str())
-                .unwrap_or("Unknown error");
-            return Err(DriverError::QueryFailed(format!(
-                "HTTP {status}: {err_msg}"
-            )));
-        }
-
-        Ok(body)
-    }
-
-    fn es_rows(body: &Value) -> Vec<Vec<QueryValue>> {
-        body["rows"]
-            .as_array()
-            .map(|rs| {
-                rs.iter()
-                    .map(|row| {
-                        row.as_array()
-                            .map(|cells| cells.iter().map(es_value_to_query).collect())
-                            .unwrap_or_default()
-                    })
-                    .collect()
-            })
-            .unwrap_or_default()
-    }
-
     async fn run_sql_query(st: &EsState, sql: &str, started: Instant) -> Result<QueryResult> {
         Self::ensure_read_only_sql(sql)?;
 
         // First page carries the column metadata; subsequent pages are fetched by
-        // replaying the returned `cursor`. Following the cursor is required so a
-        // full-table federation scan returns every row instead of truncating at
-        // `fetch_size`. The cursor is absent on the final page (and is
-        // auto-closed by ES once exhausted).
-        let mut body = Self::post_sql(
-            st,
-            &serde_json::json!({
-                "query": sql.trim().trim_end_matches(';'),
-                "fetch_size": 1000,
-            }),
-        )
-        .await?;
+        // replaying the returned cursor so a full-table scan returns every row
+        // instead of truncating at `fetch_size`. The cursor is absent on the
+        // final page (and is auto-closed by ES once exhausted).
+        let sql_url = format!("{}/_sql", st.base_url);
+        let mut body = post_sql_page(&st.client, &sql_url, &sql_first_payload(sql)).await?;
+        let columns = sql_columns(&body);
+        let mut rows = sql_rows(&body);
 
-        let columns: Vec<ColumnSpec> = body["columns"]
-            .as_array()
-            .map(|cols| {
-                cols.iter()
-                    .map(|c| {
-                        ColumnSpec::new(
-                            c["name"].as_str().unwrap_or("?"),
-                            c["type"].as_str().unwrap_or("dynamic"),
-                        )
-                    })
-                    .collect()
-            })
-            .unwrap_or_default();
-
-        let mut rows = Self::es_rows(&body);
-
-        while let Some(cursor) = body["cursor"].as_str().filter(|c| !c.is_empty()) {
-            body = Self::post_sql(st, &serde_json::json!({ "cursor": cursor })).await?;
-            rows.extend(Self::es_rows(&body));
+        let mut cursor = sql_cursor(&body);
+        while let Some(c) = cursor {
+            body = post_sql_page(&st.client, &sql_url, &serde_json::json!({ "cursor": c })).await?;
+            rows.extend(sql_rows(&body));
+            cursor = sql_cursor(&body);
         }
 
         Ok(QueryResult {
@@ -458,6 +393,28 @@ impl DatabaseDriver for ElasticsearchDriver {
                 ..Default::default()
             })
         }
+    }
+
+    async fn run_query_stream(
+        &self,
+        text: &str,
+        params: &[QueryValue],
+        language: QueryLanguage,
+    ) -> Result<QueryStream> {
+        // Only SQL SELECT streams via the `_sql` cursor; native `_search` and
+        // writes are bounded or single-shot, so the materialized path is fine.
+        if language != QueryLanguage::Sql {
+            return Ok(QueryStream::from_materialized(
+                self.run_query(text, params, language).await?,
+            ));
+        }
+        Self::ensure_read_only_sql(text)?;
+        let (client, base_url) = {
+            let guard = self.inner.lock().await;
+            let st = guard.as_ref().ok_or(DriverError::NotConnected)?;
+            (st.client.clone(), st.base_url.clone())
+        };
+        Ok(QueryStream::Rows(stream_sql(client, base_url, text).await?))
     }
 
     async fn supports_explain(&self, _mode: ExplainMode) -> bool {

--- a/crates/arris-engines/src/drivers/elasticsearch/query.rs
+++ b/crates/arris-engines/src/drivers/elasticsearch/query.rs
@@ -1,8 +1,16 @@
+use std::collections::VecDeque;
+
+use futures_util::stream;
 use indexmap::IndexMap;
 use percent_encoding::{NON_ALPHANUMERIC, utf8_percent_encode};
+use reqwest::Client;
 use serde_json::Value;
 
-use crate::QueryValue;
+use crate::drivers::common::RowChunkPump;
+use crate::drivers::errors::{DriverError, Result};
+use crate::{ColumnSpec, QueryValue, RowChunkStream};
+
+use super::constants::ES_SQL_FETCH_SIZE;
 
 pub(super) struct ParsedRequest {
     pub(super) method: String,
@@ -96,4 +104,136 @@ pub(super) fn query_value_to_json(v: &QueryValue) -> Value {
 
 pub(super) fn encode_path_part(value: &str) -> String {
     utf8_percent_encode(value, NON_ALPHANUMERIC).to_string()
+}
+
+/// POST a `_sql` payload (first page or cursor continuation) and return the
+/// parsed body, surfacing Elasticsearch's structured error on a non-2xx status.
+pub(super) async fn post_sql_page(
+    client: &Client,
+    sql_url: &str,
+    payload: &Value,
+) -> Result<Value> {
+    let resp = client
+        .post(sql_url)
+        .header("content-type", "application/json")
+        .body(payload.to_string())
+        .send()
+        .await
+        .map_err(|e| DriverError::QueryFailed(e.to_string()))?;
+
+    let status = resp.status();
+    let body: Value = resp
+        .json()
+        .await
+        .map_err(|e| DriverError::QueryFailed(e.to_string()))?;
+
+    if !status.is_success() {
+        let err_msg = body["error"]["reason"]
+            .as_str()
+            .or_else(|| body["error"]["root_cause"][0]["reason"].as_str())
+            .or_else(|| body["error"].as_str())
+            .unwrap_or("Unknown error");
+        return Err(DriverError::QueryFailed(format!("HTTP {status}: {err_msg}")));
+    }
+    Ok(body)
+}
+
+/// The initial `_sql` request body: the query plus the cursor page size.
+pub(super) fn sql_first_payload(sql: &str) -> Value {
+    serde_json::json!({
+        "query": sql.trim().trim_end_matches(';'),
+        "fetch_size": ES_SQL_FETCH_SIZE,
+    })
+}
+
+pub(super) fn sql_columns(body: &Value) -> Vec<ColumnSpec> {
+    body["columns"]
+        .as_array()
+        .map(|cols| {
+            cols.iter()
+                .map(|c| {
+                    ColumnSpec::new(
+                        c["name"].as_str().unwrap_or("?"),
+                        c["type"].as_str().unwrap_or("dynamic"),
+                    )
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+pub(super) fn sql_rows(body: &Value) -> Vec<Vec<QueryValue>> {
+    body["rows"]
+        .as_array()
+        .map(|rs| {
+            rs.iter()
+                .map(|row| {
+                    row.as_array()
+                        .map(|cells| cells.iter().map(es_value_to_query).collect())
+                        .unwrap_or_default()
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// The pagination cursor, present until the final page.
+pub(super) fn sql_cursor(body: &Value) -> Option<String> {
+    body["cursor"]
+        .as_str()
+        .filter(|c| !c.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+/// State threaded through the cursor unfold: buffered rows of the current page
+/// plus the token for the next page (`None` once exhausted or on error).
+struct SqlCursor {
+    client: Client,
+    sql_url: String,
+    pending: VecDeque<Vec<QueryValue>>,
+    cursor: Option<String>,
+}
+
+/// Stream a SQL SELECT via the `_sql` cursor: the first page carries the column
+/// metadata and first rows, then each cursor round trip yields the next page,
+/// pumped onto a chunked, backpressured stream. Column types are declared by ES,
+/// so no sampling is needed.
+pub(super) async fn stream_sql(
+    client: Client,
+    base_url: String,
+    sql: &str,
+) -> Result<RowChunkStream> {
+    let sql_url = format!("{base_url}/_sql");
+    let first = post_sql_page(&client, &sql_url, &sql_first_payload(sql)).await?;
+    let columns = sql_columns(&first);
+    let state = SqlCursor {
+        client,
+        sql_url,
+        pending: sql_rows(&first).into(),
+        cursor: sql_cursor(&first),
+    };
+
+    let rows = stream::unfold(state, |mut s| async move {
+        loop {
+            if let Some(row) = s.pending.pop_front() {
+                return Some((Ok(row), s));
+            }
+            let cursor = s.cursor.take()?;
+            match post_sql_page(&s.client, &s.sql_url, &serde_json::json!({ "cursor": cursor })).await
+            {
+                Ok(body) => {
+                    s.pending = sql_rows(&body).into();
+                    s.cursor = sql_cursor(&body);
+                }
+                // cursor is now None and pending empty, so the next poll ends the stream.
+                Err(e) => return Some((Err(e), s)),
+            }
+        }
+    });
+
+    Ok(RowChunkPump::spawn(
+        columns,
+        move || async move { Ok(rows) },
+        |row| row,
+    ))
 }

--- a/crates/arris-engines/tests/elasticsearch_integration.rs
+++ b/crates/arris-engines/tests/elasticsearch_integration.rs
@@ -824,3 +824,184 @@ async fn access_control_unavailable_when_security_disabled() {
         "the _security API must be unavailable when security is disabled"
     );
 }
+
+// ===========================================================================
+// Streaming ingestion (canvas cell). A SQL SELECT drains the `_sql` cursor into
+// the cell cache in the background while the first 500-row page returns
+// synchronously. Unlike schemaless Mongo, ES SQL declares its column types on
+// the first page, so there is no first-chunk sampling to cover.
+// ===========================================================================
+
+mod streaming_scenario;
+
+use arris_engines::{
+    CanvasEngine, CanvasError, CELL_INGEST_BYTE_BUDGET, CELL_RESULT_PAGE_ROWS, QueryEngine,
+};
+use streaming_scenario::BOARD;
+use tokio_util::sync::CancellationToken;
+
+fn canvas_engine() -> CanvasEngine {
+    streaming_scenario::canvas_engine("elasticsearch")
+}
+
+/// Base URL for the container's mapped 9200 port. Seeding goes over raw HTTP
+/// because the engine's native path trims the trailing newline the `_bulk` API
+/// requires; assertions still run through the engine.
+async fn es_url(container: &ContainerAsync<GenericImage>) -> String {
+    let host = container.get_host().await.expect("host").to_string();
+    let port = container.get_host_port_ipv4(9200).await.expect("port");
+    format!("http://{host}:{port}")
+}
+
+/// Bulk-index `count` docs `{n, label}` into the `src` index, then refresh so
+/// the SQL cursor sees them.
+async fn seed_src(container: &ContainerAsync<GenericImage>, count: i64) {
+    let base = es_url(container).await;
+    let client = reqwest::Client::new();
+    let batch: i64 = 10_000;
+    let mut start = 1;
+    while start <= count {
+        let end = (start + batch - 1).min(count);
+        let mut body = String::new();
+        for n in start..=end {
+            body.push_str("{\"index\":{}}\n");
+            body.push_str(&format!("{{\"n\":{n},\"label\":\"row-{n}\"}}\n"));
+        }
+        let resp = client
+            .post(format!("{base}/src/_bulk"))
+            .header("content-type", "application/x-ndjson")
+            .body(body)
+            .send()
+            .await
+            .expect("bulk seed");
+        assert!(resp.status().is_success(), "bulk failed: {}", resp.status());
+        start = end + 1;
+    }
+    client
+        .post(format!("{base}/src/_refresh"))
+        .send()
+        .await
+        .expect("refresh");
+}
+
+#[tokio::test]
+async fn streaming_ingests_100k_docs_with_exact_totals_and_page() {
+    let (container, driver) = start_es().await;
+    seed_src(&container, 100_000).await;
+    let engine = canvas_engine();
+
+    let stream = driver
+        .run_query_stream("SELECT n, label FROM src ORDER BY n", &[], QueryLanguage::Sql)
+        .await
+        .expect("open stream");
+    let out = engine
+        .ingest_cell_stream(BOARD, "big", stream, None, CELL_INGEST_BYTE_BUDGET, None)
+        .await
+        .expect("ingest stream");
+
+    assert_eq!(out.total_rows, 100_000);
+    assert!(out.complete);
+    assert_eq!(out.result.rows.len(), CELL_RESULT_PAGE_ROWS);
+    let names: Vec<&str> = out.result.columns.iter().map(|c| c.name.as_str()).collect();
+    assert_eq!(names, vec!["n", "label"]);
+    assert_eq!(out.result.rows[0][0], QueryValue::Int(1));
+    assert_eq!(out.result.rows[0][1], QueryValue::Text("row-1".into()));
+    assert_eq!(out.result.rows[499][0], QueryValue::Int(500));
+
+    // A chained cell aggregates the FULL cached result, not the 500-row page.
+    let agg = engine
+        .run_cell(BOARD, "sums", "SELECT COUNT(*) AS c, SUM(n) AS s FROM big")
+        .await
+        .expect("chained aggregate");
+    assert_eq!(agg.result.rows[0][0], QueryValue::Int(100_000));
+    assert_eq!(agg.result.rows[0][1], QueryValue::Int(5_000_050_000));
+}
+
+#[tokio::test]
+async fn streaming_cancel_registers_no_cache_entry() {
+    let (container, driver) = start_es().await;
+    seed_src(&container, 5_000).await;
+    let engine = canvas_engine();
+
+    let stream = driver
+        .run_query_stream("SELECT n FROM src", &[], QueryLanguage::Sql)
+        .await
+        .expect("open stream");
+
+    // A pre-cancelled token exercises the abort path deterministically.
+    let token = CancellationToken::new();
+    token.cancel();
+
+    let err = engine
+        .ingest_cell_stream(BOARD, "huge", stream, Some(&token), CELL_INGEST_BYTE_BUDGET, None)
+        .await
+        .expect_err("cancel must fail the ingest");
+    assert!(matches!(err, CanvasError::Cancelled), "got {err:?}");
+
+    // The aborted cell was never registered, so downstream cannot read it.
+    let chained = engine.run_cell(BOARD, "agg", "SELECT COUNT(*) FROM huge").await;
+    assert!(chained.is_err(), "cancelled cell must not be queryable");
+
+    // The driver is healthy for new queries after the aborted stream drops.
+    let r = run_sql(driver.as_ref(), "SELECT COUNT(*) AS c FROM src").await;
+    assert_eq!(r.rows[0][0], QueryValue::Int(5_000));
+}
+
+#[tokio::test]
+async fn streaming_byte_budget_truncates_and_reports_incomplete() {
+    let (container, driver) = start_es().await;
+    seed_src(&container, 100_000).await;
+    let engine = canvas_engine();
+
+    let stream = driver
+        .run_query_stream("SELECT n, label FROM src ORDER BY n", &[], QueryLanguage::Sql)
+        .await
+        .expect("open stream");
+    // A ~1 MiB budget admits a few chunks, then stops.
+    let out = engine
+        .ingest_cell_stream(BOARD, "capped", stream, None, 1 << 20, None)
+        .await
+        .expect("ingest stream");
+
+    assert!(!out.complete, "budget stop must be surfaced, never silent");
+    assert!(out.total_rows >= CELL_RESULT_PAGE_ROWS as u64);
+    assert!(out.total_rows < 100_000, "budget must truncate the run");
+    assert_eq!(out.result.rows.len(), CELL_RESULT_PAGE_ROWS);
+
+    let agg = engine
+        .run_cell(BOARD, "agg", "SELECT COUNT(*) AS c FROM capped")
+        .await
+        .expect("chained count");
+    assert_eq!(agg.result.rows[0][0], QueryValue::Int(out.total_rows as i64));
+}
+
+#[tokio::test]
+async fn streaming_cell_limit_caps_to_500() {
+    let (container, driver) = start_es().await;
+    seed_src(&container, 10_000).await;
+    let engine = canvas_engine();
+
+    // ES SQL has a LIMIT clause, but the driver reports PaginationStrategy::None,
+    // so the per-cell limit becomes an ingest-side row cap and the query text is
+    // left untouched.
+    let (sql, row_cap) = QueryEngine::apply_cell_limit(
+        "SELECT n FROM src ORDER BY n",
+        &driver.pagination_strategy(),
+        Some(500),
+    );
+    assert_eq!(sql, "SELECT n FROM src ORDER BY n");
+    assert_eq!(row_cap, Some(500));
+
+    let stream = driver
+        .run_query_stream(&sql, &[], QueryLanguage::Sql)
+        .await
+        .expect("open stream");
+    let out = engine
+        .ingest_cell_stream(BOARD, "lim", stream, None, 1 << 30, row_cap)
+        .await
+        .expect("ingest stream");
+
+    assert_eq!(out.total_rows, 500);
+    assert!(out.complete, "a row-capped run is a complete result");
+    assert_eq!(out.result.rows.len(), 500);
+}

--- a/fixtures/initdb/elasticsearch-init.sh
+++ b/fixtures/initdb/elasticsearch-init.sh
@@ -19,6 +19,7 @@ curl -sS -X DELETE "$ES_URL/products" >/dev/null || true
 curl -sS -X DELETE "$ES_URL/orders" >/dev/null || true
 curl -sS -X DELETE "$ES_URL/order_items" >/dev/null || true
 curl -sS -X DELETE "$ES_URL/logs" >/dev/null || true
+curl -sS -X DELETE "$ES_URL/events_10m" >/dev/null || true
 curl -sS -X DELETE "$ES_URL/_data_stream/metrics-prod" >/dev/null || true
 
 # =================================================================
@@ -355,6 +356,53 @@ es_post "/metrics-prod/_bulk" "application/x-ndjson" <<'NDJSON'
 {"create":{}}
 {"@timestamp":"2025-04-01T10:02:00Z","service":"worker","host":"worker-1","cpu_pct":0.81,"mem_bytes":734003200,"labels":{"region":"us-east","env":"dev"}}
 NDJSON
+
+# =================================================================
+# Large index for streaming-ingestion testing. 10M docs; refresh is
+# disabled during the bulk load and re-enabled after, so indexing stays
+# fast on the small container heap.
+# =================================================================
+
+es_put "/events_10m" <<'JSON'
+{
+  "settings": { "refresh_interval": "-1", "number_of_replicas": 0 },
+  "mappings": {
+    "properties": {
+      "id": { "type": "long" },
+      "user_id": { "type": "integer" },
+      "event_type": { "type": "keyword" },
+      "event_time": { "type": "date" },
+      "device": { "type": "keyword" },
+      "country": { "type": "keyword" },
+      "amount": { "type": "scaled_float", "scaling_factor": 100 }
+    }
+  }
+}
+JSON
+
+echo "Seeding events_10m (10,000,000 docs)..."
+TOTAL=10000000
+BATCH=10000
+i=0
+while [ $i -lt $TOTAL ]; do
+  end=$((i + BATCH))
+  awk -v s="$i" -v e="$end" 'BEGIN {
+    split("view click purchase signup logout", et, " ")
+    split("ios android web", dv, " ")
+    split("US GB DE CA AU JP", cc, " ")
+    for (n = s + 1; n <= e; n++) {
+      printf "{\"index\":{\"_id\":\"%d\"}}\n", n
+      printf "{\"id\":%d,\"user_id\":%d,\"event_type\":\"%s\",\"event_time\":\"2025-06-%02dT00:00:00Z\",\"device\":\"%s\",\"country\":\"%s\",\"amount\":%d.%02d}\n", \
+        n, n % 100000, et[(n % 5) + 1], (n % 28) + 1, dv[(n % 3) + 1], cc[(n % 6) + 1], n % 500, n % 100
+    }
+  }' | curl -sS -X POST "$ES_URL/events_10m/_bulk" \
+    -H 'Content-Type: application/x-ndjson' --data-binary @- >/dev/null
+  i=$end
+done
+
+es_put "/events_10m/_settings" <<'JSON'
+{ "index": { "refresh_interval": "1s" } }
+JSON
 
 curl -sS -X POST "$ES_URL/_refresh"
 


### PR DESCRIPTION
## What does this PR do?

Extends chunked streaming ingestion to Elasticsearch.

Changes:
- `run_query_stream`: the `_sql` endpoint's cursor pagination becomes a `RowChunkStream` via `RowChunkPump`, so HTTP page fetches overlap the consumer's Arrow build + spill. Column types come declared on the first page (no first-chunk sampling, unlike schemaless Mongo). Native `_search` and writes keep the materialized fallback.
- ES has no server-push body stream; "streaming" here is client-pull cursor pagination (N sequential `POST /_sql` round trips). Cursor page size moved to a new `constants.rs` and raised to 10k to cut round trips when draining a large index; both the buffered and streamed paths share it.
- Dedupe: the `_sql` post/columns/rows/cursor helpers moved into `query.rs` free functions used by both the buffered `run_query` and the new stream, dropping the old `post_sql`/`es_rows` methods.

## Checklist

- [ ] I opened an issue first for non-trivial changes, or this is a small fix.
- [x] Tests added/updated for my change.
- [x] **I license my contribution under the MIT License**, per [CONTRIBUTING.md](../CONTRIBUTING.md). I confirm this is my original work, or that I have the right to submit it.
