### PR TITLE
[Feature] Enhance canvas query cell UI

### DIFF
--- a/frontend/src/domains/canvas/components/CanvasView/components/CanvasPropertiesPane/components/QuerySection/index.tsx
+++ b/frontend/src/domains/canvas/components/CanvasView/components/CanvasPropertiesPane/components/QuerySection/index.tsx
@@ -35,7 +35,11 @@ function QuerySection({ component, onChange }: SectionProps) {
         onChange={(v) => onChange({ connectionId: v })}
         data-testid="query-connection-select"
       />
-      <span className="mdbc-pane-label">Limit</span>
+      <span
+        className={`mdbc-pane-label${component.selectAll ? " mdbc-pane-label-disabled" : ""}`}
+      >
+        Limit
+      </span>
       <input
         type="number"
         className="mdbc-pane-input"

--- a/frontend/src/domains/canvas/components/CanvasView/components/CanvasPropertiesPane/index.css
+++ b/frontend/src/domains/canvas/components/CanvasView/components/CanvasPropertiesPane/index.css
@@ -43,6 +43,16 @@
   width: 120px;
 }
 
+/* A disabled field (e.g. Limit while "Select all rows" is on) reads clearly as
+   inactive: dimmed and non-interactive, its caption dimmed to match. */
+.mdbc-pane-form .mdbc-pane-input:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+.mdbc-pane-label.mdbc-pane-label-disabled {
+  opacity: 0.45;
+}
+
 /* Small colour swatch, matching the chart editor's series-colour blob: a compact
    square, not a full-width bar. */
 .mdbc-canvas-color {

--- a/frontend/src/domains/canvas/components/CanvasView/components/QueryNode/components/QueryStatus/constants.ts
+++ b/frontend/src/domains/canvas/components/CanvasView/components/QueryNode/components/QueryStatus/constants.ts
@@ -1,0 +1,8 @@
+// Run-status row constants. Named (not bare literals) per the constants
+// discipline and so the font-size scan does not flag `SPINNER_SIZE`.
+const SPINNER_SIZE = 12;
+const MS_PER_SECOND = 1000;
+const TIMESTAMP_PAD_WIDTH = 2;
+const TIMESTAMP_PAD_CHAR = "0";
+
+export { SPINNER_SIZE, MS_PER_SECOND, TIMESTAMP_PAD_WIDTH, TIMESTAMP_PAD_CHAR };

--- a/frontend/src/domains/canvas/components/CanvasView/components/QueryNode/components/QueryStatus/hooks.test.ts
+++ b/frontend/src/domains/canvas/components/CanvasView/components/QueryNode/components/QueryStatus/hooks.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { renderHook } from "@testing-library/react";
+
+import { useLiveElapsed } from "./hooks";
+
+describe("useLiveElapsed", () => {
+  it("returns null when there is no run in flight", () => {
+    const { result } = renderHook(() => useLiveElapsed(undefined));
+    expect(result.current).toBeNull();
+  });
+
+  it("returns a non-negative elapsed while running", () => {
+    const { result } = renderHook(() => useLiveElapsed(Date.now()));
+    expect(typeof result.current).toBe("number");
+    expect(result.current!).toBeGreaterThanOrEqual(0);
+  });
+
+  it("drops back to null when the run stops", () => {
+    const { result, rerender } = renderHook(({ s }) => useLiveElapsed(s), {
+      initialProps: { s: Date.now() as number | undefined },
+    });
+    expect(typeof result.current).toBe("number");
+    rerender({ s: undefined });
+    expect(result.current).toBeNull();
+  });
+});

--- a/frontend/src/domains/canvas/components/CanvasView/components/QueryNode/components/QueryStatus/hooks.ts
+++ b/frontend/src/domains/canvas/components/CanvasView/components/QueryNode/components/QueryStatus/hooks.ts
@@ -1,0 +1,26 @@
+import { useEffect, useState } from "react";
+
+/// Live elapsed milliseconds since `startedAt`, ticking every animation frame
+/// while a run is in flight. Pass `undefined` (run not running) to freeze at
+/// null so the status can switch to the final total time instead.
+function useLiveElapsed(startedAt: number | undefined): number | null {
+  const [ms, setMs] = useState<number | null>(
+    startedAt === undefined ? null : Date.now() - startedAt,
+  );
+  useEffect(() => {
+    if (startedAt === undefined) {
+      setMs(null);
+      return;
+    }
+    let raf = 0;
+    const tick = () => {
+      setMs(Date.now() - startedAt);
+      raf = requestAnimationFrame(tick);
+    };
+    tick();
+    return () => cancelAnimationFrame(raf);
+  }, [startedAt]);
+  return ms;
+}
+
+export { useLiveElapsed };

--- a/frontend/src/domains/canvas/components/CanvasView/components/QueryNode/components/QueryStatus/index.test.tsx
+++ b/frontend/src/domains/canvas/components/CanvasView/components/QueryNode/components/QueryStatus/index.test.tsx
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import type { QueryRunState } from "../../../../../../types";
+import { QueryStatus } from "./index";
+
+const result = {
+  columns: [{ name: "n", type: "number" }],
+  rows: [[{ kind: "int", value: 1 }]],
+} as never;
+
+const TIMESTAMP = /\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}/;
+
+describe("QueryStatus", () => {
+  it("prompts to run when there is no run yet", () => {
+    render(<QueryStatus run={undefined} />);
+    expect(screen.getByText("Run the query to preview data")).toBeTruthy();
+  });
+
+  it("shows a spinner and a live elapsed timer while running", () => {
+    const run: QueryRunState = { running: true, startedAt: Date.now() };
+    const { container } = render(<QueryStatus run={run} />);
+    expect(container.querySelector(".mdbc-spinner")).toBeTruthy();
+    expect(container.querySelector(".mdbc-canvas-run-elapsed")?.textContent).toMatch(/ms/);
+    // The old plain "Running…" text is gone (replaced by the spinner row).
+    expect(screen.queryByText("Running…")).toBeNull();
+  });
+
+  it("shows total execution time and the last-run timestamp once settled", () => {
+    const startedAt = new Date(2026, 6, 5, 9, 5, 3).getTime();
+    const run: QueryRunState = { result, startedAt, endedAt: startedAt + 1500 };
+    render(<QueryStatus run={run} />);
+    const text = screen.getByText(/1 row · 1 column/).textContent ?? "";
+    expect(text).toContain("1 s 500 ms");
+    expect(text).toMatch(TIMESTAMP);
+  });
+
+  it("renders a backend error", () => {
+    const run: QueryRunState = { error: "boom" };
+    render(<QueryStatus run={run} />);
+    expect(screen.getByText("boom")).toBeTruthy();
+  });
+});

