### PR TITLE
[Feature] Streaming ingestion for Snowflake

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -212,6 +212,7 @@ dependencies = [
  "directories",
  "dirs",
  "duckdb",
+ "flate2",
  "futures",
  "futures-util",
  "gcp-bigquery-client",

--- a/crates/arris-engines/Cargo.toml
+++ b/crates/arris-engines/Cargo.toml
@@ -23,7 +23,7 @@ duckdb = ["dep:duckdb"]
 oracle = ["dep:oracle-rs"]
 elasticsearch = ["dep:reqwest"]
 bigquery = ["dep:gcp-bigquery-client"]
-snowflake = ["dep:reqwest"]
+snowflake = ["dep:reqwest", "dep:flate2"]
 trino = ["dep:reqwest"]
 clickhouse = ["dep:clickhouse"]
 dynamodb = ["dep:aws-config", "dep:aws-sdk-dynamodb"]
@@ -101,6 +101,9 @@ async-stream = { version = "0.3", optional = true }
 # drivers: kafka + mixpanel + elasticsearch (shared reqwest)
 rdkafka = { version = "0.39", features = ["cmake-build", "ssl-vendored"], optional = true }
 reqwest = { workspace = true, optional = true, features = ["stream"] }
+
+# drivers: snowflake - gunzip out-of-line result chunks (pure-Rust miniz_oxide backend)
+flate2 = { version = "1.0", optional = true }
 
 # drivers: redis
 redis = { version = "1.2", features = ["tokio-rustls-comp", "connection-manager"], optional = true }

--- a/crates/arris-engines/src/drivers/snowflake/api.rs
+++ b/crates/arris-engines/src/drivers/snowflake/api.rs
@@ -1,14 +1,23 @@
 use std::collections::HashMap;
+use std::io::Read;
 use std::time::Duration;
 
+use flate2::read::GzDecoder;
+use futures::stream::{BoxStream, StreamExt};
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use url::Url;
 use uuid::Uuid;
 
+use super::constants::GZIP_MAGIC;
 use crate::drivers::errors::Result;
 use crate::DriverError;
 
+/// One raw Snowflake row (nullable string cells) or a paging error, as delivered
+/// by the lazy chunk-download walk.
+pub(super) type RowStream = BoxStream<'static, std::result::Result<Vec<Option<String>>, DriverError>>;
+
+#[derive(Clone)]
 pub(super) struct SnowflakeApi {
     http: Client,
     base_url: String,
@@ -95,7 +104,10 @@ impl SnowflakeApi {
         })
     }
 
