### PR TITLE
[Feature] Streaming ingestion for Kafka

### DIFF
--- a/crates/arris-engines/src/drivers/kafka/constants.rs
+++ b/crates/arris-engines/src/drivers/kafka/constants.rs
@@ -18,6 +18,11 @@ pub(super) const POLL_INTERVAL: Duration = Duration::from_millis(1000);
 /// Consecutive empty polls (after at least one row) that mean the topic is drained.
 pub(super) const EMPTY_POLLS_BEFORE_STOP: u32 = 2;
 
+/// Idle-poll backstop for the watermark-terminated stream: stop after this many
+/// empty polls even if a partition never reaches its high watermark (offset gaps
+/// from log compaction/retention would otherwise loop forever).
+pub(super) const WATERMARK_IDLE_POLLS_BEFORE_STOP: u32 = 5;
+
 /// Bound on the row hand-off channel from the blocking poll task to the async
 /// chunker, so a slow consumer backpressures the poll loop instead of buffering
 /// the whole topic in memory.

--- a/crates/arris-engines/src/drivers/kafka/constants.rs
+++ b/crates/arris-engines/src/drivers/kafka/constants.rs
@@ -1,0 +1,24 @@
+//! Constants for the Kafka driver.
+
+use std::time::Duration;
+
+/// Row cap for the buffered path (`GROUP BY` / `ORDER BY`), which must hold the
+/// whole result in memory to aggregate or sort. The streaming path is uncapped.
+pub(super) const MAX_ROWS: usize = 10_000;
+
+/// Overall budget for draining a topic before giving up waiting for more.
+pub(super) const CONSUME_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Timeout for metadata / group-list fetches.
+pub(super) const METADATA_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Longest single `poll` wait; keeps the deadline check responsive.
+pub(super) const POLL_INTERVAL: Duration = Duration::from_millis(1000);
+
+/// Consecutive empty polls (after at least one row) that mean the topic is drained.
+pub(super) const EMPTY_POLLS_BEFORE_STOP: u32 = 2;
+
+/// Bound on the row hand-off channel from the blocking poll task to the async
+/// chunker, so a slow consumer backpressures the poll loop instead of buffering
+/// the whole topic in memory.
+pub(super) const STREAM_ROW_CHANNEL_CAPACITY: usize = 8_192;

--- a/crates/arris-engines/src/drivers/kafka/mod.rs
+++ b/crates/arris-engines/src/drivers/kafka/mod.rs
@@ -1,14 +1,13 @@
+mod constants;
 mod query;
 pub mod schema_registry;
 pub mod sql_parser;
 
-use std::time::Duration;
-
 use async_trait::async_trait;
 use crate::{
     ConnectionConfig, DriverError, ExplainMode, MutationResult, PlanResult,
-    QueryLanguage, QueryResult, QueryValue, RowDelete, RowInsert, SchemaNode,
-    SchemaNodeKind, TableRef,
+    QueryLanguage, QueryResult, QueryStream, QueryValue, RowDelete, RowInsert,
+    SchemaNode, SchemaNodeKind, TableRef,
 };
 use crate::drivers::errors::Result;
 use rdkafka::admin::AdminClient;
@@ -18,12 +17,9 @@ use rdkafka::ClientConfig;
 use tokio::sync::Mutex;
 
 use crate::drivers::DatabaseDriver;
+use constants::METADATA_TIMEOUT;
 use schema_registry::SchemaRegistryClient;
 use sql_parser::parse_kafka_sql;
-
-const MAX_ROWS: usize = 10_000;
-const CONSUME_TIMEOUT: Duration = Duration::from_secs(30);
-const METADATA_TIMEOUT: Duration = Duration::from_secs(10);
 
 pub struct KafkaDriver {
     inner: Mutex<Option<KafkaState>>,
@@ -234,6 +230,32 @@ impl DatabaseDriver for KafkaDriver {
             elapsed: start.elapsed().as_secs_f64(),
             ..Default::default()
         })