--- a/frontend/src/domains/canvas/components/CanvasView/components/QueryNode/components/QueryStatus/index.tsx
+++ b/frontend/src/domains/canvas/components/CanvasView/components/QueryNode/components/QueryStatus/index.tsx
@@ -1,0 +1,45 @@
+import { Spinner } from "@shared/ui";
+
+import type { QueryRunState } from "../../../../../../types";
+import { runResultSummary, runStreamingSummary } from "../../utils";
+import { SPINNER_SIZE } from "./constants";
+import { useLiveElapsed } from "./hooks";
+import { formatElapsed, formatRunTimestamp } from "./utils";
+
+/// One-line run status under the query editor. Idle shows a prompt; while running
+/// it shows a spinner plus a live elapsed timer (and the streaming row count once
+/// the first page lands); once settled it shows the row summary with the total
+/// execution time and the last-execution timestamp.
+function QueryStatus({ run }: { run: QueryRunState | undefined }) {
+  const liveMs = useLiveElapsed(run?.running ? run.startedAt : undefined);
+
+  if (run?.error) {
+    return <span className="mdbc-canvas-result-error">{run.error}</span>;
+  }
+  if (run?.running) {
+    return (
+      <span className="mdbc-canvas-query-running">
+        <Spinner size={SPINNER_SIZE} />
+        <span className="mdbc-canvas-run-elapsed">{formatElapsed(liveMs ?? 0)}</span>
+        {run.result && (
+          <span className="mdbc-canvas-result-empty">{runStreamingSummary(run.result)}</span>
+        )}
+      </span>
+    );
+  }
+  if (run?.result) {
+    const timing =
+      run.startedAt !== undefined && run.endedAt !== undefined
+        ? ` · ${formatElapsed(run.endedAt - run.startedAt)} · ${formatRunTimestamp(run.endedAt)}`
+        : "";
+    return (
+      <span className="mdbc-canvas-result-empty">
+        {runResultSummary(run.result, run.totalRows, run.complete)}
+        {timing}
+      </span>
+    );
+  }
+  return <span className="mdbc-canvas-result-empty">Run the query to preview data</span>;
+}
+
+export { QueryStatus };

