### PR TITLE
[Feature] Streaming ingestion for Mixpanel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7411,6 +7411,7 @@ dependencies = [
  "bytes",
  "encoding_rs",
  "futures-core",
+ "futures-util",
  "h2 0.4.15",
  "http 1.4.2",
  "http-body 1.0.1",
@@ -7432,12 +7433,14 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls 0.26.4",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
 ]
 
@@ -9561,6 +9564,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/crates/arris-engines/Cargo.toml
+++ b/crates/arris-engines/Cargo.toml
@@ -100,7 +100,7 @@ async-stream = { version = "0.3", optional = true }
 
 # drivers: kafka + mixpanel + elasticsearch (shared reqwest)
 rdkafka = { version = "0.39", features = ["cmake-build", "ssl-vendored"], optional = true }
-reqwest = { workspace = true, optional = true }
+reqwest = { workspace = true, optional = true, features = ["stream"] }
 
 # drivers: redis
 redis = { version = "1.2", features = ["tokio-rustls-comp", "connection-manager"], optional = true }

--- a/crates/arris-engines/src/drivers/mixpanel/api.rs
+++ b/crates/arris-engines/src/drivers/mixpanel/api.rs
@@ -16,35 +16,29 @@ pub(super) struct Inner {
     pub(super) password: String,
 }
 