+    }
+
+    async fn run_query_stream(
+        &self,
+        text: &str,
+        params: &[QueryValue],
+        language: QueryLanguage,
+    ) -> Result<QueryStream> {
+        let parsed = parse_kafka_sql(text).map_err(|e| DriverError::QueryFailed(e.to_string()))?;
+
+        // GROUP BY / ORDER BY buffer the whole result to aggregate or sort, so
+        // they stay on the materialized path; plain projections stream.
+        if !query::is_streamable(&parsed) {
+            return Ok(QueryStream::from_materialized(
+                self.run_query(text, params, language).await?,
+            ));
+        }
+
+        let (cc, registry) = {
+            let guard = self.inner.lock().await;
+            let state = guard.as_ref().ok_or(DriverError::NotConnected)?;
+            (state.client_config.clone(), state.schema_registry.clone())
+        };
+        Ok(QueryStream::Rows(
+            query::stream_query(cc, parsed, registry).await?,
+        ))
     }
 
     async fn supports_explain(&self, _mode: ExplainMode) -> bool {

--- a/crates/arris-engines/src/drivers/kafka/query.rs
+++ b/crates/arris-engines/src/drivers/kafka/query.rs
@@ -1,19 +1,29 @@
-use std::time::Duration;
-
-use crate::{ColumnSpec, DriverError, QueryValue};
-use crate::drivers::errors::Result;
+use futures::stream::{self, StreamExt};
 use rdkafka::consumer::{BaseConsumer, Consumer};
-use rdkafka::message::Message;
+use rdkafka::message::{BorrowedMessage, Message};
 use rdkafka::ClientConfig;
+use tokio::sync::mpsc;
 
-use super::schema_registry::columns_from_json_sample;
-use super::sql_parser::{AggFunc, ColumnExpr, KafkaQuery, SelectClause};
-use super::{KafkaState, CONSUME_TIMEOUT, MAX_ROWS};
+use crate::drivers::common::RowChunkPump;
+use crate::drivers::constants::STREAM_CHUNK_ROWS;
+use crate::drivers::errors::Result;
+use crate::{ColumnSpec, DriverError, QueryValue, RowChunkStream};
 
-pub(super) fn consume_topic_fresh(
-    cc: &ClientConfig,
-    query: &KafkaQuery,
-) -> Result<Vec<serde_json::Value>> {
+use super::constants::{
+    CONSUME_TIMEOUT, EMPTY_POLLS_BEFORE_STOP, MAX_ROWS, METADATA_TIMEOUT, POLL_INTERVAL,
+    STREAM_ROW_CHANNEL_CAPACITY,
+};
+use super::schema_registry::{columns_from_rows, SchemaRegistryClient};
+use super::sql_parser::{
+    eval_condition, AggFunc, ColumnExpr, KafkaQuery, SelectClause, SelectColumn,
+};
+use super::KafkaState;
+
+// ── shared consume helpers ──────────────────────────────────────────────────
+
+/// Create a fresh consumer and assign every partition of the query's topic at
+/// the requested start offset. Shared by the buffered and streaming paths.
+fn build_assigned_consumer(cc: &ClientConfig, query: &KafkaQuery) -> Result<BaseConsumer> {
     use rdkafka::TopicPartitionList;
 
     let consumer: BaseConsumer = cc
@@ -21,14 +31,13 @@ pub(super) fn consume_topic_fresh(
         .map_err(|e| DriverError::QueryFailed(format!("Failed to create consumer: {e}")))?;
 
     let metadata = consumer
-        .fetch_metadata(Some(&query.topic), super::METADATA_TIMEOUT)
+        .fetch_metadata(Some(&query.topic), METADATA_TIMEOUT)
         .map_err(|e| DriverError::QueryFailed(e.to_string()))?;
 
     let topic_meta = metadata
         .topics()
         .first()
         .ok_or_else(|| DriverError::QueryFailed(format!("Topic '{}' not found", query.topic)))?;
-
     if topic_meta.partitions().is_empty() {
         return Err(DriverError::QueryFailed(format!(
             "Topic '{}' has no partitions",
@@ -39,19 +48,78 @@ pub(super) fn consume_topic_fresh(
     let partition_ids: Vec<i32> = topic_meta.partitions().iter().map(|p| p.id()).collect();
     drop(metadata);
 
+    let offset = if query.from_latest {
+        rdkafka::Offset::End
+    } else {
+        rdkafka::Offset::Beginning
+    };
     let mut tpl = TopicPartitionList::new();
     for pid in &partition_ids {
-        let offset = if query.from_latest {
-            rdkafka::Offset::End
-        } else {
-            rdkafka::Offset::Beginning
-        };
         tpl.add_partition_offset(&query.topic, *pid, offset)
             .map_err(|e| DriverError::QueryFailed(e.to_string()))?;
     }
     consumer
         .assign(&tpl)
         .map_err(|e| DriverError::QueryFailed(e.to_string()))?;
+    Ok(consumer)
+}
+
+/// Decode a message payload to a JSON row, injecting the `_partition`/`_offset`/
+/// `_timestamp` metadata fields. Non-object or non-JSON payloads become `value`.
+pub(super) fn build_row(
+    payload: &[u8],
+    partition: i32,
+    offset: i64,
+    timestamp_ms: Option<i64>,
+) -> serde_json::Value {
+    let json_val: serde_json::Value = serde_json::from_slice(payload).unwrap_or_else(|_| {
+        serde_json::json!({ "value": String::from_utf8_lossy(payload).to_string() })
+    });
+    match json_val {
+        serde_json::Value::Object(mut map) => {
+            map.insert("_partition".to_string(), serde_json::json!(partition));
+            map.insert("_offset".to_string(), serde_json::json!(offset));
+            if let Some(ts) = timestamp_ms {
+                map.insert("_timestamp".to_string(), serde_json::json!(ts));
+            }
+            serde_json::Value::Object(map)
+        }
+        other => serde_json::json!({
+            "value": other,
+            "_partition": partition,
+            "_offset": offset,
+        }),
+    }
+}
+
+fn message_to_row(msg: &BorrowedMessage) -> Option<serde_json::Value> {
+    let payload = msg.payload()?;
+    Some(build_row(
+        payload,
+        msg.partition(),
+        msg.offset(),
+        msg.timestamp().to_millis(),
+    ))
+}
+
+fn passes_filter(row: &serde_json::Value, query: &KafkaQuery) -> bool {
+    query
+        .where_conditions
+        .iter()
+        .all(|cond| eval_condition(row, cond))
+}
+
+/// A query streams when it needs no whole-result buffering: no `GROUP BY`
+/// (aggregate) and no `ORDER BY` (sort). Those take the materialized path.
+pub(super) fn is_streamable(query: &KafkaQuery) -> bool {
+    query.group_by.is_empty() && query.order_by.is_empty()
+}
+
+pub(super) fn consume_topic_fresh(
+    cc: &ClientConfig,
+    query: &KafkaQuery,
+) -> Result<Vec<serde_json::Value>> {
+    let consumer = build_assigned_consumer(cc, query)?;
 
     let max_rows = query.limit.unwrap_or(MAX_ROWS).min(MAX_ROWS);
     let mut rows = Vec::with_capacity(max_rows);
@@ -61,48 +129,14 @@ pub(super) fn consume_topic_fresh(
     while rows.len() < max_rows && std::time::Instant::now() < deadline {
         let poll_timeout = deadline
             .saturating_duration_since(std::time::Instant::now())
-            .min(Duration::from_millis(1000));
+            .min(POLL_INTERVAL);
         match consumer.poll(poll_timeout) {
             Some(Ok(msg)) => {
                 empty_polls = 0;
-                let payload = match msg.payload() {
-                    Some(bytes) => bytes,
-                    None => continue,
+                let Some(row) = message_to_row(&msg) else {
+                    continue;
                 };
-                let json_val: serde_json::Value = match serde_json::from_slice(payload) {
-                    Ok(v) => v,
-                    Err(_) => {
-                        serde_json::json!({
-                            "value": String::from_utf8_lossy(payload).to_string(),
-                            "_partition": msg.partition(),
-                            "_offset": msg.offset(),
-                        })
-                    }
-                };
-                let row = match json_val {
-                    serde_json::Value::Object(mut map) => {
-                        map.insert("_partition".to_string(), serde_json::json!(msg.partition()));
-                        map.insert("_offset".to_string(), serde_json::json!(msg.offset()));
-                        if let Some(ts) = msg.timestamp().to_millis() {
-                            map.insert("_timestamp".to_string(), serde_json::json!(ts));
-                        }
-                        serde_json::Value::Object(map)
-                    }
-                    other => {
-                        serde_json::json!({
-                            "value": other,
-                            "_partition": msg.partition(),
-                            "_offset": msg.offset(),
-                        })
-                    }
-                };
-
-                let passes_filter = query
-                    .where_conditions
-                    .iter()
-                    .all(|cond| super::sql_parser::eval_condition(&row, cond));
-
-                if passes_filter {
+                if passes_filter(&row, query) {
                     rows.push(row);
                 }
             }
@@ -112,7 +146,7 @@ pub(super) fn consume_topic_fresh(
             }
             None => {
                 empty_polls += 1;
-                if !rows.is_empty() && empty_polls >= 2 {
+                if !rows.is_empty() && empty_polls >= EMPTY_POLLS_BEFORE_STOP {
                     break;
                 }
             }
@@ -121,6 +155,184 @@ pub(super) fn consume_topic_fresh(
 
     Ok(rows)
 }
+
+// ── column inference ────────────────────────────────────────────────────────
+
+fn meta_columns() -> Vec<ColumnSpec> {
+    vec![
+        ColumnSpec { name: "_partition".into(), type_hint: "int".into() },
+        ColumnSpec { name: "_offset".into(), type_hint: "long".into() },
+        ColumnSpec { name: "_timestamp".into(), type_hint: "long".into() },
+    ]
+}
+
+pub(super) fn columns_for_select(cols: &[SelectColumn]) -> Vec<ColumnSpec> {
+    cols.iter()
+        .map(|sc| {
+            let name = sc.alias.clone().unwrap_or_else(|| match &sc.expr {
+                ColumnExpr::Name(n) => n.clone(),
+                ColumnExpr::Agg(func, col) => format!("{func:?}({col})").to_lowercase(),
+                ColumnExpr::CountAll => "count(*)".to_string(),
+            });
+            ColumnSpec { name, type_hint: "text".to_string() }
+        })
+        .collect()
+}
+
+/// Columns known before reading any data: an explicit column list, or a
+/// `SELECT *` backed by a schema-registry subject. Returns `None` when the shape
+/// must be sampled from the rows (`SELECT *` without a registry).
+async fn columns_upfront(
+    query: &KafkaQuery,
+    registry: Option<&SchemaRegistryClient>,
+) -> Option<Vec<ColumnSpec>> {
+    match &query.select {
+        SelectClause::Columns(cols) => Some(columns_for_select(cols)),
+        SelectClause::All => {
+            let sr = registry?;
+            let subject = format!("{}-value", query.topic);
+            let mut cols = sr.get_columns_for_subject(&subject).await.ok()?;
+            cols.extend(meta_columns());
+            Some(cols)
+        }
+    }
+}
+
+/// `SELECT *` fallback: infer columns from the sampled rows (their field union
+/// plus metadata), or a bare `value` column when the topic yielded nothing.
+fn columns_from_sample_rows(rows: &[serde_json::Value]) -> Vec<ColumnSpec> {
+    if rows.is_empty() {
+        let mut cols = vec![ColumnSpec { name: "value".into(), type_hint: "bytes".into() }];
+        cols.extend(meta_columns());
+        return cols;
+    }
+    let mut cols = columns_from_rows(rows);
+    for mc in meta_columns() {
+        if !cols.iter().any(|c| c.name == mc.name) {
+            cols.push(mc);
+        }
+    }
+    cols
+}
+
+async fn infer_columns(
+    rows: &[serde_json::Value],
+    query: &KafkaQuery,
+    state: &KafkaState,
+) -> Vec<ColumnSpec> {
+    if let Some(cols) = columns_upfront(query, state.schema_registry.as_ref()).await {
+        return cols;
+    }
+    columns_from_sample_rows(rows)
+}
+
+fn project_row(row: &serde_json::Value, columns: &[ColumnSpec]) -> Vec<QueryValue> {
+    columns
+        .iter()
+        .map(|col| json_to_query_value(row.get(&col.name)))
+        .collect()
+}
+
+// ── streaming ───────────────────────────────────────────────────────────────
+
+/// Blocking poll loop feeding parsed, filtered rows to the async chunker. No row
+/// cap (only the query's `LIMIT`); a bounded channel backpressures the consumer.
+fn stream_poll_blocking(
+    cc: ClientConfig,
+    query: KafkaQuery,
+    row_tx: mpsc::Sender<Result<serde_json::Value>>,
+) {
+    let consumer = match build_assigned_consumer(&cc, &query) {
+        Ok(c) => c,
+        Err(e) => {
+            let _ = row_tx.blocking_send(Err(e));
+            return;
+        }
+    };
+    let deadline = std::time::Instant::now() + CONSUME_TIMEOUT;
+    let mut empty_polls = 0u32;
+    let mut sent = 0usize;
+
+    loop {
+        if query.limit.is_some_and(|l| sent >= l) {
+            break;
+        }
+        let now = std::time::Instant::now();
+        if now >= deadline {
+            break;
+        }
+        let poll_timeout = deadline.saturating_duration_since(now).min(POLL_INTERVAL);
+        match consumer.poll(poll_timeout) {
+            Some(Ok(msg)) => {
+                empty_polls = 0;
+                let Some(row) = message_to_row(&msg) else {
+                    continue;
+                };
+                if !passes_filter(&row, &query) {
+                    continue;
+                }
+                if row_tx.blocking_send(Ok(row)).is_err() {
+                    return; // consumer dropped: cancel
+                }
+                sent += 1;
+            }
+            Some(Err(e)) => {
+                let _ = row_tx.blocking_send(Err(DriverError::QueryFailed(e.to_string())));
+                return;
+            }
+            None => {
+                empty_polls += 1;
+                if sent > 0 && empty_polls >= EMPTY_POLLS_BEFORE_STOP {
+                    break;
+                }
+            }
+        }
+    }
+}
+
+/// Stream a plain projection: resolve columns up front (registry / explicit) or
+/// sample the first chunk to fix them, then hand the rest to `RowChunkPump`.
+pub(super) async fn stream_query(
+    cc: ClientConfig,
+    query: KafkaQuery,
+    registry: Option<SchemaRegistryClient>,
+) -> Result<RowChunkStream> {
+    let upfront = columns_upfront(&query, registry.as_ref()).await;
+
+    let (row_tx, row_rx) = mpsc::channel::<Result<serde_json::Value>>(STREAM_ROW_CHANNEL_CAPACITY);
+    let poll_query = query.clone();
+    tokio::task::spawn_blocking(move || stream_poll_blocking(cc, poll_query, row_tx));
+
+    let mut rows = stream::unfold(row_rx, |mut rx| async move {
+        rx.recv().await.map(|item| (item, rx))
+    })
+    .boxed();
+
+    let (columns, first): (Vec<ColumnSpec>, Vec<serde_json::Value>) = match upfront {
+        Some(cols) => (cols, Vec::new()),
+        None => {
+            let mut buf = Vec::new();
+            while buf.len() < STREAM_CHUNK_ROWS {
+                match rows.next().await {
+                    Some(Ok(row)) => buf.push(row),
+                    Some(Err(e)) => return Err(e),
+                    None => break,
+                }
+            }
+            (columns_from_sample_rows(&buf), buf)
+        }
+    };
+
+    let map_cols = columns.clone();
+    let combined = stream::iter(first.into_iter().map(Ok::<_, DriverError>)).chain(rows);
+    Ok(RowChunkPump::spawn(
+        columns,
+        move || async move { Ok::<_, DriverError>(combined) },
+        move |row: serde_json::Value| project_row(&row, &map_cols),
+    ))
+}
+
+// ── projection / aggregation ────────────────────────────────────────────────
 
 pub(super) async fn project_rows(
     rows: &[serde_json::Value],
@@ -147,71 +359,10 @@ pub(super) async fn project_rows(
         });
     }
 
-    let result_rows: Vec<Vec<QueryValue>> = sorted_rows
-        .iter()
-        .map(|row| {
-            columns
-                .iter()
-                .map(|col| json_to_query_value(row.get(&col.name)))
-                .collect()
-        })
-        .collect();
+    let result_rows: Vec<Vec<QueryValue>> =
+        sorted_rows.iter().map(|row| project_row(row, &columns)).collect();
 
     Ok((columns, result_rows))
-}
-
-async fn infer_columns(
-    rows: &[serde_json::Value],
-    query: &KafkaQuery,
-    state: &KafkaState,
-) -> Vec<ColumnSpec> {
-    let meta_cols = vec![
-        ColumnSpec { name: "_partition".into(), type_hint: "int".into() },
-        ColumnSpec { name: "_offset".into(), type_hint: "long".into() },
-        ColumnSpec { name: "_timestamp".into(), type_hint: "long".into() },
-    ];
-
-    match &query.select {
-        SelectClause::All => {
-            if let Some(ref sr) = state.schema_registry {
-                let subject = format!("{}-value", query.topic);
-                if let Ok(mut cols) = sr.get_columns_for_subject(&subject).await {
-                    cols.extend(meta_cols);
-                    return cols;
-                }
-            }
-            if let Some(first) = rows.first() {
-                let mut cols = columns_from_json_sample(first);
-                for mc in &meta_cols {
-                    if !cols.iter().any(|c| c.name == mc.name) {
-                        cols.push(mc.clone());
-                    }
-                }
-                cols
-            } else {
-                let mut cols = vec![ColumnSpec {
-                    name: "value".into(),
-                    type_hint: "bytes".into(),
-                }];
-                cols.extend(meta_cols);
-                cols
-            }
-        }
-        SelectClause::Columns(cols) => cols
-            .iter()
-            .map(|sc| {
-                let name = sc.alias.clone().unwrap_or_else(|| match &sc.expr {
-                    ColumnExpr::Name(n) => n.clone(),
-                    ColumnExpr::Agg(func, col) => format!("{func:?}({col})").to_lowercase(),
-                    ColumnExpr::CountAll => "count(*)".to_string(),
-                });
-                ColumnSpec {
-                    name,
-                    type_hint: "text".to_string(),
-                }
-            })
-            .collect(),
-    }
 }
 
 pub(super) fn aggregate_rows(
@@ -243,20 +394,7 @@ pub(super) fn aggregate_rows(
         }
     };
 
-    let columns: Vec<ColumnSpec> = select_cols
-        .iter()
-        .map(|sc| {
-            let name = sc.alias.clone().unwrap_or_else(|| match &sc.expr {
-                ColumnExpr::Name(n) => n.clone(),
-                ColumnExpr::Agg(func, col) => format!("{func:?}({col})").to_lowercase(),
-                ColumnExpr::CountAll => "count(*)".to_string(),
-            });
-            ColumnSpec {
-                name,
-                type_hint: "text".to_string(),
-            }
-        })
-        .collect();
+    let columns = columns_for_select(select_cols);
 
     let mut result_rows = Vec::new();
     for group_rows in groups.values() {
@@ -368,5 +506,105 @@ fn compare_query_values(a: &QueryValue, b: &QueryValue) -> std::cmp::Ordering {
         (QueryValue::Null, _) => std::cmp::Ordering::Less,
         (_, QueryValue::Null) => std::cmp::Ordering::Greater,
         _ => std::cmp::Ordering::Equal,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::drivers::kafka::sql_parser::{OrderByClause, SelectColumn};
+
+    fn query_all(topic: &str) -> KafkaQuery {
+        KafkaQuery {
+            topic: topic.into(),
+            select: SelectClause::All,
+            where_conditions: vec![],
+            group_by: vec![],
+            order_by: vec![],
+            limit: None,
+            from_latest: false,
+        }
+    }
+
+    #[test]
+    fn build_row_injects_metadata_into_object() {
+        let payload = br#"{"event_id":7,"page":"/home"}"#;
+        let row = build_row(payload, 2, 99, Some(1234));
+        assert_eq!(row.get("event_id").unwrap(), &serde_json::json!(7));
+        assert_eq!(row.get("_partition").unwrap(), &serde_json::json!(2));
+        assert_eq!(row.get("_offset").unwrap(), &serde_json::json!(99));
+        assert_eq!(row.get("_timestamp").unwrap(), &serde_json::json!(1234));
+    }
+
+    #[test]
+    fn build_row_wraps_non_object_payload() {
+        let row = build_row(b"not json", 0, 1, None);
+        assert_eq!(row.get("value").unwrap(), &serde_json::json!("not json"));
+        assert_eq!(row.get("_partition").unwrap(), &serde_json::json!(0));
+        assert!(row.get("_timestamp").is_none());
+    }
+
+    #[test]
+    fn project_row_orders_by_columns_and_nulls_missing() {
+        let row = serde_json::json!({"a": 1, "b": "x"});
+        let cols = vec![
+            ColumnSpec { name: "b".into(), type_hint: "text".into() },
+            ColumnSpec { name: "missing".into(), type_hint: "text".into() },
+            ColumnSpec { name: "a".into(), type_hint: "int".into() },
+        ];
+        assert_eq!(
+            project_row(&row, &cols),
+            vec![QueryValue::Text("x".into()), QueryValue::Null, QueryValue::Int(1)]
+        );
+    }
+
+    #[test]
+    fn columns_from_sample_rows_unions_fields_and_appends_meta() {
+        let rows = vec![
+            serde_json::json!({"a": 1, "_partition": 0, "_offset": 0}),
+            serde_json::json!({"a": 2, "b": "x", "_partition": 0, "_offset": 1}),
+        ];
+        let cols = columns_from_sample_rows(&rows);
+        let has = |n: &str| cols.iter().any(|c| c.name == n);
+        assert!(has("a"));
+        assert!(has("b"));
+        assert!(has("_partition"));
+        assert!(has("_offset"));
+        assert!(has("_timestamp"));
+    }
+
+    #[test]
+    fn columns_from_sample_rows_empty_yields_value_and_meta() {
+        let cols = columns_from_sample_rows(&[]);
+        let names: Vec<&str> = cols.iter().map(|c| c.name.as_str()).collect();
+        assert_eq!(names, vec!["value", "_partition", "_offset", "_timestamp"]);
+    }
+
+    #[tokio::test]
+    async fn columns_upfront_uses_explicit_column_list() {
+        let mut q = query_all("t");
+        q.select = SelectClause::Columns(vec![SelectColumn {
+            expr: ColumnExpr::Name("page".into()),
+            alias: None,
+        }]);
+        let cols = columns_upfront(&q, None).await.unwrap();
+        assert_eq!(cols.len(), 1);
+        assert_eq!(cols[0].name, "page");
+    }
+
+    #[tokio::test]
+    async fn columns_upfront_none_for_select_star_without_registry() {
+        assert!(columns_upfront(&query_all("t"), None).await.is_none());
+    }
+
+    #[test]
+    fn is_streamable_only_without_group_or_order() {
+        let mut q = query_all("t");
+        assert!(is_streamable(&q));
+        q.group_by = vec!["region".into()];
+        assert!(!is_streamable(&q));
+        let mut q2 = query_all("t");
+        q2.order_by = vec![OrderByClause { column: "a".into(), desc: false }];
+        assert!(!is_streamable(&q2));
     }
 }

--- a/crates/arris-engines/src/drivers/kafka/query.rs
+++ b/crates/arris-engines/src/drivers/kafka/query.rs
@@ -333,24 +333,16 @@ fn stream_poll_blocking(
     }
 }
 
-/// Stream a plain projection: resolve columns up front (registry / explicit) or
-/// sample the first chunk to fix them, then hand the rest to `RowChunkPump`.
-pub(super) async fn stream_query(
-    cc: ClientConfig,
-    query: KafkaQuery,
-    registry: Option<SchemaRegistryClient>,
+/// Fix columns (up front, or by sampling the first chunk of `rows`) then hand
+/// the sampled rows plus the rest of the stream to `RowChunkPump`.
+async fn assemble_stream(
+    upfront: Option<Vec<ColumnSpec>>,
+    rows: futures::stream::BoxStream<'static, Result<serde_json::Value>>,
 ) -> Result<RowChunkStream> {
-    let upfront = columns_upfront(&query, registry.as_ref()).await;
-
-    let (row_tx, row_rx) = mpsc::channel::<Result<serde_json::Value>>(STREAM_ROW_CHANNEL_CAPACITY);
-    let poll_query = query.clone();
-    tokio::task::spawn_blocking(move || stream_poll_blocking(cc, poll_query, row_tx));
-
-    let mut rows = stream::unfold(row_rx, |mut rx| async move {
-        rx.recv().await.map(|item| (item, rx))
-    })
-    .boxed();
-
+    // Fuse: sampling may drain the stream to its terminal `None`, and the
+    // `chain` below re-polls it afterwards. An unfused mpsc-backed stream panics
+    // on that post-`None` poll (returns nothing for a sub-chunk result).
+    let mut rows = rows.fuse();
     let (columns, first): (Vec<ColumnSpec>, Vec<serde_json::Value>) = match upfront {
         Some(cols) => (cols, Vec::new()),
         None => {
@@ -373,6 +365,27 @@ pub(super) async fn stream_query(
         move || async move { Ok::<_, DriverError>(combined) },
         move |row: serde_json::Value| project_row(&row, &map_cols),
     ))
+}
+
+/// Stream a plain projection: resolve columns up front (registry / explicit) or
+/// sample the first chunk to fix them, then hand the rest to `RowChunkPump`.
+pub(super) async fn stream_query(
+    cc: ClientConfig,
+    query: KafkaQuery,
+    registry: Option<SchemaRegistryClient>,
+) -> Result<RowChunkStream> {
+    let upfront = columns_upfront(&query, registry.as_ref()).await;
+
+    let (row_tx, row_rx) = mpsc::channel::<Result<serde_json::Value>>(STREAM_ROW_CHANNEL_CAPACITY);
+    let poll_query = query.clone();
+    tokio::task::spawn_blocking(move || stream_poll_blocking(cc, poll_query, row_tx));
+
+    let rows = stream::unfold(row_rx, |mut rx| async move {
+        rx.recv().await.map(|item| (item, rx))
+    })
+    .boxed();
+
+    assemble_stream(upfront, rows).await
 }
 
 // ── projection / aggregation ────────────────────────────────────────────────
@@ -638,6 +651,34 @@ mod tests {
     #[tokio::test]
     async fn columns_upfront_none_for_select_star_without_registry() {
         assert!(columns_upfront(&query_all("t"), None).await.is_none());
+    }
+
+    async fn assembled_row_count(n: usize) -> usize {
+        // `unfold` (like the real mpsc-backed stream) panics if re-polled after
+        // `None`, so this catches a missing fuse; `stream::iter` would not.
+        let rows = stream::unfold(0usize, move |i| async move {
+            (i < n).then(|| (Ok(serde_json::json!({ "n": i })), i + 1))
+        })
+        .boxed();
+        let rs = assemble_stream(None, rows).await.unwrap();
+        let mut chunks = rs.chunks;
+        let mut total = 0usize;
+        while let Some(item) = chunks.next().await {
+            total += item.unwrap().len();
+        }
+        total
+    }
+
+    #[tokio::test]
+    async fn assemble_emits_all_rows_below_chunk_size() {
+        // Stream ends during sampling (n < STREAM_CHUNK_ROWS): every row must
+        // still reach the output. Regression: LIMIT 1000 returned nothing.
+        assert_eq!(assembled_row_count(1000).await, 1000);
+    }
+
+    #[tokio::test]
+    async fn assemble_emits_all_rows_above_chunk_size() {
+        assert_eq!(assembled_row_count(STREAM_CHUNK_ROWS + 1808).await, STREAM_CHUNK_ROWS + 1808);
     }
 
     #[test]

--- a/crates/arris-engines/src/drivers/kafka/query.rs
+++ b/crates/arris-engines/src/drivers/kafka/query.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use futures::stream::{self, StreamExt};
 use rdkafka::consumer::{BaseConsumer, Consumer};
 use rdkafka::message::{BorrowedMessage, Message};
@@ -11,7 +13,7 @@ use crate::{ColumnSpec, DriverError, QueryValue, RowChunkStream};
 
 use super::constants::{
     CONSUME_TIMEOUT, EMPTY_POLLS_BEFORE_STOP, MAX_ROWS, METADATA_TIMEOUT, POLL_INTERVAL,
-    STREAM_ROW_CHANNEL_CAPACITY,
+    STREAM_ROW_CHANNEL_CAPACITY, WATERMARK_IDLE_POLLS_BEFORE_STOP,
 };
 use super::schema_registry::{columns_from_rows, SchemaRegistryClient};
 use super::sql_parser::{
@@ -22,8 +24,12 @@ use super::KafkaState;
 // ── shared consume helpers ──────────────────────────────────────────────────
 
 /// Create a fresh consumer and assign every partition of the query's topic at
-/// the requested start offset. Shared by the buffered and streaming paths.
-fn build_assigned_consumer(cc: &ClientConfig, query: &KafkaQuery) -> Result<BaseConsumer> {
+/// the requested start offset. Returns the assigned partition ids. Shared by the
+/// buffered and streaming paths.
+fn build_assigned_consumer(
+    cc: &ClientConfig,
+    query: &KafkaQuery,
+) -> Result<(BaseConsumer, Vec<i32>)> {
     use rdkafka::TopicPartitionList;
 
     let consumer: BaseConsumer = cc
@@ -61,7 +67,7 @@ fn build_assigned_consumer(cc: &ClientConfig, query: &KafkaQuery) -> Result<Base
     consumer
         .assign(&tpl)
         .map_err(|e| DriverError::QueryFailed(e.to_string()))?;
-    Ok(consumer)
+    Ok((consumer, partition_ids))
 }
 
 /// Decode a message payload to a JSON row, injecting the `_partition`/`_offset`/
@@ -119,7 +125,7 @@ pub(super) fn consume_topic_fresh(
     cc: &ClientConfig,
     query: &KafkaQuery,
 ) -> Result<Vec<serde_json::Value>> {
-    let consumer = build_assigned_consumer(cc, query)?;
+    let (consumer, _partitions) = build_assigned_consumer(cc, query)?;
 
     let max_rows = query.limit.unwrap_or(MAX_ROWS).min(MAX_ROWS);
     let mut rows = Vec::with_capacity(max_rows);
@@ -191,7 +197,7 @@ async fn columns_upfront(
         SelectClause::All => {
             let sr = registry?;
             let subject = format!("{}-value", query.topic);
-            let mut cols = sr.get_columns_for_subject(&subject).await.ok()?;
+            let mut cols = sr.get_columns_for_subject(&subject).await.ok().flatten()?;
             cols.extend(meta_columns());
             Some(cols)
         }
@@ -237,18 +243,38 @@ fn project_row(row: &serde_json::Value, columns: &[ColumnSpec]) -> Vec<QueryValu
 
 /// Blocking poll loop feeding parsed, filtered rows to the async chunker. No row
 /// cap (only the query's `LIMIT`); a bounded channel backpressures the consumer.
+///
+/// A historical read (from the beginning) terminates once every partition
+/// reaches its start-of-read high watermark, so the whole snapshot drains
+/// without a wall-clock guess. A tail read (`[LATEST]`) has no bounded end, so
+/// it keeps the consume timeout.
 fn stream_poll_blocking(
     cc: ClientConfig,
     query: KafkaQuery,
     row_tx: mpsc::Sender<Result<serde_json::Value>>,
 ) {
-    let consumer = match build_assigned_consumer(&cc, &query) {
-        Ok(c) => c,
+    let (consumer, partitions) = match build_assigned_consumer(&cc, &query) {
+        Ok(pair) => pair,
         Err(e) => {
             let _ = row_tx.blocking_send(Err(e));
             return;
         }
     };
+
+    let mut targets: HashMap<i32, i64> = HashMap::new();
+    if !query.from_latest {
+        for pid in &partitions {
+            if let Ok((low, high)) =
+                consumer.fetch_watermarks(&query.topic, *pid, METADATA_TIMEOUT)
+            {
+                if high > low {
+                    targets.insert(*pid, high);
+                }
+            }
+        }
+    }
+    let use_watermarks = !targets.is_empty();
+
     let deadline = std::time::Instant::now() + CONSUME_TIMEOUT;
     let mut empty_polls = 0u32;
     let mut sent = 0usize;
@@ -257,24 +283,37 @@ fn stream_poll_blocking(
         if query.limit.is_some_and(|l| sent >= l) {
             break;
         }
-        let now = std::time::Instant::now();
-        if now >= deadline {
+        if !use_watermarks && std::time::Instant::now() >= deadline {
             break;
         }
-        let poll_timeout = deadline.saturating_duration_since(now).min(POLL_INTERVAL);
+        let poll_timeout = if use_watermarks {
+            POLL_INTERVAL
+        } else {
+            deadline
+                .saturating_duration_since(std::time::Instant::now())
+                .min(POLL_INTERVAL)
+        };
         match consumer.poll(poll_timeout) {
             Some(Ok(msg)) => {
                 empty_polls = 0;
-                let Some(row) = message_to_row(&msg) else {
-                    continue;
-                };
-                if !passes_filter(&row, &query) {
-                    continue;
+                // Offsets advance for every message, filtered or not, so track
+                // watermark progress before deciding whether to emit the row.
+                if let Some(&high) = targets.get(&msg.partition()) {
+                    if msg.offset() + 1 >= high {
+                        targets.remove(&msg.partition());
+                    }
                 }
-                if row_tx.blocking_send(Ok(row)).is_err() {
-                    return; // consumer dropped: cancel
+                if let Some(row) = message_to_row(&msg) {
+                    if passes_filter(&row, &query) {
+                        if row_tx.blocking_send(Ok(row)).is_err() {
+                            return; // consumer dropped: cancel
+                        }
+                        sent += 1;
+                    }
                 }
-                sent += 1;
+                if use_watermarks && targets.is_empty() {
+                    break;
+                }
             }
             Some(Err(e)) => {
                 let _ = row_tx.blocking_send(Err(DriverError::QueryFailed(e.to_string())));
@@ -282,7 +321,11 @@ fn stream_poll_blocking(
             }
             None => {
                 empty_polls += 1;
-                if sent > 0 && empty_polls >= EMPTY_POLLS_BEFORE_STOP {
+                if use_watermarks {
+                    if empty_polls >= WATERMARK_IDLE_POLLS_BEFORE_STOP {
+                        break;
+                    }
+                } else if sent > 0 && empty_polls >= EMPTY_POLLS_BEFORE_STOP {
                     break;
                 }
             }

--- a/crates/arris-engines/src/drivers/kafka/schema_registry.rs
+++ b/crates/arris-engines/src/drivers/kafka/schema_registry.rs
@@ -2,6 +2,7 @@ use anyhow::{Context, Result};
 use crate::{ColumnSpec, SchemaNode, SchemaNodeKind};
 use serde::Deserialize;
 
+#[derive(Clone)]
 pub struct SchemaRegistryClient {
     base_url: String,
     client: reqwest::Client,
@@ -149,6 +150,25 @@ pub fn columns_from_json_sample(sample: &serde_json::Value) -> Vec<ColumnSpec> {
             .collect(),
         _ => vec![fallback_value_column()],
     }
+}
+
+/// Column union over sampled rows: first-seen field order, and a null hint gets
+/// upgraded to the first concrete type seen for that field.
+pub fn columns_from_rows(rows: &[serde_json::Value]) -> Vec<ColumnSpec> {
+    let mut union: indexmap::IndexMap<String, ColumnSpec> = indexmap::IndexMap::new();
+    for row in rows {
+        for col in columns_from_json_sample(row) {
+            union
+                .entry(col.name.clone())
+                .and_modify(|existing| {
+                    if existing.type_hint == "null" && col.type_hint != "null" {
+                        existing.type_hint = col.type_hint.clone();
+                    }
+                })
+                .or_insert(col);
+        }
+    }
+    union.into_values().collect()
 }
 
 fn json_value_type(val: &serde_json::Value) -> String {

--- a/crates/arris-engines/src/drivers/kafka/schema_registry.rs
+++ b/crates/arris-engines/src/drivers/kafka/schema_registry.rs
@@ -47,7 +47,9 @@ impl SchemaRegistryClient {
         Ok(subjects)
     }
 
-    pub async fn get_columns_for_subject(&self, subject: &str) -> Result<Vec<ColumnSpec>> {
+    /// `None` when the subject has no registered schema (404) or an empty one, so
+    /// the caller falls back to sampling rows rather than a bogus `value` column.
+    pub async fn get_columns_for_subject(&self, subject: &str) -> Result<Option<Vec<ColumnSpec>>> {
         let url = format!("{}/subjects/{}/versions/latest", self.base_url, subject);
         let resp = self
             .client
@@ -57,7 +59,7 @@ impl SchemaRegistryClient {
             .context("Schema Registry: failed to get schema")?;
 
         if !resp.status().is_success() {
-            return Ok(vec![fallback_value_column()]);
+            return Ok(None);
         }
 
         let schema_resp: SchemaResponse = resp.json().await.context("Schema Registry: bad response")?;
@@ -66,7 +68,7 @@ impl SchemaRegistryClient {
 
     pub async fn get_topic_schema_nodes(&self, topic: &str) -> Result<Vec<SchemaNode>> {
         let subject = format!("{topic}-value");
-        let columns = self.get_columns_for_subject(&subject).await?;
+        let columns = self.get_columns_for_subject(&subject).await?.unwrap_or_default();
         Ok(columns
             .into_iter()
             .map(|col| SchemaNode {
@@ -80,25 +82,24 @@ impl SchemaRegistryClient {
     }
 }
 
-fn parse_avro_columns(schema_json: &str) -> Result<Vec<ColumnSpec>> {
+fn parse_avro_columns(schema_json: &str) -> Result<Option<Vec<ColumnSpec>>> {
     let schema: AvroSchema =
         serde_json::from_str(schema_json).context("Failed to parse Avro schema")?;
 
     if schema.fields.is_empty() {
-        return Ok(vec![fallback_value_column()]);
+        return Ok(None);
     }
 
-    Ok(schema
-        .fields
-        .iter()
-        .map(|f| {
-            let type_hint = avro_type_to_hint(&f.field_type);
-            ColumnSpec {
+    Ok(Some(
+        schema
+            .fields
+            .iter()
+            .map(|f| ColumnSpec {
                 name: f.name.clone(),
-                type_hint,
-            }
-        })
-        .collect())
+                type_hint: avro_type_to_hint(&f.field_type),
+            })
+            .collect(),
+    ))
 }
 
 fn avro_type_to_hint(val: &serde_json::Value) -> String {
@@ -203,7 +204,7 @@ mod tests {
                 {"name": "email", "type": ["null", "string"]}
             ]
         }"#;
-        let cols = parse_avro_columns(schema).unwrap();
+        let cols = parse_avro_columns(schema).unwrap().unwrap();
         assert_eq!(cols.len(), 3);
         assert_eq!(cols[0].name, "id");
         assert_eq!(cols[0].type_hint, "long");
@@ -214,11 +215,9 @@ mod tests {
     }
 
     #[test]
-    fn parse_avro_empty_fallback() {
+    fn parse_avro_no_fields_is_none() {
         let schema = r#"{"type": "string"}"#;
-        let cols = parse_avro_columns(schema).unwrap();
-        assert_eq!(cols.len(), 1);
-        assert_eq!(cols[0].name, "value");
+        assert!(parse_avro_columns(schema).unwrap().is_none());
     }
 
     #[test]
@@ -230,7 +229,7 @@ mod tests {
                 {"name": "data", "type": {"type": "map", "values": "string"}}
             ]
         }"#;
-        let cols = parse_avro_columns(schema).unwrap();
+        let cols = parse_avro_columns(schema).unwrap().unwrap();
         assert_eq!(cols[0].type_hint, "map");
     }
 

--- a/fixtures/initdb/kafka-init.sh
+++ b/fixtures/initdb/kafka-init.sh
@@ -4,6 +4,9 @@ set -e
 BROKER="kafka:19092"
 SCHEMA_REGISTRY="http://schema-registry:8081"
 
+# Row count for the large streaming-test topic (events_large).
+LARGE_EVENTS_COUNT=10000000
+
 # =================================================================
 # Canonical sample dataset — one topic per table, JSON records.
 # Same keys / rows as every other engine so cross-source joins line up.
@@ -182,9 +185,31 @@ for i in $(seq 1 100); do
   echo "{\"id\":$i,\"customer_id\":$customer_id,\"action\":\"$action\",\"ip\":\"10.0.$((RANDOM % 256)).$((RANDOM % 256))\"}"
 done | kafka-console-producer --bootstrap-server $BROKER --topic audit-log
 
+echo "=== Producing large events topic ($LARGE_EVENTS_COUNT records) ==="
+kafka-topics --bootstrap-server $BROKER --create --if-not-exists --topic events_large --partitions 12 --replication-factor 1
+# Skip re-producing on restart if the topic already holds the full dataset.
+EXISTING=$(kafka-run-class kafka.tools.GetOffsetShell --broker-list $BROKER --topic events_large --time -1 2>/dev/null | awk -F: '{s+=$3} END{print s+0}')
+if [ "$EXISTING" -ge "$LARGE_EVENTS_COUNT" ]; then
+  echo "events_large already has $EXISTING records, skipping"
+else
+  awk -v n="$LARGE_EVENTS_COUNT" 'BEGIN{
+    srand(42);
+    split("page_view,click,scroll,form_submit,search,add_to_cart,purchase,logout",et,",");
+    split("/home,/products,/product/123,/cart,/checkout,/account,/search,/about",pg,",");
+    for(i=1;i<=n;i++){
+      c=1+int(rand()*12); e=et[1+int(rand()*8)]; p=pg[1+int(rand()*8)];
+      d=50+int(rand()*10000); mo=1+int(rand()*12); da=1+int(rand()*28);
+      printf "{\"event_id\":%d,\"customer_id\":%d,\"event_type\":\"%s\",\"page\":\"%s\",\"duration_ms\":%d,\"timestamp\":\"2025-%02d-%02dT%02d:%02d:%02dZ\"}\n", i,c,e,p,d,mo,da,int(rand()*24),int(rand()*60),int(rand()*60);
+    }
+  }' | kafka-console-producer --bootstrap-server $BROKER --topic events_large \
+      --producer-property compression.type=lz4 \
+      --producer-property batch.size=1000000 \
+      --producer-property linger.ms=100
+fi
+
 echo "=== Registering consumer groups ==="
 timeout 10 kafka-console-consumer --bootstrap-server $BROKER --topic orders --group order-processing-svc --from-beginning --max-messages 5 > /dev/null 2>&1 || true
 timeout 10 kafka-console-consumer --bootstrap-server $BROKER --topic events --group analytics-pipeline --from-beginning --max-messages 5 > /dev/null 2>&1 || true
 timeout 10 kafka-console-consumer --bootstrap-server $BROKER --topic notifications --group notification-sender --from-beginning --max-messages 5 > /dev/null 2>&1 || true
 
-echo "=== Kafka init complete: 7 topics, 3 consumer groups ==="
+echo "=== Kafka init complete: 8 topics, 3 consumer groups ==="


### PR DESCRIPTION
## What does this PR do?

Implmenting `run_query_stream` for Kafka for by-chunk ingestion.

Changes:
- Plain projections (no `GROUP BY` / `ORDER BY`) stream via a blocking poll task feeding parsed, filtered rows to an async chunker over a bounded channel (backpressure, drop-to-cancel); aggregation/sort keep the materialized path.
- Historical reads terminate at each partition's start-of-read high watermark instead of a 30s timeout; `[LATEST]` tail reads keep the timeout since they have no bounded end. Removes the old silent 10k row cap.
- **Schemaless columns**: a registry 404 (topic with no Avro subject) now falls back to row sampling instead of a bogus `value` column, fixing both `SELECT *` (was `value=NULL`) and the schema browser's phantom column.
- **Sub-chunk fix**: a result smaller than the chunk size (e.g. `LIMIT 1000`) returned zero rows because the `unfold` row stream panicked when re-polled after `None`; the assembly step now fuses the stream.
- **Fixture**: adds `events_large` (10M JSON records, idempotent on restart) for streaming tests.

## Checklist

- [ ] I opened an issue first for non-trivial changes, or this is a small fix.
- [x] Tests added/updated for my change.
- [x] **I license my contribution under the MIT License**, per [CONTRIBUTING.md](../CONTRIBUTING.md). I confirm this is my original work, or that I have the right to submit it.