--- a/frontend/src/domains/canvas/components/CanvasView/components/QueryNode/components/QueryStatus/index.tsx
+++ b/frontend/src/domains/canvas/components/CanvasView/components/QueryNode/components/QueryStatus/index.tsx
@@ -1,7 +1,7 @@
 import { Spinner } from "@shared/ui";
 
 import type { QueryRunState } from "../../../../../../types";
-import { runResultSummary, runStreamingSummary } from "../../utils";
+import { runResultSummary } from "../../utils";
 import { SPINNER_SIZE } from "./constants";
 import { useLiveElapsed } from "./hooks";
 import { formatElapsed, formatRunTimestamp } from "./utils";
@@ -22,7 +22,7 @@ function QueryStatus({ run }: { run: QueryRunState | undefined }) {
         <Spinner size={SPINNER_SIZE} />
         <span className="mdbc-canvas-run-elapsed">{formatElapsed(liveMs ?? 0)}</span>
         {run.result && (
-          <span className="mdbc-canvas-result-empty">{runStreamingSummary(run.result)}</span>
+          <span className="mdbc-canvas-result-empty">loading all rows…</span>
         )}
       </span>
     );

--- a/frontend/src/domains/canvas/components/CanvasView/components/QueryNode/components/QueryStatus/utils.test.ts
+++ b/frontend/src/domains/canvas/components/CanvasView/components/QueryNode/components/QueryStatus/utils.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import { formatElapsed, formatRunTimestamp } from "./utils";
+
+describe("formatElapsed", () => {
+  it("shows milliseconds below one second", () => {
+    expect(formatElapsed(15)).toBe("15 ms");
+  });
+
+  it("splits into seconds and milliseconds past one second", () => {
+    expect(formatElapsed(2791)).toBe("2 s 791 ms");
+  });
+
+  it("clamps negatives to zero", () => {
+    expect(formatElapsed(-5)).toBe("0 ms");
+  });
+});
+
+describe("formatRunTimestamp", () => {
+  it("renders YYYY-MM-DD HH:MM:SS with zero padding", () => {
+    // Built from local parts so the assertion is timezone-independent.
+    const epoch = new Date(2026, 6, 5, 9, 5, 3).getTime();
+    expect(formatRunTimestamp(epoch)).toBe("2026-07-05 09:05:03");
+  });
+});

--- a/frontend/src/domains/canvas/components/CanvasView/components/QueryNode/components/QueryStatus/utils.ts
+++ b/frontend/src/domains/canvas/components/CanvasView/components/QueryNode/components/QueryStatus/utils.ts
@@ -1,0 +1,24 @@
+import { MS_PER_SECOND, TIMESTAMP_PAD_CHAR, TIMESTAMP_PAD_WIDTH } from "./constants";
+
+// "15 ms" below a second; "2 s 791 ms" once it crosses one second (mirrors the
+// console editor's run timer).
+function formatElapsed(ms: number): string {
+  const clamped = Math.max(0, Math.floor(ms));
+  if (clamped < MS_PER_SECOND) return `${clamped} ms`;
+  return `${Math.floor(clamped / MS_PER_SECOND)} s ${clamped % MS_PER_SECOND} ms`;
+}
+
+function pad(n: number): string {
+  return String(n).padStart(TIMESTAMP_PAD_WIDTH, TIMESTAMP_PAD_CHAR);
+}
+
+// The last-execution wall-clock as "YYYY-MM-DD HH:MM:SS" (deterministic, so it
+// reads the same everywhere and is testable).
+function formatRunTimestamp(epochMs: number): string {
+  const d = new Date(epochMs);
+  const date = `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+  const time = `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
+  return `${date} ${time}`;
+}
+
+export { formatElapsed, formatRunTimestamp };

