### PR TITLE
[Feature] Streaming ingestion for SQL Server

### DIFF
--- a/crates/arris-engines/src/drivers/mssql/mod.rs
+++ b/crates/arris-engines/src/drivers/mssql/mod.rs
@@ -14,8 +14,8 @@ use tokio_util::compat::Compat;
 
 use crate::{
     ConnectionConfig, DriverError, ExplainMode, MutationResult, ObjectRef, PlanAttribute, PlanNode,
-    PlanResult, QueryLanguage, QueryResult, QueryValue, RowDelete, RowInsert, SchemaNode,
-    TableRef,
+    PlanResult, QueryLanguage, QueryResult, QueryStream, QueryValue, RowDelete, RowInsert,
+    SchemaNode, TableRef,
 };
 use crate::drivers::errors::Result;
 
@@ -23,11 +23,11 @@ use crate::drivers::DatabaseDriver;
 use crate::drivers::sql_builder::SqlBuilder;
 
 use config::{build_config, connect_tcp};
-use query::rows_to_query_result;
+use query::{rows_to_query_result, stream_query};
 use schema::{MssqlColumn, MssqlObject, MssqlSchema, build_mssql_schema_tree, mssql_kind_from_catalog};
 use values::{SqlParam, ToSql};
 
-type MssqlClient = Client<Compat<TcpStream>>;
+pub(super) type MssqlClient = Client<Compat<TcpStream>>;
 
 pub struct MssqlDriver {
     inner: Mutex<Option<MssqlClient>>,
@@ -518,6 +518,31 @@ impl DatabaseDriver for MssqlDriver {
                 })
             }
         }