-    pub(super) async fn query(&self, sql: &str) -> Result<QueryResponse> {
+    /// POST the statement and return its columns, inline first chunk, and the
+    /// descriptors for any out-of-line chunks. Snowflake caps the inline
+    /// `rowset` at one chunk (~12k rows); the rest live at pre-signed URLs.
+    async fn submit(&self, sql: &str) -> Result<QueryData> {
         let request_id = Uuid::new_v4();
         let url = format!(
             "{}/queries/v1/query-request?requestId={request_id}",
@@ -134,20 +146,130 @@ impl SnowflakeApi {
             serde_json::from_str(&raw).map_err(|e| DriverError::QueryFailed(e.to_string()))?;
 
         if !parsed.success {
-            return Err(DriverError::QueryFailed(format!(
-                "{}",
-                parsed.message.unwrap_or_else(|| "query failed".to_owned())
-            )));
+            return Err(DriverError::QueryFailed(
+                parsed.message.unwrap_or_else(|| "query failed".to_owned()),
+            ));
         }
 
         let data = parsed
             .data
             .ok_or_else(|| DriverError::QueryFailed("missing query response data".to_owned()))?;
 
-        Ok(QueryResponse {
+        Ok(QueryData {
             columns: data.row_types.unwrap_or_default(),
             rows: data.row_set.unwrap_or_default(),
+            chunks: data.chunks.unwrap_or_default(),
+            chunk_headers: data.chunk_headers.unwrap_or_default(),
         })
+    }
+
+    /// Run a statement to completion, materializing the inline chunk plus every
+    /// out-of-line chunk. Used by the buffered `run_query` path (schema
+    /// introspection, mutations, EXPLAIN).
+    pub(super) async fn query(&self, sql: &str) -> Result<QueryResponse> {
+        let mut data = self.submit(sql).await?;
+        for chunk in std::mem::take(&mut data.chunks) {
+            let rows = self.download_chunk(&chunk.url, &data.chunk_headers).await?;
+            data.rows.extend(rows);
+        }
+        Ok(QueryResponse {
+            columns: data.columns,
+            rows: data.rows,
+        })
+    }
+
+    /// Submit the statement and hand back a lazy stream: the inline chunk first,
+    /// then each out-of-line chunk downloaded on demand. Snowflake applies
+    /// ORDER BY / aggregation / LIMIT server-side, so chunks are already final
+    /// and stream without any in-driver reordering.
+    pub(super) async fn open_row_stream(&self, sql: &str) -> Result<(Vec<ColumnMeta>, RowStream)> {
+        let QueryData {
+            columns,
+            rows,
+            chunks,
+            chunk_headers,
+        } = self.submit(sql).await?;
+        let cursor = PageCursor {
+            api: self.clone(),
+            headers: chunk_headers,
+            chunks: chunks.into_iter(),
+            pending: rows.into_iter(),
+        };
+        Ok((columns, cursor.into_row_stream()))
+    }
+
+    async fn download_chunk(
+        &self,
+        url: &str,
+        headers: &HashMap<String, String>,
+    ) -> Result<Vec<Vec<Option<String>>>> {
+        let mut req = self.http.get(url);
+        for (k, v) in headers {
+            req = req.header(k, v);
+        }
+        let resp = req
+            .send()
+            .await
+            .map_err(|e| DriverError::QueryFailed(e.to_string()))?;
+        let status = resp.status();
+        let bytes = resp
+            .bytes()
+            .await
+            .map_err(|e| DriverError::QueryFailed(e.to_string()))?;
+        if !status.is_success() {
+            return Err(DriverError::QueryFailed(
+                String::from_utf8_lossy(&bytes).into_owned(),
+            ));
+        }
+        Self::decode_chunk_bytes(&bytes)
+    }
+
+    /// Chunk files are gzip-compressed JSON fragments: comma-separated row
+    /// arrays with no enclosing brackets. Inflate by signature, then wrap in
+    /// `[ ]` so the fragment parses as a row array.
+    fn decode_chunk_bytes(bytes: &[u8]) -> Result<Vec<Vec<Option<String>>>> {
+        let text = if bytes.starts_with(&GZIP_MAGIC) {
+            let mut s = String::new();
+            GzDecoder::new(bytes)
+                .read_to_string(&mut s)
+                .map_err(|e| DriverError::QueryFailed(format!("chunk gunzip: {e}")))?;
+            s
+        } else {
+            String::from_utf8_lossy(bytes).into_owned()
+        };
+        serde_json::from_str(&format!("[{text}]"))
+            .map_err(|e| DriverError::QueryFailed(format!("chunk parse: {e}")))
+    }
+}
+
+/// Lazy chunk walk: drains the current chunk's buffered rows, then downloads the
+/// next chunk on demand. Owns a cheap `SnowflakeApi` clone so the stream outlives
+/// the connection guard.
+struct PageCursor {
+    api: SnowflakeApi,
+    headers: HashMap<String, String>,
+    chunks: std::vec::IntoIter<ChunkMeta>,
+    pending: std::vec::IntoIter<Vec<Option<String>>>,
+}
+
+impl PageCursor {
+    fn into_row_stream(self) -> RowStream {
+        futures::stream::unfold(self, |mut cursor| async move {
+            loop {
+                if let Some(row) = cursor.pending.next() {
+                    return Some((Ok(row), cursor));
+                }
+                let chunk = cursor.chunks.next()?;
+                match cursor.api.download_chunk(&chunk.url, &cursor.headers).await {
+                    Ok(rows) => cursor.pending = rows.into_iter(),
+                    Err(e) => {
+                        cursor.chunks = Vec::new().into_iter();
+                        return Some((Err(e), cursor));
+                    }
+                }
+            }
+        })
+        .boxed()
     }
 }
 
@@ -189,6 +311,22 @@ struct RawResponseData {
     row_set: Option<Vec<Vec<Option<String>>>>,
     #[serde(rename = "rowtype")]
     row_types: Option<Vec<ColumnMeta>>,
+    chunks: Option<Vec<ChunkMeta>>,
+    chunk_headers: Option<HashMap<String, String>>,
+}
+
+#[derive(Deserialize)]
+struct ChunkMeta {
+    url: String,
+}
+
+/// A statement's parsed response: columns, the inline first chunk, and the
+/// descriptors + shared headers for any out-of-line chunks.
+struct QueryData {
+    columns: Vec<ColumnMeta>,
+    rows: Vec<Vec<Option<String>>>,
+    chunks: Vec<ChunkMeta>,
+    chunk_headers: HashMap<String, String>,
 }
 
 pub(super) struct QueryResponse {
@@ -206,6 +344,7 @@ pub(super) struct ColumnMeta {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::Write;
 
     #[test]
     fn login_response_deserializes() {
@@ -274,5 +413,66 @@ mod tests {
         let json = serde_json::to_value(&body).unwrap();
         assert_eq!(json["sqlText"], "SELECT 1");
         assert!(json.get("bindings").is_none());
+    }
+
+    #[test]
+    fn raw_response_parses_out_of_line_chunks() {
+        let json = r#"{
+            "data": {
+                "rowtype": [{"name":"N","type":"FIXED"}],
+                "rowset": [["0"]],
+                "chunks": [
+                    {"url":"https://sf/chunk/1","rowCount":100,"uncompressedSize":900,"compressedSize":300},
+                    {"url":"https://sf/chunk/2","rowCount":50}
+                ],
+                "chunkHeaders": {"x-amz-server-side-encryption-customer-key":"KEY"},
+                "queryResultFormat": "json"
+            },
+            "message": null,
+            "success": true
+        }"#;
+        let resp: RawResponse = serde_json::from_str(json).unwrap();
+        let data = resp.data.unwrap();
+        let chunks = data.chunks.unwrap();
+        assert_eq!(chunks.len(), 2);
+        assert_eq!(chunks[0].url, "https://sf/chunk/1");
+        assert_eq!(chunks[1].url, "https://sf/chunk/2");
+        let headers = data.chunk_headers.unwrap();
+        assert_eq!(
+            headers.get("x-amz-server-side-encryption-customer-key").unwrap(),
+            "KEY"
+        );
+    }
+
+    #[test]
+    fn decode_chunk_bytes_parses_plain_fragment() {
+        // Chunk files are bracket-less JSON fragments; the decoder wraps them.
+        let fragment = br#"["1","alice"],["2",null]"#;
+        let rows = SnowflakeApi::decode_chunk_bytes(fragment).unwrap();
+        assert_eq!(
+            rows,
+            vec![
+                vec![Some("1".to_owned()), Some("alice".to_owned())],
+                vec![Some("2".to_owned()), None],
+            ]
+        );
+    }
+
+    #[test]
+    fn decode_chunk_bytes_inflates_gzip_fragment() {
+        let fragment = br#"["3","bob"],["4","carol"]"#;
+        let mut enc = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+        enc.write_all(fragment).unwrap();
+        let gz = enc.finish().unwrap();
+        assert_eq!(&gz[..2], &GZIP_MAGIC);
+
+        let rows = SnowflakeApi::decode_chunk_bytes(&gz).unwrap();
+        assert_eq!(
+            rows,
+            vec![
+                vec![Some("3".to_owned()), Some("bob".to_owned())],
+                vec![Some("4".to_owned()), Some("carol".to_owned())],
+            ]
+        );
     }
 }

--- a/crates/arris-engines/src/drivers/snowflake/constants.rs
+++ b/crates/arris-engines/src/drivers/snowflake/constants.rs
@@ -1,0 +1,3 @@
+/// Gzip magic bytes. Result chunks arrive gzip-compressed even when the HTTP
+/// layer does not advertise `Content-Encoding: gzip`, so we inflate by signature.
+pub(super) const GZIP_MAGIC: [u8; 2] = [0x1f, 0x8b];

--- a/crates/arris-engines/src/drivers/snowflake/mod.rs
+++ b/crates/arris-engines/src/drivers/snowflake/mod.rs
@@ -1,4 +1,5 @@
 mod api;
+mod constants;
 mod definition;
 mod schema;
 mod values;
@@ -13,13 +14,13 @@ use crate::drivers::sql_builder::SqlBuilder;
 use crate::drivers::DatabaseDriver;
 use crate::{
     ConnectionConfig, DriverError, ExplainMode, MutationResult, PlanAttribute, PlanNode,
-    PlanResult, QueryLanguage, QueryResult, QueryValue, RowDelete, RowInsert, SchemaNode,
-    SchemaNodeKind, TableRef,
+    PlanResult, QueryLanguage, QueryResult, QueryStream, QueryValue, RowDelete, RowInsert,
+    SchemaNode, SchemaNodeKind, TableRef,
 };
 
 use api::SnowflakeApi;
 use schema::{assemble_database_node, database_names_from_show, SfColumn, SfObject};
-use values::response_to_query_result;
+use values::{response_to_query_result, row_chunk_stream};
 
 pub struct SnowflakeDriver {
     api: Mutex<Option<SnowflakeApi>>,
@@ -319,6 +320,28 @@ impl DatabaseDriver for SnowflakeDriver {
                 ..Default::default()
             })
         }
+    }
+
+    async fn run_query_stream(
+        &self,
+        text: &str,
+        params: &[QueryValue],
+        language: QueryLanguage,
+    ) -> Result<QueryStream> {
+        // Only row-returning statements stream; DML/DDL yield an update count and
+        // fall back to the materialized path.
+        if !self.looks_like_select(text) {
+            return Ok(QueryStream::from_materialized(
+                self.run_query(text, params, language).await?,
+            ));
+        }
+        // Clone the handle out of the guard so the chunk-download task runs lock-free.
+        let api = {
+            let guard = self.api.lock().await;
+            guard.as_ref().ok_or(DriverError::NotConnected)?.clone()
+        };
+        let (columns, rows) = api.open_row_stream(text).await?;
+        Ok(QueryStream::Rows(row_chunk_stream(columns, rows)))
     }
 
     async fn explain_query(

--- a/crates/arris-engines/src/drivers/snowflake/values.rs
+++ b/crates/arris-engines/src/drivers/snowflake/values.rs
@@ -1,5 +1,14 @@
-use super::api::QueryResponse;
+use super::api::{ColumnMeta, QueryResponse, RowStream};
+use crate::drivers::common::RowChunkPump;
+use crate::drivers::types::RowChunkStream;
 use crate::{ColumnSpec, QueryResult, QueryValue};
+
+fn cell_to_value(cell: Option<String>) -> QueryValue {
+    match cell {
+        Some(s) => QueryValue::Text(s).coerce_text(),
+        None => QueryValue::Null,
+    }
+}
 
 pub(super) fn response_to_query_result(resp: QueryResponse, elapsed: f64) -> QueryResult {
     let columns: Vec<ColumnSpec> = resp
@@ -11,14 +20,7 @@ pub(super) fn response_to_query_result(resp: QueryResponse, elapsed: f64) -> Que
     let rows: Vec<Vec<QueryValue>> = resp
         .rows
         .into_iter()
-        .map(|row| {
-            row.into_iter()
-                .map(|cell| match cell {
-                    Some(s) => QueryValue::Text(s).coerce_text(),
-                    None => QueryValue::Null,
-                })
-                .collect()
-        })
+        .map(|row| row.into_iter().map(cell_to_value).collect())
         .collect();
 
     QueryResult {
@@ -26,5 +28,64 @@ pub(super) fn response_to_query_result(resp: QueryResponse, elapsed: f64) -> Que
         rows,
         elapsed,
         ..Default::default()
+    }
+}
+
+pub(super) fn row_chunk_stream(columns: Vec<ColumnMeta>, rows: RowStream) -> RowChunkStream {
+    let specs: Vec<ColumnSpec> = columns
+        .iter()
+        .map(|c| ColumnSpec::new(&c.name, &c.data_type))
+        .collect();
+    RowChunkPump::spawn(
+        specs,
+        move || async move { Ok(rows) },
+        |row: Vec<Option<String>>| row.into_iter().map(cell_to_value).collect(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::stream::{self, StreamExt};
+
+    #[test]
+    fn cell_some_maps_to_coerced_text() {
+        assert_eq!(cell_to_value(Some("42".to_owned())), QueryValue::Text("42".to_owned()).coerce_text());
+    }
+
+    #[test]
+    fn cell_none_maps_to_null() {
+        assert_eq!(cell_to_value(None), QueryValue::Null);
+    }
+
+    #[tokio::test]
+    async fn row_chunk_stream_carries_columns_and_maps_cells() {
+        let cols = vec![
+            ColumnMeta { name: "id".into(), data_type: "FIXED".into() },
+            ColumnMeta { name: "name".into(), data_type: "TEXT".into() },
+        ];
+        let rows: RowStream = stream::iter(vec![
+            Ok(vec![Some("1".to_owned()), Some("alice".to_owned())]),
+            Ok(vec![Some("2".to_owned()), None]),
+        ])
+        .boxed();
+
+        let mut rs = row_chunk_stream(cols, rows);
+        assert_eq!(
+            rs.columns,
+            vec![ColumnSpec::new("id", "FIXED"), ColumnSpec::new("name", "TEXT")]
+        );
+
+        let mut all: Vec<Vec<QueryValue>> = Vec::new();
+        while let Some(chunk) = rs.chunks.next().await {
+            all.extend(chunk.unwrap());
+        }
+        assert_eq!(
+            all,
+            vec![
+                vec![QueryValue::Text("1".to_owned()).coerce_text(), QueryValue::Text("alice".to_owned()).coerce_text()],
+                vec![QueryValue::Text("2".to_owned()).coerce_text(), QueryValue::Null],
+            ]
+        );
     }
 }

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -212,6 +212,7 @@ dependencies = [
  "directories",
  "dirs",
  "duckdb",
+ "flate2",
  "futures",
  "futures-util",
  "gcp-bigquery-client",


### PR DESCRIPTION
## What does this PR do?

Streams Snowflake query results chunk-by-chunk instead of buffering the whole set: the inline first chunk lands early and remaining out-of-line chunks download on demand. Also fixes a latent truncation bug where the driver silently dropped every row past the ~12,288-row inline cap.

- Truncation fix: the driver ignored Snowflake's out-of-line result chunks entirely, capping every large result at the inline chunk (~12k rows). Confirmed live: a 500k-row query returned only 12,288. Both the streaming and buffered paths now return whole results.
- `SELECT`-like statements stream (Snowflake applies `ORDER BY` / aggregation / `LIMIT` server-side, so chunks are already final and need no in-driver reordering); DML/DDL fall back to the materialized update-count path.
- `api.rs`: parse `chunks` + `chunkHeaders`; `open_row_stream` + `PageCursor` walk the chunk URLs lazily; `SnowflakeApi` derives `Clone` so paging never holds the connection mutex across network I/O; `query()` now drains all chunks so the buffered path is whole too.
- Chunk decode: chunk files are gzip JSON fragments (comma-separated row arrays, no enclosing brackets); `gunzip` by magic-byte, wrap in `[ ]`, parse. New `flate2` dep (pure-Rust `miniz_oxide` backend).
- `row_chunk_stream`: feeds the `RowStream` through the shared `RowChunkPump` (chunked, backpressured).

## Checklist

- [ ] I opened an issue first for non-trivial changes, or this is a small fix.
- [x] Tests added/updated for my change.
- [x] **I license my contribution under the MIT License**, per [CONTRIBUTING.md](../CONTRIBUTING.md). I confirm this is my original work, or that I have the right to submit it.