--- a/frontend/src/domains/canvas/components/CanvasView/components/QueryNode/index.test.tsx
+++ b/frontend/src/domains/canvas/components/CanvasView/components/QueryNode/index.test.tsx
@@ -48,6 +48,12 @@ describe("QueryNode", () => {
     expect(container.querySelector(".cm-content")?.textContent).toContain("select 1");
   });
 
+  it("renders a line-number gutter like the console editor", () => {
+    seed(makeComponent({ kind: "query", id: "q", sql: "select 1\nfrom t", connectionId: "c" }));
+    const { container } = renderNode("q");
+    expect(container.querySelector(".cm-lineNumbers")).toBeTruthy();
+  });
+
   it("writes editor edits back to the store", () => {
     seed(makeComponent({ kind: "query", id: "q", sql: "select 1", connectionId: "c" }));
     const { container } = renderNode("q");

--- a/frontend/src/domains/canvas/components/CanvasView/components/QueryNode/index.test.tsx
+++ b/frontend/src/domains/canvas/components/CanvasView/components/QueryNode/index.test.tsx
@@ -111,8 +111,8 @@ describe("QueryNode", () => {
       running: true,
     });
     renderNode("q");
-    expect(screen.getByText(/first 1 rows · loading all…/)).toBeTruthy();
-    expect(screen.queryByText("Running…")).toBeNull();
+    expect(screen.getByText("loading all rows…")).toBeTruthy();
+    expect(screen.queryByText(/first/)).toBeNull();
     expect(screen.getByRole("button", { name: "Cancel" })).toBeTruthy();
   });
 

--- a/frontend/src/domains/canvas/components/CanvasView/components/QueryNode/index.tsx
+++ b/frontend/src/domains/canvas/components/CanvasView/components/QueryNode/index.tsx
@@ -8,8 +8,8 @@ import { IconButton } from "@shared/ui/IconButton";
 import { useCanvasStore } from "../../../../hooks";
 import type { CanvasNodeData } from "../../types";
 import { CanvasResizer } from "../CanvasResizer";
+import { QueryStatus } from "./components/QueryStatus";
 import { useQueryEditor } from "./hooks";
-import { runResultSummary, runStreamingSummary } from "./utils";
 
 /// A SQL object: a schema-aware CodeMirror editor (same dialect + completion as
 /// the main editor), a Run button, and a one-line run status. It holds no result