+    }
+
+    async fn run_query_stream(
+        &self,
+        text: &str,
+        params: &[QueryValue],
+        language: QueryLanguage,
+    ) -> Result<QueryStream> {
+        // Streaming runs on a fresh ephemeral connection, so non-SELECTs and an
+        // open manual transaction (pinned to the main client) stay materialized.
+        if !self.looks_like_select(text) || self.in_transaction().await {
+            return Ok(QueryStream::from_materialized(
+                self.run_query(text, params, language).await?,
+            ));
+        }
+        let cfg = self
+            .cancel_config
+            .lock()
+            .await
+            .clone()
+            .ok_or(DriverError::NotConnected)?;
+        let client = connect_tcp(&cfg).await?;
+        Ok(QueryStream::Rows(
+            stream_query(client, text.to_owned(), params.to_vec()).await?,
+        ))
     }
 
     async fn explain_query(

--- a/crates/arris-engines/src/drivers/mssql/query.rs
+++ b/crates/arris-engines/src/drivers/mssql/query.rs
@@ -1,8 +1,13 @@
+use futures::StreamExt;
 use tiberius::{Column, Row};
+use tokio::sync::{mpsc, oneshot};
 
-use crate::{ColumnSpec, QueryResult, QueryValue};
+use crate::drivers::constants::{STREAM_CHUNK_CHANNEL_CAPACITY, STREAM_CHUNK_ROWS};
+use crate::drivers::errors::{DriverError, Result};
+use crate::{ColumnSpec, QueryResult, QueryValue, RowChunkStream};
 
-use super::values::{column_data_to_query, mssql_column_type_name};
+use super::MssqlClient;
+use super::values::{SqlParam, ToSql, column_data_to_query, mssql_column_type_name};
 
 pub(super) fn rows_to_query_result(columns: &[Column], rows: Vec<Row>, elapsed: f64) -> QueryResult {
     let column_specs: Vec<ColumnSpec> = columns
@@ -25,4 +30,81 @@ pub(super) fn rows_to_query_result(columns: &[Column], rows: Vec<Row>, elapsed: 
         elapsed,
         ..Default::default()
     }
+}
+
+/// One streamed row to `QueryValue`s (cells moved out, not cloned).
+pub(super) fn row_to_query_values(row: Row) -> Vec<QueryValue> {
+    row.into_iter().map(column_data_to_query).collect()
+}
+
+/// Stream a SELECT over an owned ephemeral client: a spawned task runs the query,
+/// reads the leading metadata into `ColumnSpec`s (sent up front over a oneshot,
+/// since tiberius can only learn columns by executing), then chunks rows onto a
+/// bounded channel. Dropping the receiver drops the task and its connection.
+pub(super) async fn stream_query(
+    mut client: MssqlClient,
+    text: String,
+    params: Vec<QueryValue>,
+) -> Result<RowChunkStream> {
+    let (col_tx, col_rx) = oneshot::channel::<Result<Vec<ColumnSpec>>>();
+    let (chunk_tx, chunk_rx) = mpsc::channel(STREAM_CHUNK_CHANNEL_CAPACITY);
+
+    tokio::spawn(async move {
+        let sql_params: Vec<SqlParam> = params.into_iter().map(SqlParam).collect();
+        let refs: Vec<&dyn ToSql> = sql_params.iter().map(|p| p as &dyn ToSql).collect();
+        let mut stream = match client.query(&text, &refs).await {
+            Ok(s) => s,
+            Err(e) => {
+                let _ = col_tx.send(Err(DriverError::QueryFailed(e.to_string())));
+                return;
+            }
+        };
+        let columns = match stream.columns().await {
+            Ok(cols) => cols
+                .unwrap_or_default()
+                .iter()
+                .map(|c| ColumnSpec::new(c.name(), mssql_column_type_name(c.column_type())))
+                .collect(),
+            Err(e) => {
+                let _ = col_tx.send(Err(DriverError::QueryFailed(e.to_string())));
+                return;
+            }
+        };
+        if col_tx.send(Ok(columns)).is_err() {
+            return;
+        }
+
+        let mut rows = stream.into_row_stream();
+        let mut chunk: Vec<Vec<QueryValue>> = Vec::with_capacity(STREAM_CHUNK_ROWS);
+        while let Some(item) = rows.next().await {
+            match item {
+                Ok(row) => {
+                    chunk.push(row_to_query_values(row));
+                    if chunk.len() >= STREAM_CHUNK_ROWS {
+                        let full =
+                            std::mem::replace(&mut chunk, Vec::with_capacity(STREAM_CHUNK_ROWS));
+                        if chunk_tx.send(Ok(full)).await.is_err() {
+                            return;
+                        }
+                    }
+                }
+                Err(e) => {
+                    let _ = chunk_tx.send(Err(DriverError::QueryFailed(e.to_string()))).await;
+                    return;
+                }
+            }
+        }
+        if !chunk.is_empty() {
+            let _ = chunk_tx.send(Ok(chunk)).await;
+        }
+    });
+
+    let columns = col_rx
+        .await
+        .map_err(|_| DriverError::QueryFailed("MSSQL stream task ended before sending columns".into()))??;
+    let chunks = futures::stream::unfold(chunk_rx, |mut rx| async move {
+        rx.recv().await.map(|item| (item, rx))
+    })
+    .boxed();
+    Ok(RowChunkStream { columns, chunks })
 }

--- a/crates/arris-engines/tests/mssql_integration.rs
+++ b/crates/arris-engines/tests/mssql_integration.rs
@@ -1322,3 +1322,181 @@ async fn slim_diff_keyless_and_keyed() {
     dbt_diff_scenario::assert_keyless(driver.as_ref(), DiffDialect::MsSql, prod, new_select).await;
     dbt_diff_scenario::assert_keyed(driver.as_ref(), DiffDialect::MsSql, prod, new_select).await;
 }
+
+// ── streaming ingestion ───────────────────────────────────────────────────────
+
+mod streaming_scenario;
+
+use arris_engines::{
+    CanvasEngine, CanvasError, CELL_INGEST_BYTE_BUDGET, CELL_RESULT_PAGE_ROWS, QueryEngine,
+};
+use streaming_scenario::BOARD;
+use tokio_util::sync::CancellationToken;
+
+fn stream_canvas_engine() -> CanvasEngine {
+    streaming_scenario::canvas_engine("mssql")
+}
+
+/// Boot a container and connect straight to `master` (no `USE appdb`). Streaming
+/// opens a fresh connection from the stored config, so keeping the pinned client
+/// and the ephemeral stream connection in the same database lets both see `src`.
+async fn start_mssql_stream() -> (ContainerAsync<MssqlServer>, Box<dyn DatabaseDriver>) {
+    let container = MssqlServer::default()
+        .with_accept_eula()
+        .with_sa_password(SA_PASSWORD)
+        .with_tag("2022-latest")
+        .start()
+        .await
+        .expect("start mssql container");
+    let host = container.get_host().await.expect("container host").to_string();
+    let port = container
+        .get_host_port_ipv4(1433)
+        .await
+        .expect("container port");
+
+    let mut cfg = ConnectionConfig::new("it-mssql-stream", DatabaseKind::Mssql);
+    cfg.host = host;
+    cfg.port = port;
+    cfg.user = "sa".to_string();
+    cfg.password = SA_PASSWORD.to_string();
+    cfg.database = "master".to_string();
+    cfg.ssl_mode = arris_engines::SslMode::Required;
+
+    let driver = driver_for_kind(DatabaseKind::Mssql).expect("mssql driver");
+    driver.connect(&cfg).await.expect("connect to mssql");
+    (container, driver)
+}
+
+/// Create `src` and fill it with `count` rows `{n, label}` via a set-based tally
+/// insert (fast; no per-row round trips).
+async fn seed_stream_src(driver: &dyn DatabaseDriver, count: i64) {
+    run(driver, "CREATE TABLE src (n INT PRIMARY KEY, label NVARCHAR(50))").await;
+    let sql = format!(
+        "INSERT INTO src (n, label) \
+         SELECT rn, CONCAT(N'row-', rn) \
+         FROM (SELECT TOP ({count}) ROW_NUMBER() OVER (ORDER BY (SELECT NULL)) AS rn \
+               FROM sys.all_objects a CROSS JOIN sys.all_objects b) AS t"
+    );
+    run(driver, &sql).await;
+}
+
+#[tokio::test]
+async fn streaming_ingests_100k_rows_with_exact_totals_and_page() {
+    let (_c, driver) = start_mssql_stream().await;
+    seed_stream_src(driver.as_ref(), 100_000).await;
+    let engine = stream_canvas_engine();
+
+    let stream = driver
+        .run_query_stream("SELECT n, label FROM src ORDER BY n", &[], QueryLanguage::Sql)
+        .await
+        .expect("open stream");
+    let out = engine
+        .ingest_cell_stream(BOARD, "big", stream, None, CELL_INGEST_BYTE_BUDGET, None)
+        .await
+        .expect("ingest stream");
+
+    assert_eq!(out.total_rows, 100_000);
+    assert!(out.complete);
+    assert_eq!(out.result.rows.len(), CELL_RESULT_PAGE_ROWS);
+    let names: Vec<&str> = out.result.columns.iter().map(|c| c.name.as_str()).collect();
+    assert_eq!(names, vec!["n", "label"]);
+    assert_eq!(out.result.rows[0][0], QueryValue::Int(1));
+    assert_eq!(out.result.rows[0][1], QueryValue::Text("row-1".into()));
+    assert_eq!(out.result.rows[499][0], QueryValue::Int(500));
+
+    // A chained cell aggregates the FULL cached result, not the 500-row page.
+    let agg = engine
+        .run_cell(BOARD, "sums", "SELECT COUNT(*) AS c, SUM(n) AS s FROM big")
+        .await
+        .expect("chained aggregate");
+    assert_eq!(agg.result.rows[0][0], QueryValue::Int(100_000));
+    assert_eq!(agg.result.rows[0][1], QueryValue::Int(5_000_050_000));
+}
+
+#[tokio::test]
+async fn streaming_cancel_registers_no_cache_entry() {
+    let (_c, driver) = start_mssql_stream().await;
+    seed_stream_src(driver.as_ref(), 5_000).await;
+    let engine = stream_canvas_engine();
+
+    let stream = driver
+        .run_query_stream("SELECT n FROM src", &[], QueryLanguage::Sql)
+        .await
+        .expect("open stream");
+
+    // A pre-cancelled token exercises the abort path deterministically.
+    let token = CancellationToken::new();
+    token.cancel();
+
+    let err = engine
+        .ingest_cell_stream(BOARD, "huge", stream, Some(&token), CELL_INGEST_BYTE_BUDGET, None)
+        .await
+        .expect_err("cancel must fail the ingest");
+    assert!(matches!(err, CanvasError::Cancelled), "got {err:?}");
+
+    // The aborted cell was never registered, so downstream cannot read it.
+    let chained = engine.run_cell(BOARD, "agg", "SELECT COUNT(*) FROM huge").await;
+    assert!(chained.is_err(), "cancelled cell must not be queryable");
+
+    // The pinned client is healthy after the aborted stream's connection drops.
+    let healthy = run(driver.as_ref(), "SELECT COUNT(*) AS c FROM src").await;
+    assert_eq!(healthy.rows[0][0], QueryValue::Int(5_000));
+}
+
+#[tokio::test]
+async fn streaming_byte_budget_truncates_and_reports_incomplete() {
+    let (_c, driver) = start_mssql_stream().await;
+    seed_stream_src(driver.as_ref(), 100_000).await;
+    let engine = stream_canvas_engine();
+
+    let stream = driver
+        .run_query_stream("SELECT n, label FROM src ORDER BY n", &[], QueryLanguage::Sql)
+        .await
+        .expect("open stream");
+    // A ~1 MiB budget admits a few chunks, then stops.
+    let out = engine
+        .ingest_cell_stream(BOARD, "capped", stream, None, 1 << 20, None)
+        .await
+        .expect("ingest stream");
+
+    assert!(!out.complete, "budget stop must be surfaced, never silent");
+    assert!(out.total_rows >= CELL_RESULT_PAGE_ROWS as u64);
+    assert!(out.total_rows < 100_000, "budget must truncate the run");
+    assert_eq!(out.result.rows.len(), CELL_RESULT_PAGE_ROWS);
+
+    let agg = engine
+        .run_cell(BOARD, "agg", "SELECT COUNT(*) AS c FROM capped")
+        .await
+        .expect("chained count");
+    assert_eq!(agg.result.rows[0][0], QueryValue::Int(out.total_rows as i64));
+}
+
+#[tokio::test]
+async fn streaming_cell_limit_caps_to_500() {
+    let (_c, driver) = start_mssql_stream().await;
+    seed_stream_src(driver.as_ref(), 10_000).await;
+    let engine = stream_canvas_engine();
+
+    // SQL Server is a wrappable dialect, so the per-cell limit rewrites the query
+    // (the DB does top-N via OFFSET/FETCH) and leaves no ingest-side row cap.
+    let (sql, row_cap) = QueryEngine::apply_cell_limit(
+        "SELECT n FROM src",
+        &driver.pagination_strategy(),
+        Some(500),
+    );
+    assert!(sql.contains("FETCH NEXT 500 ROWS ONLY"), "got {sql}");
+    assert_eq!(row_cap, None);
+
+    let stream = driver
+        .run_query_stream(&sql, &[], QueryLanguage::Sql)
+        .await
+        .expect("open stream");
+    let out = engine
+        .ingest_cell_stream(BOARD, "lim", stream, None, 1 << 30, row_cap)
+        .await
+        .expect("ingest stream");
+
+    assert_eq!(out.total_rows, 500);
+    assert!(out.complete, "a top-N result is complete");
+    assert_eq!(out.result.rows.len(), 500);
+}

--- a/fixtures/initdb/mssql.sql
+++ b/fixtures/initdb/mssql.sql
@@ -360,3 +360,50 @@ GO
 IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = N'ix_invoices_paid_issued_at' AND object_id = OBJECT_ID(N'sales.invoices'))
     CREATE INDEX ix_invoices_paid_issued_at ON sales.invoices (paid, issued_at);
 GO