-pub(super) async fn execute_export(
+// The export endpoint caps returned events with `limit`, so push the query's
+// LIMIT down to Mixpanel rather than downloading the full history. Only safe when
+// no ORDER BY / aggregation reorders the result (see the caller's guard).
+pub(super) fn build_export_url(
     inner: &Inner,
     parsed_query: &sql_parser::MixpanelQuery,
     api_limit: Option<usize>,
-) -> Result<Vec<BTreeMap<String, QueryValue>>> {
+) -> Result<String> {
     let mut url = format!(
         "{EXPORT_BASE_URL}?project_id={}&from_date={}&to_date={}",
         inner.project_id, parsed_query.from_date, parsed_query.to_date,
     );
-
-    // The export endpoint caps returned events with `limit`, so push the query's
-    // LIMIT down to Mixpanel rather than downloading the full history and slicing
-    // in memory. Only safe when no ORDER BY / aggregation reorders the result.
     if let Some(limit) = api_limit {
         url.push_str(&format!("&limit={limit}"));
     }
-
     if !parsed_query.event_filter.is_empty() {
         let json_array = serde_json::to_string(&parsed_query.event_filter)
             .map_err(|e| DriverError::QueryFailed(e.to_string()))?;
         url.push_str(&format!(
             "&event={}",
-            percent_encoding::utf8_percent_encode(
-                &json_array,
-                percent_encoding::NON_ALPHANUMERIC
-            )
+            percent_encoding::utf8_percent_encode(&json_array, percent_encoding::NON_ALPHANUMERIC)
         ));
     }
-
     if let Some(where_expr) = &parsed_query.where_expression {
         let mp_where = sql_parser::build_mixpanel_where(where_expr);
         url.push_str(&format!(
@@ -52,7 +46,33 @@ pub(super) async fn execute_export(
             percent_encoding::utf8_percent_encode(&mp_where, percent_encoding::NON_ALPHANUMERIC)
         ));
     }
+    Ok(url)
+}
 
+// Parse one JSONL export line into a row map; None for blank or malformed lines.
+pub(super) fn parse_export_line(line: &str) -> Option<BTreeMap<String, QueryValue>> {
+    if line.is_empty() {
+        return None;
+    }
+    let obj = serde_json::from_str::<serde_json::Value>(line).ok()?;
+    let mut row = BTreeMap::new();
+    if let Some(event_name) = obj.get("event").and_then(|v| v.as_str()) {
+        row.insert("event".into(), QueryValue::Text(event_name.into()));
+    }
+    if let Some(props) = obj.get("properties").and_then(|v| v.as_object()) {
+        for (key, value) in props {
+            row.insert(key.clone(), query::json_to_query_value(value));
+        }
+    }
+    Some(row)
+}
+
+pub(super) async fn execute_export(
+    inner: &Inner,
+    parsed_query: &sql_parser::MixpanelQuery,
+    api_limit: Option<usize>,
+) -> Result<Vec<BTreeMap<String, QueryValue>>> {
+    let url = build_export_url(inner, parsed_query, api_limit)?;
     let resp = inner
         .client
         .get(&url)
@@ -75,29 +95,29 @@ pub(super) async fn execute_export(
         .text()
         .await
         .map_err(|e| DriverError::QueryFailed(format!("Failed to read response: {e}")))?;
-    let mut rows: Vec<BTreeMap<String, QueryValue>> = Vec::new();
+    Ok(text.lines().filter_map(parse_export_line).collect())
+}
 
-    for line in text.lines() {
-        if line.is_empty() {
-            continue;
-        }
-        let Ok(obj) = serde_json::from_str::<serde_json::Value>(line) else {
-            continue;
-        };
+// Send the export request for streaming: no total timeout (a large export can run
+// past any fixed deadline), body consumed lazily by the caller's byte stream.
+pub(super) async fn send_export_stream(inner: &Inner, url: String) -> Result<reqwest::Response> {
+    let resp = inner
+        .client
+        .get(&url)
+        .basic_auth(&inner.username, Some(&inner.password))
+        .header("Accept", "text/plain")
+        .send()
+        .await
+        .map_err(|e| DriverError::QueryFailed(format!("Mixpanel export request failed: {e}")))?;
 
-        let mut row = BTreeMap::new();
-        if let Some(event_name) = obj.get("event").and_then(|v| v.as_str()) {
-            row.insert("event".into(), QueryValue::Text(event_name.into()));
-        }
-        if let Some(props) = obj.get("properties").and_then(|v| v.as_object()) {
-            for (key, value) in props {
-                row.insert(key.clone(), query::json_to_query_value(value));
-            }
-        }
-        rows.push(row);
+    let status = resp.status().as_u16();
+    if status != 200 {
+        let body = resp.text().await.unwrap_or_default();
+        return Err(DriverError::QueryFailed(format!(
+            "Mixpanel export failed (HTTP {status}): {body}"
+        )));
     }
-
-    Ok(rows)
+    Ok(resp)
 }
 
 async fn fetch_event_names(inner: &Inner) -> Vec<String> {

--- a/crates/arris-engines/src/drivers/mixpanel/api.rs
+++ b/crates/arris-engines/src/drivers/mixpanel/api.rs
@@ -9,6 +9,10 @@ use super::constants::{
 use super::query;
 use super::sql_parser;
 
+// Cheap to clone: `reqwest::Client` is Arc-backed (shares the connection pool),
+// the rest are small Strings. Cloned out of the guard so network I/O never holds
+// the connection mutex (a long query would otherwise starve the schema browser).
+#[derive(Clone)]
 pub(super) struct Inner {
     pub(super) client: reqwest::Client,
     pub(super) project_id: String,

--- a/crates/arris-engines/src/drivers/mixpanel/constants.rs
+++ b/crates/arris-engines/src/drivers/mixpanel/constants.rs
@@ -18,6 +18,12 @@ pub const MAX_PROPERTY_FETCHES: usize = 50;
 pub const SCHEMA_SAMPLE_LIMIT: usize = 1000;
 pub const SCHEMA_SAMPLE_DAYS: i64 = 30;
 
+// Query-result column type hints, inferred from the first row's cell value.
+pub const TYPE_HINT_BIGINT: &str = "bigint";
+pub const TYPE_HINT_DOUBLE: &str = "double";
+pub const TYPE_HINT_BOOLEAN: &str = "boolean";
+pub const TYPE_HINT_TEXT: &str = "text";
+
 // The export endpoint requires an explicit from_date/to_date window and rejects
 // any from_date earlier than 2011-07-10 (HTTP 400). Anchoring to that floor
 // expresses "unlimited" unless a WHERE clause on `time` narrows the range.

--- a/crates/arris-engines/src/drivers/mixpanel/driver.rs
+++ b/crates/arris-engines/src/drivers/mixpanel/driver.rs
@@ -27,6 +27,13 @@ impl MixpanelDriver {
             inner: Mutex::new(None),
         }
     }
+
+    // Clone the connection handle out of the guard so network I/O runs lock-free;
+    // holding the mutex across a request would serialize queries and schema loads.
+    async fn connected_inner(&self) -> Result<api::Inner> {
+        let guard = self.inner.lock().await;
+        Ok(guard.as_ref().ok_or(DriverError::NotConnected)?.clone())
+    }
 }
 
 #[async_trait]
@@ -86,9 +93,8 @@ impl DatabaseDriver for MixpanelDriver {
     }
 
     async fn list_schemas(&self) -> Result<Vec<SchemaNode>> {
-        let guard = self.inner.lock().await;
-        let inner = guard.as_ref().ok_or(DriverError::NotConnected)?;
-        let discovered = api::discover_events(inner).await;
+        let inner = self.connected_inner().await?;
+        let discovered = api::discover_events(&inner).await;
         Ok(schema::build_schema_tree(&discovered))
     }
 
@@ -103,8 +109,7 @@ impl DatabaseDriver for MixpanelDriver {
         _params: &[QueryValue],
         _language: QueryLanguage,
     ) -> Result<QueryResult> {
-        let guard = self.inner.lock().await;
-        let inner = guard.as_ref().ok_or(DriverError::NotConnected)?;
+        let inner = self.connected_inner().await?;
 
         let started = Instant::now();
         let parsed_query = sql_parser::parse(text)
@@ -121,7 +126,7 @@ impl DatabaseDriver for MixpanelDriver {
         let api_limit = parsed_query
             .limit
             .filter(|_| !has_agg && parsed_query.order_by.is_empty());
-        let mut all_rows = api::execute_export(inner, &parsed_query, api_limit).await?;
+        let mut all_rows = api::execute_export(&inner, &parsed_query, api_limit).await?;
 
         if let Some(where_expr) = &parsed_query.where_expression {
             all_rows.retain(|row| sql_parser::evaluate(where_expr, row));
@@ -179,10 +184,9 @@ impl DatabaseDriver for MixpanelDriver {
             ));
         }
 
-        let guard = self.inner.lock().await;
-        let inner = guard.as_ref().ok_or(DriverError::NotConnected)?;
-        let url = api::build_export_url(inner, &parsed_query, parsed_query.limit)?;
-        let resp = api::send_export_stream(inner, url).await?;
+        let inner = self.connected_inner().await?;
+        let url = api::build_export_url(&inner, &parsed_query, parsed_query.limit)?;
+        let resp = api::send_export_stream(&inner, url).await?;
         Ok(QueryStream::Rows(
             query::stream_export(resp, &parsed_query).await?,
         ))

--- a/crates/arris-engines/src/drivers/mixpanel/driver.rs
+++ b/crates/arris-engines/src/drivers/mixpanel/driver.rs
@@ -2,8 +2,8 @@ use std::time::Instant;
 
 use async_trait::async_trait;
 use crate::{
-    ColumnSpec, ConnectionConfig, DatabaseKind, DriverError, ExplainMode, MutationResult,
-    PlanResult, QueryLanguage, QueryResult, QueryValue, RowDelete, RowInsert, SchemaNode,
+    ConnectionConfig, DatabaseKind, DriverError, ExplainMode, MutationResult, PlanResult,
+    QueryLanguage, QueryResult, QueryStream, QueryValue, RowDelete, RowInsert, SchemaNode,
     TableRef,
 };
 use crate::drivers::errors::Result;
@@ -141,41 +141,11 @@ impl DatabaseDriver for MixpanelDriver {
             all_rows.truncate(limit);
         }
 
-        let columns: Vec<ColumnSpec> = if all_rows.is_empty() {
-            sql_parser::resolve_column_names(&parsed_query)
-                .into_iter()
-                .map(|name| ColumnSpec {
-                    name,
-                    type_hint: "text".into(),
-                })
-                .collect()
-        } else {
-            all_rows[0]
-                .iter()
-                .map(|(name, val)| {
-                    let hint = match val {
-                        QueryValue::Int(_) => "bigint",
-                        QueryValue::Double(_) => "double",
-                        QueryValue::Bool(_) => "boolean",
-                        _ => "text",
-                    };
-                    ColumnSpec {
-                        name: name.clone(),
-                        type_hint: hint.into(),
-                    }
-                })
-                .collect()
-        };
-
-        let col_names: Vec<&str> = columns.iter().map(|c| c.name.as_str()).collect();
+        let columns = query::build_columns(&parsed_query, &all_rows);
+        let col_names: Vec<String> = columns.iter().map(|c| c.name.clone()).collect();
         let rows: Vec<Vec<QueryValue>> = all_rows
             .iter()
-            .map(|row| {
-                col_names
-                    .iter()
-                    .map(|name| row.get(*name).cloned().unwrap_or(QueryValue::Null))
-                    .collect()
-            })
+            .map(|row| query::project_row(row, &col_names))
             .collect();
 
         Ok(QueryResult {
@@ -185,6 +155,37 @@ impl DatabaseDriver for MixpanelDriver {
             elapsed: started.elapsed().as_secs_f64(),
             ..Default::default()
         })
+    }
+
+    async fn run_query_stream(
+        &self,
+        text: &str,
+        params: &[QueryValue],
+        language: QueryLanguage,
+    ) -> Result<QueryStream> {
+        let parsed_query =
+            sql_parser::parse(text).map_err(|e| DriverError::QueryFailed(e.to_string()))?;
+        let has_agg = !parsed_query.group_by.is_empty()
+            || parsed_query
+                .columns
+                .iter()
+                .any(|c| matches!(c, ColumnSelection::Aggregation(..)));
+
+        // Aggregation and ORDER BY collapse or reorder the whole result, so they
+        // need the buffered path; a plain projection with WHERE/LIMIT streams.
+        if has_agg || !parsed_query.order_by.is_empty() {
+            return Ok(QueryStream::from_materialized(
+                self.run_query(text, params, language).await?,
+            ));
+        }
+
+        let guard = self.inner.lock().await;
+        let inner = guard.as_ref().ok_or(DriverError::NotConnected)?;
+        let url = api::build_export_url(inner, &parsed_query, parsed_query.limit)?;
+        let resp = api::send_export_stream(inner, url).await?;
+        Ok(QueryStream::Rows(
+            query::stream_export(resp, &parsed_query).await?,
+        ))
     }
 
     fn pagination_strategy(&self) -> crate::PaginationStrategy {

--- a/crates/arris-engines/src/drivers/mixpanel/query.rs
+++ b/crates/arris-engines/src/drivers/mixpanel/query.rs
@@ -1,8 +1,18 @@
 use std::collections::BTreeMap;
 
-use crate::QueryValue;
+use futures::stream::{self, Stream, StreamExt, TryStreamExt};
 
-use super::sql_parser::{AggFunc, ColumnSelection, MixpanelQuery};
+use crate::drivers::common::RowChunkPump;
+use crate::drivers::constants::STREAM_CHUNK_ROWS;
+use crate::drivers::errors::{DriverError, Result};
+use crate::drivers::types::RowChunkStream;
+use crate::{ColumnSpec, QueryValue};
+
+use super::api;
+use super::constants::{TYPE_HINT_BIGINT, TYPE_HINT_BOOLEAN, TYPE_HINT_DOUBLE, TYPE_HINT_TEXT};
+use super::sql_parser::{self, AggFunc, ColumnSelection, MixpanelQuery};
+
+type RowStream = std::pin::Pin<Box<dyn Stream<Item = Result<BTreeMap<String, QueryValue>>> + Send>>;
 
 pub(super) fn json_to_query_value(value: &serde_json::Value) -> QueryValue {
     match value {
@@ -24,41 +34,81 @@ pub(super) fn json_to_query_value(value: &serde_json::Value) -> QueryValue {
     }
 }
 
-pub(super) fn select_columns(
-    rows: &[BTreeMap<String, QueryValue>],
+fn select_columns_row(
+    row: &BTreeMap<String, QueryValue>,
     query: &MixpanelQuery,
-) -> Vec<BTreeMap<String, QueryValue>> {
+) -> BTreeMap<String, QueryValue> {
     let wants_all = query
         .columns
         .iter()
         .any(|c| matches!(c, ColumnSelection::All));
     if wants_all {
-        return rows.to_vec();
+        return row.clone();
     }
-
     let names: Vec<&str> = query
         .columns
         .iter()
-        .filter_map(|c| {
-            if let ColumnSelection::Named(n) = c {
-                Some(n.as_str())
-            } else {
-                None
-            }
+        .filter_map(|c| match c {
+            ColumnSelection::Named(n) => Some(n.as_str()),
+            _ => None,
         })
         .collect();
     if names.is_empty() {
-        return rows.to_vec();
+        return row.clone();
     }
+    names
+        .into_iter()
+        .map(|n| (n.to_string(), row.get(n).cloned().unwrap_or(QueryValue::Null)))
+        .collect()
+}
 
-    rows.iter()
-        .map(|row| {
-            let mut filtered = BTreeMap::new();
-            for &n in &names {
-                filtered.insert(n.to_string(), row.get(n).cloned().unwrap_or(QueryValue::Null));
-            }
-            filtered
-        })
+pub(super) fn select_columns(
+    rows: &[BTreeMap<String, QueryValue>],
+    query: &MixpanelQuery,
+) -> Vec<BTreeMap<String, QueryValue>> {
+    rows.iter().map(|row| select_columns_row(row, query)).collect()
+}
+
+fn type_hint(value: &QueryValue) -> &'static str {
+    match value {
+        QueryValue::Int(_) => TYPE_HINT_BIGINT,
+        QueryValue::Double(_) => TYPE_HINT_DOUBLE,
+        QueryValue::Bool(_) => TYPE_HINT_BOOLEAN,
+        _ => TYPE_HINT_TEXT,
+    }
+}
+
+// Column specs for an already-projected row set: names/types from the first row,
+// or the parser's resolved names (typed `text`) when the result is empty.
+pub(super) fn build_columns(
+    query: &MixpanelQuery,
+    projected: &[BTreeMap<String, QueryValue>],
+) -> Vec<ColumnSpec> {
+    match projected.first() {
+        Some(first) => first
+            .iter()
+            .map(|(name, val)| ColumnSpec {
+                name: name.clone(),
+                type_hint: type_hint(val).into(),
+            })
+            .collect(),
+        None => sql_parser::resolve_column_names(query)
+            .into_iter()
+            .map(|name| ColumnSpec {
+                name,
+                type_hint: TYPE_HINT_TEXT.into(),
+            })
+            .collect(),
+    }
+}
+
+pub(super) fn project_row(
+    row: &BTreeMap<String, QueryValue>,
+    col_names: &[String],
+) -> Vec<QueryValue> {
+    col_names
+        .iter()
+        .map(|name| row.get(name).cloned().unwrap_or(QueryValue::Null))
         .collect()
 }
 
@@ -241,4 +291,229 @@ fn compare_query_values(a: &QueryValue, b: &QueryValue) -> std::cmp::Ordering {
         }
         _ => a.display_string().cmp(&b.display_string()),
     }
+}
+
+// Split a raw byte stream into JSONL rows lazily. `\n` never appears inside a
+// UTF-8 multibyte sequence, so splitting on the raw byte is safe; each complete
+// line is parsed, blank/malformed lines dropped, the trailing partial flushed at EOF.
+fn line_row_stream<B, E, S>(bytes: S) -> impl Stream<Item = Result<BTreeMap<String, QueryValue>>>
+where
+    B: AsRef<[u8]> + Send + 'static,
+    E: std::fmt::Display + Send + 'static,
+    S: Stream<Item = std::result::Result<B, E>> + Send + 'static,
+{
+    let bytes = Box::pin(bytes);
+    stream::unfold(
+        (bytes, Vec::<u8>::new(), false),
+        |(mut bytes, mut buf, mut done)| async move {
+            loop {
+                if let Some(pos) = buf.iter().position(|&b| b == b'\n') {
+                    let mut line: Vec<u8> = buf.drain(..=pos).collect();
+                    line.pop();
+                    if let Some(row) = parse_line(&line) {
+                        return Some((Ok(row), (bytes, buf, done)));
+                    }
+                    continue;
+                }
+                if done {
+                    if !buf.is_empty() {
+                        let line = std::mem::take(&mut buf);
+                        if let Some(row) = parse_line(&line) {
+                            return Some((Ok(row), (bytes, buf, true)));
+                        }
+                    }
+                    return None;
+                }
+                match bytes.next().await {
+                    Some(Ok(chunk)) => buf.extend_from_slice(chunk.as_ref()),
+                    Some(Err(e)) => {
+                        let err = DriverError::QueryFailed(format!(
+                            "Mixpanel export stream failed: {e}"
+                        ));
+                        return Some((Err(err), (bytes, Vec::new(), true)));
+                    }
+                    None => done = true,
+                }
+            }
+        },
+    )
+}
+
+fn export_row_stream(
+    resp: reqwest::Response,
+) -> impl Stream<Item = Result<BTreeMap<String, QueryValue>>> {
+    line_row_stream(resp.bytes_stream())
+}
+
+fn parse_line(line: &[u8]) -> Option<BTreeMap<String, QueryValue>> {
+    std::str::from_utf8(line).ok().and_then(api::parse_export_line)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn query_with(columns: Vec<ColumnSelection>) -> MixpanelQuery {
+        MixpanelQuery {
+            columns,
+            event_filter: vec![],
+            from_date: "2025-01-01".into(),
+            to_date: "2025-01-02".into(),
+            where_expression: None,
+            group_by: vec![],
+            order_by: vec![],
+            limit: None,
+        }
+    }
+
+    fn row(pairs: &[(&str, QueryValue)]) -> BTreeMap<String, QueryValue> {
+        pairs.iter().map(|(k, v)| (k.to_string(), v.clone())).collect()
+    }
+
+    #[test]
+    fn select_columns_row_named_picks_subset_and_nulls_missing() {
+        let q = query_with(vec![
+            ColumnSelection::Named("event".into()),
+            ColumnSelection::Named("missing".into()),
+        ]);
+        let src = row(&[("event", QueryValue::Text("a".into())), ("extra", QueryValue::Int(9))]);
+        let out = select_columns_row(&src, &q);
+        assert_eq!(out.len(), 2);
+        assert_eq!(out["event"], QueryValue::Text("a".into()));
+        assert_eq!(out["missing"], QueryValue::Null);
+        assert!(!out.contains_key("extra"));
+    }
+
+    #[test]
+    fn select_columns_row_star_keeps_all() {
+        let q = query_with(vec![ColumnSelection::All]);
+        let src = row(&[("a", QueryValue::Int(1)), ("b", QueryValue::Text("x".into()))]);
+        assert_eq!(select_columns_row(&src, &q), src);
+    }
+
+    #[test]
+    fn build_columns_infers_types_from_first_row() {
+        let q = query_with(vec![ColumnSelection::All]);
+        let rows = vec![row(&[
+            ("i", QueryValue::Int(1)),
+            ("d", QueryValue::Double(2.0)),
+            ("b", QueryValue::Bool(true)),
+            ("s", QueryValue::Text("x".into())),
+        ])];
+        let cols = build_columns(&q, &rows);
+        let by: BTreeMap<_, _> = cols.iter().map(|c| (c.name.as_str(), c.type_hint.as_str())).collect();
+        assert_eq!(by["i"], TYPE_HINT_BIGINT);
+        assert_eq!(by["d"], TYPE_HINT_DOUBLE);
+        assert_eq!(by["b"], TYPE_HINT_BOOLEAN);
+        assert_eq!(by["s"], TYPE_HINT_TEXT);
+    }
+
+    #[test]
+    fn build_columns_empty_falls_back_to_resolved_text_names() {
+        let q = query_with(vec![
+            ColumnSelection::Named("event".into()),
+            ColumnSelection::Named("page".into()),
+        ]);
+        let cols = build_columns(&q, &[]);
+        assert_eq!(cols.iter().map(|c| c.name.clone()).collect::<Vec<_>>(), vec!["event", "page"]);
+        assert!(cols.iter().all(|c| c.type_hint == TYPE_HINT_TEXT));
+    }
+
+    #[test]
+    fn project_row_aligns_columns_and_nulls_missing() {
+        let src = row(&[("a", QueryValue::Int(1)), ("b", QueryValue::Text("x".into()))]);
+        let cols = vec!["b".to_string(), "a".to_string(), "c".to_string()];
+        assert_eq!(
+            project_row(&src, &cols),
+            vec![QueryValue::Text("x".into()), QueryValue::Int(1), QueryValue::Null]
+        );
+    }
+
+    fn bytes_stream(
+        chunks: Vec<&'static [u8]>,
+    ) -> impl Stream<Item = std::result::Result<&'static [u8], std::io::Error>> {
+        stream::iter(chunks.into_iter().map(Ok))
+    }
+
+    async fn collect_rows(
+        s: impl Stream<Item = Result<BTreeMap<String, QueryValue>>>,
+    ) -> Vec<BTreeMap<String, QueryValue>> {
+        s.map(|r| r.unwrap()).collect().await
+    }
+
+    #[tokio::test]
+    async fn line_stream_splits_lines_across_chunk_boundaries() {
+        let s = line_row_stream(bytes_stream(vec![
+            b"{\"event\":\"a\",\"prope",
+            b"rties\":{\"x\":1}}\n{\"event\":\"b\",\"properties\":{\"x\":2}}\n",
+        ]));
+        let rows = collect_rows(s).await;
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0]["event"], QueryValue::Text("a".into()));
+        assert_eq!(rows[0]["x"], QueryValue::Int(1));
+        assert_eq!(rows[1]["event"], QueryValue::Text("b".into()));
+    }
+
+    #[tokio::test]
+    async fn line_stream_flushes_trailing_partial_and_skips_bad_lines() {
+        let s = line_row_stream(bytes_stream(vec![
+            b"\nnot json\n{\"event\":\"c\",\"properties\":{}}",
+        ]));
+        let rows = collect_rows(s).await;
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0]["event"], QueryValue::Text("c".into()));
+    }
+
+    #[tokio::test]
+    async fn line_stream_surfaces_a_read_error() {
+        let s = line_row_stream(stream::iter(vec![
+            Ok::<&[u8], std::io::Error>(b"{\"event\":\"a\",\"properties\":{}}\n"),
+            Err(std::io::Error::other("wire dropped")),
+        ]));
+        let items: Vec<_> = s.collect().await;
+        assert!(items.iter().any(|r| r.is_err()));
+    }
+}
+
+// Stream the export result as chunked rows: filter each event by WHERE, cap at
+// LIMIT, then fix the schemaless columns from the first buffered chunk (mirroring
+// the buffered path) before streaming the rest. Caller guarantees no aggregation
+// or ORDER BY, both of which need the full result and take the materialized path.
+pub(super) async fn stream_export(
+    resp: reqwest::Response,
+    parsed_query: &MixpanelQuery,
+) -> Result<RowChunkStream> {
+    let where_expr = parsed_query.where_expression.clone();
+    let filtered = export_row_stream(resp).try_filter(move |row| {
+        let keep = where_expr
+            .as_ref()
+            .is_none_or(|w| sql_parser::evaluate(w, row));
+        async move { keep }
+    });
+    let mut rows: RowStream = match parsed_query.limit {
+        Some(limit) => filtered.take(limit).boxed(),
+        None => filtered.boxed(),
+    };
+
+    let mut first: Vec<BTreeMap<String, QueryValue>> = Vec::new();
+    while first.len() < STREAM_CHUNK_ROWS {
+        match rows.next().await {
+            Some(Ok(row)) => first.push(row),
+            Some(Err(e)) => return Err(e),
+            None => break,
+        }
+    }
+    let sample: Vec<BTreeMap<String, QueryValue>> = first
+        .first()
+        .map(|row| vec![select_columns_row(row, parsed_query)])
+        .unwrap_or_default();
+    let columns = build_columns(parsed_query, &sample);
+    let col_names: Vec<String> = columns.iter().map(|c| c.name.clone()).collect();
+
+    let chained = stream::iter(first.into_iter().map(Ok)).chain(rows);
+    Ok(RowChunkPump::spawn(
+        columns,
+        move || async move { Ok(chained) },
+        move |row: BTreeMap<String, QueryValue>| project_row(&row, &col_names),
+    ))
 }


### PR DESCRIPTION
## What does this PR do?

Streams the Mixpanel export API's JSONL body incrementally instead of buffering the whole result, so plain reads deliver a first chunk early with bounded memory. Aggregation and ORDER BY still take the materialized path.

- Plain projection + WHERE + LIMIT streams via `RowChunkPump`; aggregation / `ORDER BY` (need the full buffered result) fall back to `run_query`.
- **Byte-line reader:** enable `reqwest` `stream` feature; lazy `\n`-splitter over the response body (UTF-8-safe), drops blank/malformed lines, flushes trailing partial at EOF, surfaces read errors.
- Fixed from the first buffered chunk (`STREAM_CHUNK_ROWS`); `WHERE` + `LIMIT` applied per-row so columns/types match the buffered path exactly.
- Extracted `build_columns` / `project_row` / `select_columns_row` and `build_export_url` / `parse_export_line` / `send_export_stream`; `run_query` + `execute_export` now share them. Type hints moved to `constants.rs`.

## Checklist

- [ ] I opened an issue first for non-trivial changes, or this is a small fix.
- [x] Tests added/updated for my change.
- [x] **I license my contribution under the MIT License**, per [CONTRIBUTING.md](../CONTRIBUTING.md). I confirm this is my original work, or that I have the right to submit it.