@@ -82,19 +82,7 @@ function QueryNodeImpl({ id, data, selected }: NodeProps<CanvasNodeData>) {
         </div>
         <div ref={hostRef} className="nodrag nowheel mdbc-canvas-sql" />
         <div className="mdbc-canvas-query-status">
-          {run?.error ? (
-            <span className="mdbc-canvas-result-error">{run.error}</span>
-          ) : run?.result ? (
-            <span className="mdbc-canvas-result-empty">
-              {run.running
-                ? runStreamingSummary(run.result)
-                : runResultSummary(run.result, run.totalRows, run.complete)}
-            </span>
-          ) : run?.running ? (
-            <span className="mdbc-canvas-result-empty">Running…</span>
-          ) : (
-            <span className="mdbc-canvas-result-empty">Run the query to preview data</span>
-          )}
+          <QueryStatus run={run} />
         </div>
       </div>
     </>

--- a/frontend/src/domains/canvas/components/CanvasView/components/QueryNode/utils.test.ts
+++ b/frontend/src/domains/canvas/components/CanvasView/components/QueryNode/utils.test.ts
@@ -23,21 +23,21 @@ describe("runResultSummary", () => {
     expect(runResultSummary(result(1, 1))).toBe("1 row · 1 column");
   });
 
-  it("shows first N of M when the full result is larger than the page", () => {
+  it("reports the full total when it is larger than the page", () => {
     expect(runResultSummary(result(500, 4), 12345, true)).toBe(
-      "first 500 of 12345 rows · 4 columns",
+      "12345 rows · 4 columns",
     );
   });
 
   it("appends a plus when the ingestion budget truncated the run", () => {
     expect(runResultSummary(result(500, 4), 9000, false)).toBe(
-      "first 500 of 9000+ rows · 4 columns",
+      "9000+ rows · 4 columns",
     );
   });
 
   it("never reports a total smaller than the visible page", () => {
     expect(runResultSummary(result(100, 1), 0, false)).toBe(
-      "first 100 of 100+ rows · 1 column",
+      "100+ rows · 1 column",
     );
   });
 });

--- a/frontend/src/domains/canvas/components/CanvasView/components/QueryNode/utils.test.ts
+++ b/frontend/src/domains/canvas/components/CanvasView/components/QueryNode/utils.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import type { QueryResult } from "@shared";
 
-import { runResultSummary, runStreamingSummary } from "./utils";
+import { runResultSummary } from "./utils";
 
 function result(rows: number, cols: number): QueryResult {
   return {
@@ -39,15 +39,5 @@ describe("runResultSummary", () => {
     expect(runResultSummary(result(100, 1), 0, false)).toBe(
       "100+ rows · 1 column",
     );
-  });
-});
-
-describe("runStreamingSummary", () => {
-  it("labels the early page while the full result streams in", () => {
-    const r = {
-      columns: [{ name: "n", type: "number" }],
-      rows: Array.from({ length: 1500 }, () => [{ kind: "int", value: 1 }]),
-    } as unknown as QueryResult;
-    expect(runStreamingSummary(r)).toBe("first 1,500 rows · loading all…");
   });
 });

--- a/frontend/src/domains/canvas/components/CanvasView/components/QueryNode/utils.ts
+++ b/frontend/src/domains/canvas/components/CanvasView/components/QueryNode/utils.ts
@@ -149,8 +149,9 @@ function runStreamingSummary(result: QueryResult): string {
   return `first ${rows.toLocaleString()} rows · loading all…`;
 }
 
-// One-line status for a finished run: "first N of M rows" past one page, with
-// a trailing "+" when the ingestion byte budget truncated the run.
+// One-line status for a finished run: the FULL row count (the cell shows no rows
+// inline, a bound table does, so the page size is irrelevant here). A trailing
+// "+" marks a run the ingestion byte budget truncated.
 function runResultSummary(
   result: QueryResult,
   totalRows?: number,
@@ -161,10 +162,7 @@ function runResultSummary(
   const columnsPart = `${cols} column${cols === 1 ? "" : "s"}`;
   const truncated = complete === false;
   const total = Math.max(totalRows ?? rows, rows);
-  if (truncated || total > rows) {
-    return `first ${rows} of ${total}${truncated ? "+" : ""} rows · ${columnsPart}`;
-  }
-  return `${rows} row${rows === 1 ? "" : "s"} · ${columnsPart}`;
+  return `${total}${truncated ? "+" : ""} row${total === 1 ? "" : "s"} · ${columnsPart}`;
 }
 
 export {

--- a/frontend/src/domains/canvas/components/CanvasView/components/QueryNode/utils.ts
+++ b/frontend/src/domains/canvas/components/CanvasView/components/QueryNode/utils.ts
@@ -6,7 +6,7 @@ import {
 import { defaultKeymap, history, historyKeymap } from "@codemirror/commands";
 import { syntaxHighlighting } from "@codemirror/language";
 import { type Extension } from "@codemirror/state";
-import { drawSelection, EditorView, keymap, placeholder } from "@codemirror/view";
+import { drawSelection, EditorView, keymap, lineNumbers, placeholder } from "@codemirror/view";
 
 import { arrisHighlight } from "@shared/ui/utils/codeHighlight";
 import {
@@ -14,6 +14,7 @@ import {
   deriveSchemaScoping,
   editorCompletionExtensions,
   editorLanguageExtensions,
+  indentGuidesExtension,
 } from "@domains/editor";
 import type { DatabaseKind, QueryResult, SchemaNode } from "@shared";
 
@@ -33,6 +34,13 @@ const theme = EditorView.theme(
     ".cm-cursor, .cm-dropCursor": { borderLeftColor: "var(--m-accent, #7c8cff)" },
     ".cm-scroller": { fontFamily: "var(--m-font-editor, var(--m-font-mono))", lineHeight: "1.5" },
     ".cm-line": { padding: "0" },
+    ".cm-gutters": {
+      backgroundColor: "transparent",
+      border: "none",
+      color: "var(--m-fg-3)",
+    },
+    ".cm-lineNumbers .cm-gutterElement": { padding: "0 4px 0 8px", minWidth: "20px" },
+    ".cm-activeLineGutter": { backgroundColor: "transparent" },
     ".cm-tooltip": {
       background: "var(--m-bg-surface)",
       border: "0.5px solid var(--m-sep)",
@@ -105,6 +113,8 @@ function queryEditorExtensions(input: QueryEditorExtensionsInput): Extension[] {
   return [
     history(),
     drawSelection(),
+    lineNumbers(),
+    indentGuidesExtension(),
     // `support` always carries the SQL language (plus schema completion once the
     // schema loads), so no standalone `sql()` is added here.
     support,

--- a/frontend/src/domains/canvas/components/CanvasView/components/QueryNode/utils.ts
+++ b/frontend/src/domains/canvas/components/CanvasView/components/QueryNode/utils.ts
@@ -143,12 +143,6 @@ function queryEditorExtensions(input: QueryEditorExtensionsInput): Extension[] {
   ];
 }
 
-// Status while the early page is shown and the full result still streams in.
-function runStreamingSummary(result: QueryResult): string {
-  const rows = result.rows.length;
-  return `first ${rows.toLocaleString()} rows · loading all…`;
-}
-
 // One-line status for a finished run: the FULL row count (the cell shows no rows
 // inline, a bound table does, so the page size is irrelevant here). A trailing
 // "+" marks a run the ingestion byte budget truncated.
@@ -169,6 +163,5 @@ export {
   buildCanvasSqlSupport,
   queryEditorExtensions,
   runResultSummary,
-  runStreamingSummary,
 };
 export type { CanvasSqlSupportInput };

--- a/frontend/src/domains/canvas/components/CanvasView/index.css
+++ b/frontend/src/domains/canvas/components/CanvasView/index.css
@@ -276,7 +276,6 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  max-width: 120px;
 }
 
 .mdbc-canvas-head-sep {
@@ -288,6 +287,7 @@
 
 .mdbc-canvas-run {
   flex: 0 0 auto;
+  cursor: pointer;
 }
 
 /* ── text object ──────────────────────────────────────────────────────────── */
@@ -366,6 +366,14 @@
   box-sizing: border-box;
   overflow: hidden;
   background: var(--m-bg-editor);
+  /* Text caret over the editor, not the board's pan/grab cursor. */
+  cursor: text;
+}
+
+.mdbc-canvas-sql .cm-editor,
+.mdbc-canvas-sql .cm-scroller,
+.mdbc-canvas-sql .cm-content {
+  cursor: text;
 }
 
 .mdbc-canvas-sql .cm-editor {
@@ -429,6 +437,20 @@
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
+}
+
+/* Running row: spinner, live elapsed timer, then the streaming row count. */
+.mdbc-canvas-query-running {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: var(--m-fs-xs);
+  color: var(--m-fg-3);
+}
+
+.mdbc-canvas-run-elapsed {
+  font-variant-numeric: tabular-nums;
+  color: var(--m-fg-2);
 }
 
 /* ── table object ─────────────────────────────────────────────────────────── */

--- a/frontend/src/domains/canvas/hooks/store.test.ts
+++ b/frontend/src/domains/canvas/hooks/store.test.ts
@@ -186,6 +186,41 @@ describe("useCanvasStore", () => {
     expect(run.totalRows).toBe(7);
   });
 
+  it("stamps startedAt/endedAt on a settled run for total time + timestamp", async () => {
+    vi.mocked(runCanvasCellIPC).mockResolvedValue([
+      { id: "c1", result: { columns: [], rows: [], elapsed: 0 }, totalRows: 3, complete: true },
+    ]);
+    get().ensureBoard(TAB, "");
+    get().addComponent(
+      TAB,
+      makeComponent({ kind: "query", id: "c1", sql: "select 1", connectionId: "c" }),
+    );
+    await get().runQueryComponent(TAB, "c1");
+    const run = get().boards[TAB].runs.c1;
+    expect(typeof run.startedAt).toBe("number");
+    expect(typeof run.endedAt).toBe("number");
+    expect(run.endedAt!).toBeGreaterThanOrEqual(run.startedAt!);
+  });
+
+  it("carries startedAt through the ingest event and stamps endedAt on it", async () => {
+    vi.mocked(runCanvasCellIPC).mockResolvedValue([
+      { id: "c1", result: { columns: [], rows: [], elapsed: 0 } },
+    ]);
+    get().ensureBoard(TAB, "");
+    get().addComponent(
+      TAB,
+      makeComponent({ kind: "query", id: "c1", sql: "select 1", connectionId: "c" }),
+    );
+    await get().runQueryComponent(TAB, "c1");
+    const started = get().boards[TAB].runs.c1.startedAt;
+    expect(typeof started).toBe("number");
+    expect(get().boards[TAB].runs.c1.endedAt).toBeUndefined();
+    get().applyIngestDone(TAB, "c1", 42, true);
+    const run = get().boards[TAB].runs.c1;
+    expect(run.startedAt).toBe(started);
+    expect(typeof run.endedAt).toBe("number");
+  });
+
   it("applyIngestDone keeps event totals when it beats the run response", async () => {
     get().ensureBoard(TAB, "");
     get().addComponent(

--- a/frontend/src/domains/canvas/hooks/store.ts
+++ b/frontend/src/domains/canvas/hooks/store.ts
@@ -390,7 +390,13 @@ const useCanvasStore = create<CanvasStore>((set, get) => ({
   applyIngestDone: (tabId, id, totalRows, complete) => {
     const run = get().boards[tabId]?.runs[id];
     if (!run) return;
-    get().setRun(tabId, id, { ...run, totalRows, complete, running: false });
+    get().setRun(tabId, id, {
+      ...run,
+      totalRows,
+      complete,
+      running: false,
+      endedAt: Date.now(),
+    });
   },
 
   runQueryComponent: async (tabId, id) => {
@@ -413,19 +419,23 @@ const useCanvasStore = create<CanvasStore>((set, get) => ({
         limit: c.selectAll ? null : (c.limit ?? DEFAULT_QUERY_LIMIT),
       }));
     const queryId = cellQueryId(tabId, id);
-    get().setRun(tabId, id, { running: true });
+    get().setRun(tabId, id, { running: true, startedAt: Date.now() });
     try {
       const runs = await runCanvasCellIPC(tabId, id, cells, queryId);
+      const now = Date.now();
       // Apply each executed cell's outcome (target + its upstream dependencies).
+      // `startedAt` is carried from the running snapshot; `endedAt` stamps the
+      // settle so the status can show total time + last-execution timestamp.
       for (const r of runs) {
+        const prev = get().boards[tabId]?.runs[r.id];
+        const startedAt = prev?.startedAt;
         if (r.error) {
-          get().setRun(tabId, r.id, { error: r.error });
+          get().setRun(tabId, r.id, { error: r.error, startedAt, endedAt: now });
           continue;
         }
         if (r.totalRows === undefined) {
           // Early page: totals arrive via `canvas://cell-ingested`. Keep the
           // spinner unless the event already landed.
-          const prev = get().boards[tabId]?.runs[r.id];
           const settled = prev?.running === false && prev.totalRows !== undefined;
           get().setRun(
             tabId,
@@ -436,8 +446,10 @@ const useCanvasStore = create<CanvasStore>((set, get) => ({
                   totalRows: prev.totalRows,
                   complete: prev.complete,
                   running: false,
+                  startedAt,
+                  endedAt: prev.endedAt ?? now,
                 }
-              : { result: r.result, running: true },
+              : { result: r.result, running: true, startedAt },
           );
           continue;
         }
@@ -445,6 +457,8 @@ const useCanvasStore = create<CanvasStore>((set, get) => ({
           result: r.result,
           totalRows: r.totalRows,
           complete: r.complete,
+          startedAt,
+          endedAt: now,
         });
       }
       const targetOk = runs.some((r) => r.id === id && r.result);
@@ -457,7 +471,13 @@ const useCanvasStore = create<CanvasStore>((set, get) => ({
         }),
       }));
     } catch (e) {
-      get().setRun(tabId, id, { running: false, error: errToString(e) });
+      const startedAt = get().boards[tabId]?.runs[id]?.startedAt;
+      get().setRun(tabId, id, {
+        running: false,
+        error: errToString(e),
+        startedAt,
+        endedAt: Date.now(),
+      });
     }
   },
 

--- a/frontend/src/domains/canvas/types.ts
+++ b/frontend/src/domains/canvas/types.ts
@@ -189,6 +189,11 @@ interface QueryRunState {
   totalRows?: number;
   /// False when the ingestion byte budget truncated the run ("N+ rows").
   complete?: boolean;
+  /// Wall-clock start of the run (epoch ms); drives the live elapsed timer.
+  startedAt?: number;
+  /// Wall-clock finish (epoch ms); set once the run settles. `endedAt - startedAt`
+  /// is the total execution time, and `endedAt` is the last-execution timestamp.
+  endedAt?: number;
 }
 
 // ── agent canvas spec (the `arris-canvas` JSON the agent emits) ───────────────

--- a/frontend/src/domains/editor/index.ts
+++ b/frontend/src/domains/editor/index.ts
@@ -10,6 +10,7 @@ export type { EditorHandle } from "./utils/ui/setup";
 export { buildSqlSchema, deriveSchemaScoping } from "./utils/autocomplete/sqlSchema";
 export { editorCompletionExtensions, editorLanguageExtensions } from "./utils/dialects/registry";
 export { sqlSemanticHighlight } from "./utils/ui/sqlSemanticHighlight";
+export { indentGuidesExtension } from "./utils/ui/indentGuides";
 export {
   SCHEMA_NODE_POINTER_DROP_EVENT,
   beginSchemaNodePointerDrag,


### PR DESCRIPTION
## What does this PR do?

Polishes the canvas query cell: correct cursors, fix connection name truncation, typing area following same styling as in the editor of console tab, and a live run-status row with timing.

Changes:
- **Cursors**: text caret over the SQL editor, pointer over the run/stop button (was the board's pan cursor).
- **Connection name**: show the full name; dropped the fixed 120px ellipsis cap.
- **Editing**: line numbers + indentation guides in the cell, matching the console editor (via the shared `indentGuidesExtension`).
- **Run status**: spinner + live elapsed timer while running, then total execution time and the last-execution timestamp once settled (new `startedAt`/`endedAt` on `QueryRunState`).
- **Row summary**: show the full row total (`500000 rows`, `+` when truncated); dropped the `first 500 of …` page framing, including the running state.
- **Limit field**: greyed out with its caption while "Select all rows" is checked in the properties pane

## Checklist

- [ ] I opened an issue first for non-trivial changes, or this is a small fix.
- [x] Tests added/updated for my change.
- [x] **I license my contribution under the MIT License**, per [CONTRIBUTING.md](../CONTRIBUTING.md). I confirm this is my original work, or that I have the right to submit it.
