### PR TITLE
[Feature] Streaming ingestion for Bigquery

### DIFF
--- a/crates/arris-engines/src/drivers/bigquery/constants.rs
+++ b/crates/arris-engines/src/drivers/bigquery/constants.rs
@@ -1,0 +1,8 @@
+//! Constants for the BigQuery driver.
+
+/// Rows fetched per `getQueryResults` page while streaming a SELECT. BigQuery
+/// also caps each page at ~10 MB, so a large page still yields at that ceiling.
+pub(super) const BQ_STREAM_PAGE_ROWS: i32 = 10_000;
+
+/// Poll interval while a submitted job is not yet complete (`jobComplete=false`).
+pub(super) const BQ_JOB_POLL_INTERVAL_MS: u64 = 200;

--- a/crates/arris-engines/src/drivers/bigquery/driver.rs
+++ b/crates/arris-engines/src/drivers/bigquery/driver.rs
@@ -13,8 +13,8 @@ use crate::drivers::sql_builder::SqlBuilder;
 use crate::drivers::DatabaseDriver;
 use crate::{
     ConnectionConfig, DatabaseKind, DriverError, ExplainMode, MutationResult, PlanNode,
-    PlanResult, QueryLanguage, QueryResult, QueryValue, RowDelete, RowInsert, SchemaNode,
-    TableRef, ValueMap,
+    PlanResult, QueryLanguage, QueryResult, QueryStream, QueryValue, RowDelete, RowInsert,
+    SchemaNode, TableRef, ValueMap,
 };
 
 struct ConnState {
@@ -283,6 +283,29 @@ impl DatabaseDriver for BigqueryDriver {
             elapsed: started.elapsed().as_secs_f64(),
             ..Default::default()
         })
