### PR TITLE
[Feature] Streaming ingestion for Trino

### DIFF
--- a/crates/arris-engines/src/drivers/trino/api.rs
+++ b/crates/arris-engines/src/drivers/trino/api.rs
@@ -1,5 +1,6 @@
 use std::time::Duration;
 
+use futures::stream::{BoxStream, StreamExt};
 use reqwest::{Certificate, Client};
 use serde::Deserialize;
 use serde_json::Value;
@@ -7,6 +8,11 @@ use serde_json::Value;
 use crate::drivers::errors::Result;
 use crate::DriverError;
 
+/// One raw Trino row (JSON cells) or a paging error, as delivered by the lazy
+/// `nextUri` walk.
+pub(super) type RowStream = BoxStream<'static, std::result::Result<Vec<Value>, DriverError>>;
+
+#[derive(Clone)]
 pub(super) struct TrinoApi {
     http: Client,
     base_url: String,
@@ -59,9 +65,7 @@ impl TrinoApi {
         })
     }
 
-    /// Run a statement to completion, following `nextUri` links until the
-    /// query finishes, accumulating columns and rows along the way.
-    pub(super) async fn query(&self, sql: &str) -> Result<TrinoResponse> {
+    fn post_req(&self, sql: &str) -> reqwest::RequestBuilder {
         let mut req = self
             .http
             .post(format!("{}/v1/statement", self.base_url))
@@ -77,8 +81,13 @@ impl TrinoApi {
         if let Some(password) = &self.password {
             req = req.basic_auth(&self.user, Some(password));
         }
+        req
+    }
 
-        let mut page = self.send(req).await?;
+    /// Run a statement to completion, following `nextUri` links until the
+    /// query finishes, accumulating columns and rows along the way.
+    pub(super) async fn query(&self, sql: &str) -> Result<TrinoResponse> {
+        let mut page = self.send(self.post_req(sql)).await?;
 
         let mut columns: Vec<TrinoColumn> = Vec::new();
         let mut rows: Vec<Vec<Value>> = Vec::new();
@@ -124,6 +133,42 @@ impl TrinoApi {
         req
     }
 
+    /// Follow `nextUri` pages only until the columns are known, then hand back a
+    /// lazy stream that walks the remaining pages on demand. Trino applies
+    /// ORDER BY / aggregation / LIMIT server-side, so paged rows are already
+    /// final and stream without any in-driver reordering.
+    pub(super) async fn open_row_stream(&self, sql: &str) -> Result<(Vec<TrinoColumn>, RowStream)> {
+        let mut page = self.send(self.post_req(sql)).await?;
+        let mut columns: Vec<TrinoColumn> = Vec::new();
+        let mut buffered: Vec<Vec<Value>> = Vec::new();
+        loop {
+            if let Some(err) = page.error {
+                return Err(DriverError::QueryFailed(err.message));
+            }
+            if columns.is_empty() {
+                if let Some(cols) = page.columns.take() {
+                    columns = cols;
+                }
+            }
+            if let Some(data) = page.data.take() {
+                buffered.extend(data);
+            }
+            if !columns.is_empty() {
+                break;
+            }
+            match page.next_uri.take() {
+                Some(next) => page = self.send(self.authed_get(&next)).await?,
+                None => break,
+            }
+        }
+        let cursor = PageCursor {
+            api: self.clone(),
+            next_uri: page.next_uri.take(),
+            pending: buffered.into_iter(),
+        };
+        Ok((columns, cursor.into_row_stream()))
+    }
+
     async fn send(&self, req: reqwest::RequestBuilder) -> Result<StatementPage> {
         let resp = req
             .send()
@@ -138,6 +183,43 @@ impl TrinoApi {
             return Err(DriverError::QueryFailed(raw));
         }
         serde_json::from_str(&raw).map_err(|e| DriverError::QueryFailed(e.to_string()))
+    }
+}
+
+/// Lazy `nextUri` walk: drains the current page's buffered rows, then fetches
+/// the next page on demand. Owns a cheap `TrinoApi` clone so the stream outlives
+/// the connection guard.
+struct PageCursor {
+    api: TrinoApi,
+    next_uri: Option<String>,
+    pending: std::vec::IntoIter<Vec<Value>>,
+}
+
+impl PageCursor {
+    fn into_row_stream(self) -> RowStream {
+        futures::stream::unfold(self, |mut cursor| async move {
+            loop {
+                if let Some(row) = cursor.pending.next() {
+                    return Some((Ok(row), cursor));
+                }
+                let url = cursor.next_uri.take()?;
+                match cursor.api.send(cursor.api.authed_get(&url)).await {
+                    Ok(mut page) => {
+                        if let Some(err) = page.error {
+                            cursor.next_uri = None;
+                            return Some((Err(DriverError::QueryFailed(err.message)), cursor));
+                        }
+                        cursor.pending = page.data.take().unwrap_or_default().into_iter();
+                        cursor.next_uri = page.next_uri.take();
+                    }
+                    Err(e) => {
+                        cursor.next_uri = None;
+                        return Some((Err(e), cursor));
+                    }
+                }
+            }
+        })
+        .boxed()
     }
 }
 

--- a/crates/arris-engines/src/drivers/trino/mod.rs
+++ b/crates/arris-engines/src/drivers/trino/mod.rs
@@ -13,13 +13,13 @@ use crate::drivers::sql_builder::SqlBuilder;
 use crate::drivers::{DatabaseDriver, PaginationStrategy};
 use crate::{
     ConnectionConfig, DriverError, ExplainMode, MutationResult, PlanAttribute, PlanNode,
-    PlanResult, QueryLanguage, QueryResult, QueryValue, RowDelete, RowInsert, SchemaNode,
-    TableRef,
+    PlanResult, QueryLanguage, QueryResult, QueryStream, QueryValue, RowDelete, RowInsert,
+    SchemaNode, TableRef,
 };
 
 use api::TrinoApi;
 use schema::{build_trino_schema, build_trino_schema_tree};
-use values::response_to_query_result;
+use values::{response_to_query_result, row_chunk_stream};
 
 pub struct TrinoDriver {
     api: Mutex<Option<TrinoApi>>,
@@ -147,6 +147,28 @@ impl DatabaseDriver for TrinoDriver {
                 ..Default::default()
             })
         }
+    }
+
+    async fn run_query_stream(
+        &self,
+        text: &str,
+        params: &[QueryValue],
+        language: QueryLanguage,
+    ) -> Result<QueryStream> {
+        // Only row-returning statements stream; DML/DDL yield an update count and
+        // fall back to the materialized path.
+        if !self.looks_like_select(text) {
+            return Ok(QueryStream::from_materialized(
+                self.run_query(text, params, language).await?,
+            ));
+        }
+        // Clone the handle out of the guard so the paging task runs lock-free.
+        let api = {
+            let guard = self.api.lock().await;
+            guard.as_ref().ok_or(DriverError::NotConnected)?.clone()
+        };
+        let (columns, rows) = api.open_row_stream(text).await?;
+        Ok(QueryStream::Rows(row_chunk_stream(columns, rows)))
     }
 
     async fn explain_query(

--- a/crates/arris-engines/src/drivers/trino/values.rs
+++ b/crates/arris-engines/src/drivers/trino/values.rs
@@ -1,6 +1,8 @@
 use serde_json::Value;
 
-use super::api::TrinoResponse;
+use super::api::{RowStream, TrinoColumn, TrinoResponse};
+use crate::drivers::common::RowChunkPump;
+use crate::drivers::types::RowChunkStream;
 use crate::{ColumnSpec, QueryResult, QueryValue};
 
 pub(super) fn cell_to_value(cell: Value) -> QueryValue {
@@ -40,6 +42,18 @@ pub(super) fn response_to_query_result(resp: TrinoResponse, elapsed: f64) -> Que
         elapsed,
         ..Default::default()
     }
+}
+
+pub(super) fn row_chunk_stream(columns: Vec<TrinoColumn>, rows: RowStream) -> RowChunkStream {
+    let specs: Vec<ColumnSpec> = columns
+        .iter()
+        .map(|c| ColumnSpec::new(&c.name, &c.data_type))
+        .collect();
+    RowChunkPump::spawn(
+        specs,
+        move || async move { Ok(rows) },
+        |row: Vec<Value>| row.into_iter().map(cell_to_value).collect(),
+    )
 }
 
 #[cfg(test)]