+
+-- =================================================================
+-- Large table (10M rows) for exercising streaming-chunk ingestion
+-- against the local container. Seeded in 1M-row batches so the
+-- transaction log stays bounded during load.
+-- =================================================================
+
+IF OBJECT_ID(N'dbo.events_10m', N'U') IS NULL
+BEGIN
+    CREATE TABLE dbo.events_10m (
+        id         BIGINT PRIMARY KEY,
+        user_id    INT NOT NULL,
+        event_type NVARCHAR(20) NOT NULL,
+        device     NVARCHAR(20) NOT NULL,
+        country    CHAR(2) NOT NULL,
+        event_time DATETIME2(0) NOT NULL,
+        amount     DECIMAL(10,2) NOT NULL
+    );
+END;
+GO
+
+IF NOT EXISTS (SELECT 1 FROM dbo.events_10m)
+BEGIN
+    SET NOCOUNT ON;
+    DECLARE @batch INT = 1000000;
+    DECLARE @start BIGINT = 1;
+    DECLARE @total BIGINT = 10000000;
+    WHILE @start <= @total
+    BEGIN
+        INSERT INTO dbo.events_10m (id, user_id, event_type, device, country, event_time, amount)
+        SELECT
+            rn,
+            (rn % 100000) + 1,
+            CHOOSE((rn % 5) + 1, N'view', N'click', N'purchase', N'signup', N'logout'),
+            CHOOSE((rn % 3) + 1, N'ios', N'android', N'web'),
+            CHOOSE((rn % 4) + 1, 'US', 'GB', 'CA', 'DE'),
+            DATEADD(SECOND, rn % 31536000, '2025-01-01T00:00:00'),
+            CAST((rn % 10000) AS DECIMAL(10,2)) / 100
+        FROM (
+            SELECT TOP (@batch)
+                ROW_NUMBER() OVER (ORDER BY (SELECT NULL)) + @start - 1 AS rn
+            FROM sys.all_objects a CROSS JOIN sys.all_objects b
+        ) AS t;
+        SET @start = @start + @batch;
+    END;
+END;
+GO


### PR DESCRIPTION
## What does this PR do?

Extends chunked streaming ingestion to SQL Server. `tiberius` has no server-push stream, so streaming pulls rows off a live TDS connection.

Changes:
- `run_query_stream`: opens a fresh ephemeral tiberius connection (leaving the pinned client free), then a spawned task runs the query and chunks rows onto a bounded, backpressured channel via `RowChunkStream`. Dropping the receiver drops the task and its socket (cancel-safe). Non-SELECTs and open manual transactions keep the materialized path.
- Columns delivered up front over a oneshot: `tiberius` can only learn result columns by executing, so the task reads the leading metadata, sends the `ColumnSpec`s, then streams rows. The ephemeral connection inherits the pinned client's database from the stored config, so both see the same tables.
- Fixture: 10M-row `dbo.events_10m` table in `fixtures/initdb/mssql.sql`, seeded in 1M-row batches so the transaction log stays bounded during load.

## Checklist

- [ ] I opened an issue first for non-trivial changes, or this is a small fix.
- [x] Tests added/updated for my change.
- [x] **I license my contribution under the MIT License**, per [CONTRIBUTING.md](../CONTRIBUTING.md). I confirm this is my original work, or that I have the right to submit it.