+    }
+
+    async fn run_query_stream(
+        &self,
+        text: &str,
+        params: &[QueryValue],
+        language: QueryLanguage,
+    ) -> Result<QueryStream> {
+        // Only SELECT result sets page; DML/DDL is single-shot with an
+        // affected-rows count, so it stays on the materialized path.
+        if !self.looks_like_select(text) {
+            return Ok(QueryStream::from_materialized(
+                self.run_query(text, params, language).await?,
+            ));
+        }
+        let (client, project, location) = {
+            let guard = self.inner.lock().await;
+            let state = guard.as_ref().ok_or(DriverError::NotConnected)?;
+            (state.client.clone(), state.project_id.clone(), state.location.clone())
+        };
+        Ok(QueryStream::Rows(
+            query::stream_query(client, project, location, text.to_owned()).await?,
+        ))
     }
 
     async fn object_definition(&self, object: &crate::ObjectRef) -> Result<String> {

--- a/crates/arris-engines/src/drivers/bigquery/mod.rs
+++ b/crates/arris-engines/src/drivers/bigquery/mod.rs
@@ -1,3 +1,4 @@
+mod constants;
 mod definition;
 mod driver;
 mod query;

--- a/crates/arris-engines/src/drivers/bigquery/query.rs
+++ b/crates/arris-engines/src/drivers/bigquery/query.rs
@@ -1,6 +1,18 @@
-use gcp_bigquery_client::model::query_response::QueryResponse;
+use std::collections::VecDeque;
+use std::sync::Arc;
 
-use crate::{ColumnSpec, QueryValue};
+use futures::stream::{self, Stream};
+use gcp_bigquery_client::Client;
+use gcp_bigquery_client::model::get_query_results_parameters::GetQueryResultsParameters;
+use gcp_bigquery_client::model::query_response::QueryResponse;
+use gcp_bigquery_client::model::table_cell::TableCell;
+use gcp_bigquery_client::model::table_row::TableRow;
+
+use super::constants::{BQ_JOB_POLL_INTERVAL_MS, BQ_STREAM_PAGE_ROWS};
+use super::driver::build_query_request;
+use crate::drivers::common::RowChunkPump;
+use crate::drivers::errors::{DriverError, Result};
+use crate::{ColumnSpec, QueryValue, RowChunkStream};
 
 fn field_type_str(ft: &gcp_bigquery_client::model::field_type::FieldType) -> &'static str {
     use gcp_bigquery_client::model::field_type::FieldType;
@@ -36,6 +48,32 @@ pub(super) fn columns_from_response(resp: &QueryResponse) -> Vec<ColumnSpec> {
         .collect()
 }
 
+fn cell_to_value(cell: &TableCell) -> QueryValue {
+    match &cell.value {
+        Some(serde_json::Value::Null) | None => QueryValue::Null,
+        Some(serde_json::Value::Bool(b)) => QueryValue::Bool(*b),
+        Some(serde_json::Value::Number(n)) => {
+            if let Some(i) = n.as_i64() {
+                QueryValue::Int(i)
+            } else if let Some(f) = n.as_f64() {
+                QueryValue::Double(f)
+            } else {
+                QueryValue::Text(n.to_string())
+            }
+        }
+        Some(serde_json::Value::String(s)) => QueryValue::Text(s.clone()).coerce_text(),
+        Some(other) => QueryValue::Json(other.to_string()),
+    }
+}
+
+/// Converts one `TableRow` to cells; a row with no columns becomes all-null.
+pub(super) fn row_to_values(row: &TableRow, col_count: usize) -> Vec<QueryValue> {
+    match &row.columns {
+        Some(cells) => cells.iter().map(cell_to_value).collect(),
+        None => vec![QueryValue::Null; col_count],
+    }
+}
+
 pub(super) fn rows_from_response(
     resp: &QueryResponse,
     col_count: usize,
@@ -43,34 +81,121 @@ pub(super) fn rows_from_response(
     let Some(raw_rows) = &resp.rows else {
         return Vec::new();
     };
-    raw_rows
-        .iter()
-        .map(|row| {
-            let Some(cells) = &row.columns else {
-                return vec![QueryValue::Null; col_count];
-            };
-            cells
-                .iter()
-                .map(|cell| match &cell.value {
-                    Some(serde_json::Value::Null) | None => QueryValue::Null,
-                    Some(serde_json::Value::Bool(b)) => QueryValue::Bool(*b),
-                    Some(serde_json::Value::Number(n)) => {
-                        if let Some(i) = n.as_i64() {
-                            QueryValue::Int(i)
-                        } else if let Some(f) = n.as_f64() {
-                            QueryValue::Double(f)
-                        } else {
-                            QueryValue::Text(n.to_string())
+    raw_rows.iter().map(|row| row_to_values(row, col_count)).collect()
+}
+
+// ── streaming ─────────────────────────────────────────────────────────────
+
+/// What the page iterator does next given its buffer/job state. Split out as a
+/// pure decision so the termination edges are unit-testable without HTTP.
+#[derive(Debug, PartialEq, Eq)]
+enum PageStep {
+    Yield,
+    Fetch,
+    Done,
+}
+
+fn page_step(buf_empty: bool, complete: bool, has_token: bool) -> PageStep {
+    if !buf_empty {
+        PageStep::Yield
+    } else if complete && !has_token {
+        PageStep::Done
+    } else {
+        PageStep::Fetch
+    }
+}
+
+/// Paging state carried across the row stream's `unfold` steps.
+struct PageIter {
+    client: Arc<Client>,
+    project: String,
+    job_id: String,
+    location: Option<String>,
+    next_token: Option<String>,
+    complete: bool,
+    buf: VecDeque<TableRow>,
+}
+
+fn row_stream(state: PageIter) -> impl Stream<Item = Result<TableRow>> {
+    stream::unfold(state, |mut s| async move {
+        loop {
+            match page_step(s.buf.is_empty(), s.complete, s.next_token.is_some()) {
+                PageStep::Yield => return s.buf.pop_front().map(|row| (Ok(row), s)),
+                PageStep::Done => return None,
+                PageStep::Fetch => {
+                    let params = GetQueryResultsParameters {
+                        page_token: s.next_token.clone(),
+                        max_results: Some(BQ_STREAM_PAGE_ROWS),
+                        location: s.location.clone(),
+                        ..Default::default()
+                    };
+                    match s.client.job().get_query_results(&s.project, &s.job_id, params).await {
+                        Ok(qr) => {
+                            // A submitted job may not be ready yet; poll with the
+                            // same token until it completes.
+                            if !qr.job_complete.unwrap_or(false) {
+                                tokio::time::sleep(std::time::Duration::from_millis(
+                                    BQ_JOB_POLL_INTERVAL_MS,
+                                ))
+                                .await;
+                                continue;
+                            }
+                            s.complete = true;
+                            s.buf.extend(qr.rows.unwrap_or_default());
+                            s.next_token = qr.page_token;
+                        }
+                        Err(e) => {
+                            s.complete = true;
+                            s.next_token = None;
+                            return Some((Err(DriverError::QueryFailed(e.to_string())), s));
                         }
                     }
-                    Some(serde_json::Value::String(s)) => {
-                        QueryValue::Text(s.clone()).coerce_text()
-                    }
-                    Some(other) => QueryValue::Json(other.to_string()),
-                })
-                .collect()
-        })
-        .collect()
+                }
+            }
+        }
+    })
+}
+
+/// Streams a SELECT: one `jobs.query` for the schema and first page, then pages
+/// the rest through `getQueryResults`. Columns come from the first response, so
+/// the shared `RowChunkPump` rechunks the paged rows. `run_query` returns only
+/// the first page, so streaming is what makes large results whole.
+pub(super) async fn stream_query(
+    client: Arc<Client>,
+    project: String,
+    location: Option<String>,
+    text: String,
+) -> Result<RowChunkStream> {
+    let mut req = build_query_request(&text, location.as_deref());
+    req.max_results = Some(BQ_STREAM_PAGE_ROWS);
+    let resp = client
+        .job()
+        .query(&project, req)
+        .await
+        .map_err(|e| DriverError::QueryFailed(e.to_string()))?;
+
+    let columns = columns_from_response(&resp);
+    let col_count = columns.len();
+    let job_id = resp
+        .job_reference
+        .and_then(|r| r.job_id)
+        .ok_or_else(|| DriverError::QueryFailed("BigQuery response carried no job id".into()))?;
+
+    let state = PageIter {
+        client,
+        project,
+        job_id,
+        location,
+        next_token: resp.page_token,
+        complete: resp.job_complete.unwrap_or(false),
+        buf: resp.rows.unwrap_or_default().into(),
+    };
+
+    Ok(RowChunkPump::spawn(
+        columns,
+        move || async move { Ok(row_stream(state)) },
+        move |row: TableRow| row_to_values(&row, col_count),
+    ))
 }
 
 #[cfg(test)]
@@ -155,5 +280,46 @@ mod tests {
         let resp = QueryResponse::default();
         assert!(columns_from_response(&resp).is_empty());
         assert!(rows_from_response(&resp, 0).is_empty());
+    }
+
+    #[test]
+    fn row_to_values_missing_columns_are_all_null() {
+        let row = TableRow { columns: None };
+        assert_eq!(row_to_values(&row, 3), vec![QueryValue::Null; 3]);
+    }
+
+    #[test]
+    fn row_to_values_converts_each_cell() {
+        let row = TableRow {
+            columns: Some(vec![
+                TableCell { value: Some(serde_json::Value::String("7".into())) },
+                TableCell { value: None },
+                TableCell { value: Some(serde_json::Value::Bool(true)) },
+            ]),
+        };
+        assert_eq!(
+            row_to_values(&row, 3),
+            vec![QueryValue::Int(7), QueryValue::Null, QueryValue::Bool(true)]
+        );
+    }
+
+    #[test]
+    fn page_step_yields_while_buffer_has_rows() {
+        // A non-empty buffer always drains first, regardless of job state.
+        assert_eq!(page_step(false, true, true), PageStep::Yield);
+        assert_eq!(page_step(false, false, false), PageStep::Yield);
+    }
+
+    #[test]
+    fn page_step_done_only_when_complete_and_no_token() {
+        assert_eq!(page_step(true, true, false), PageStep::Done);
+    }
+
+    #[test]
+    fn page_step_fetches_for_more_pages_or_incomplete_job() {
+        // Complete with a token → next page. Incomplete with no token → poll.
+        assert_eq!(page_step(true, true, true), PageStep::Fetch);
+        assert_eq!(page_step(true, false, false), PageStep::Fetch);
+        assert_eq!(page_step(true, false, true), PageStep::Fetch);
     }
 }


### PR DESCRIPTION
## What does this PR do?

Streams `SELECT` results through BigQuery's `getQueryResults` pagination. Also fixes a latent bug: the old path returned only the first `jobs.query` page and silently truncated large results.

Changes:
- `run_query_stream`: one `jobs.query` fetches the schema and first page, then the rest page through `getQueryResults` (polling while the job reports `jobComplete=false`), rechunked through the shared `RowChunkPump`. Non-SELECT DML/DDL keeps the materialized path.
- `run_query` only ever read page 1, so results larger than one page were dropped without warning; streaming returns them whole.
- The BigQuery client is stateless HTTP (`Arc<Client>`), so streaming just clones the handle; columns come from the first response, so there is no schema pre-scan.

## Checklist

- [ ] I opened an issue first for non-trivial changes, or this is a small fix.
- [x] Tests added/updated for my change.
- [x] **I license my contribution under the MIT License**, per [CONTRIBUTING.md](../CONTRIBUTING.md). I confirm this is my original work, or that I have the right to submit it.