@@ -84,6 +98,39 @@ mod tests {
         assert_eq!(
             cell_to_value(serde_json::json!({"a": 1})),
             QueryValue::Json(r#"{"a":1}"#.into())
+        );
+    }
+
+    #[tokio::test]
+    async fn row_chunk_stream_carries_columns_and_maps_cells() {
+        use futures::stream::{self, StreamExt};
+
+        let cols = vec![
+            TrinoColumn { name: "id".into(), data_type: "integer".into() },
+            TrinoColumn { name: "name".into(), data_type: "varchar".into() },
+        ];
+        let rows: RowStream = stream::iter(vec![
+            Ok(vec![serde_json::json!(1), serde_json::json!("alice")]),
+            Ok(vec![serde_json::json!(2), serde_json::json!("bob")]),
+        ])
+        .boxed();
+
+        let mut rs = row_chunk_stream(cols, rows);
+        assert_eq!(
+            rs.columns,
+            vec![ColumnSpec::new("id", "integer"), ColumnSpec::new("name", "varchar")]
+        );
+
+        let mut all: Vec<Vec<QueryValue>> = Vec::new();
+        while let Some(chunk) = rs.chunks.next().await {
+            all.extend(chunk.unwrap());
+        }
+        assert_eq!(
+            all,
+            vec![
+                vec![QueryValue::Int(1), QueryValue::Text("alice".into())],
+                vec![QueryValue::Int(2), QueryValue::Text("bob".into())],
+            ]
         );
     }
 }


### PR DESCRIPTION
## What does this PR do?

Streams Trino query results page-by-page over the `nextUri` walk instead of buffering the whole result before returning.

Changes:
- Trino runs `ORDER BY` / aggregation / `LIMIT` server-side and the driver never reorders, so every `SELECT`-like statement streams. DML/DDL (update-count) fall back to the materialized path.
- `TrinoApi` is now `Clone`; extracted `post_req`; new `open_row_stream` resolves columns from the first page, then a `PageCursor` lazily walks the remaining pages as a `RowStream`.
- Lock-free paging: the streaming path clones the connection handle out of the guard before spawning, so page fetches never hold the connection mutex across network I/O.
- `values.rs`: `row_chunk_stream` feeds the `RowStream` through the shared `RowChunkPump` (chunked, backpressured), mapping each JSON cell via `cell_to_value`.

## Checklist

- [ ] I opened an issue first for non-trivial changes, or this is a small fix.
- [x] Tests added/updated for my change.
- [x] **I license my contribution under the MIT License**, per [CONTRIBUTING.md](../CONTRIBUTING.md). I confirm this is my original work, or that I have the right to submit it.
