### PR TITLE
[Feature] Enhance canvas chart cell UI

### DIFF
--- a/docs/src/pages/canvas/index.astro
+++ b/docs/src/pages/canvas/index.astro
@@ -301,7 +301,7 @@ import Screenshot from "../../components/docs/Screenshot/Screenshot.astro";
   <ul>
     <li><strong>Query:</strong> title, connection, and a row <strong>Limit</strong> for the fetch (default 500), with a <strong>Select all rows</strong> toggle that fetches the full result instead. Changes apply on the next run. (The SQL is edited in the cell body.)</li>
     <li><strong>Table:</strong> source query and a preview-row cap (blank uses the default of 200).</li>
-    <li><strong>Chart:</strong> source query and a row cap (blank uses the default of 1000), then the full chart editor: type, axes (X/Y number formatting to abbreviate large values, decimals, a prefix/suffix like <code>$</code> or <code>%</code>, axis width, tick density, and label angles), appearance, legend, and colours, driven from the bound query's last run.</li>
+    <li><strong>Chart:</strong> source query and a row cap (blank uses the default of 1000), then the full chart editor: type, axes (X/Y number formatting to abbreviate large values, decimals, a prefix/suffix like <code>$</code> or <code>%</code>, axis width, horizontal padding so long labels are not clipped, tick density, and label angles), appearance, legend, and colours, driven from the bound query's last run.</li>
     <li><strong>Shape:</strong> fill colour (rectangles and ellipses), stroke colour and width, line style (solid, dashed, dotted), and corner radius (rectangles).</li>
     <li><strong>Text:</strong> font size, bold, alignment (left, center, right), and colour.</li>
     <li><strong>Sticky note:</strong> the tint.</li>

--- a/docs/src/pages/canvas/index.astro
+++ b/docs/src/pages/canvas/index.astro
@@ -301,7 +301,7 @@ import Screenshot from "../../components/docs/Screenshot/Screenshot.astro";
   <ul>
     <li><strong>Query:</strong> title, connection, and a row <strong>Limit</strong> for the fetch (default 500), with a <strong>Select all rows</strong> toggle that fetches the full result instead. Changes apply on the next run. (The SQL is edited in the cell body.)</li>
     <li><strong>Table:</strong> source query and a preview-row cap (blank uses the default of 200).</li>
-    <li><strong>Chart:</strong> source query and a row cap (blank uses the default of 1000), then the full chart editor: type, axes (including Y-axis number formatting to abbreviate large values), appearance, legend, and colours, driven from the bound query's last run.</li>
+    <li><strong>Chart:</strong> source query and a row cap (blank uses the default of 1000), then the full chart editor: type, axes (X/Y number formatting to abbreviate large values, decimals, a prefix/suffix like <code>$</code> or <code>%</code>, axis width, tick density, and label angles), appearance, legend, and colours, driven from the bound query's last run.</li>
     <li><strong>Shape:</strong> fill colour (rectangles and ellipses), stroke colour and width, line style (solid, dashed, dotted), and corner radius (rectangles).</li>
     <li><strong>Text:</strong> font size, bold, alignment (left, center, right), and colour.</li>
     <li><strong>Sticky note:</strong> the tint.</li>

--- a/docs/src/pages/canvas/index.astro
+++ b/docs/src/pages/canvas/index.astro
@@ -272,7 +272,7 @@ import Screenshot from "../../components/docs/Screenshot/Screenshot.astro";
       </tr>
       <tr>
         <td class="font-medium text-fg">Chart</td>
-        <td>Visualizes a query's result with the same chart editor as the results viewer (type, axes, series, aggregation, colours, legend, labels), refreshed whenever that query runs.</td>
+        <td>Visualizes a query's result with the same chart editor as the results viewer (type, axes, series, aggregation, colours, legend, labels), refreshed whenever that query runs. A title bar shows the chart's name (defaulting to the source query's), and any query or chart error surfaces in a status bar in red along the bottom.</td>
       </tr>
       <tr>
         <td class="font-medium text-fg">Text</td>
@@ -301,7 +301,7 @@ import Screenshot from "../../components/docs/Screenshot/Screenshot.astro";
   <ul>
     <li><strong>Query:</strong> title, connection, and a row <strong>Limit</strong> for the fetch (default 500), with a <strong>Select all rows</strong> toggle that fetches the full result instead. Changes apply on the next run. (The SQL is edited in the cell body.)</li>
     <li><strong>Table:</strong> source query and a preview-row cap (blank uses the default of 200).</li>
-    <li><strong>Chart:</strong> source query, then the full chart editor: type, axes, appearance, legend, and colours, driven from the bound query's last run.</li>
+    <li><strong>Chart:</strong> source query and a row cap (blank uses the default of 1000), then the full chart editor: type, axes (including Y-axis number formatting to abbreviate large values), appearance, legend, and colours, driven from the bound query's last run.</li>
     <li><strong>Shape:</strong> fill colour (rectangles and ellipses), stroke colour and width, line style (solid, dashed, dotted), and corner radius (rectangles).</li>
     <li><strong>Text:</strong> font size, bold, alignment (left, center, right), and colour.</li>
     <li><strong>Sticky note:</strong> the tint.</li>

--- a/docs/src/pages/canvas/index.astro
+++ b/docs/src/pages/canvas/index.astro
@@ -272,7 +272,7 @@ import Screenshot from "../../components/docs/Screenshot/Screenshot.astro";
       </tr>
       <tr>
         <td class="font-medium text-fg">Chart</td>
-        <td>Visualizes a query's result with the same chart editor as the results viewer (type, axes, series, aggregation, colours, legend, labels), refreshed whenever that query runs. A title bar shows the chart's name (defaulting to the source query's), and any query or chart error surfaces in a status bar in red along the bottom.</td>
+        <td>Visualizes a query's result with the same chart editor as the results viewer (type, axes, series, aggregation, colours, legend, labels), refreshed whenever that query runs. A title bar shows the chart's name (defaulting to the source query's) with a refresh button that re-runs the source query, and any query or chart error surfaces in a status bar in red along the bottom. While the source is loading the chart icon spins.</td>
       </tr>
       <tr>
         <td class="font-medium text-fg">Text</td>

--- a/frontend/src/domains/canvas/components/CanvasView/components/CanvasPropertiesPane/components/ChartSection/index.test.tsx
+++ b/frontend/src/domains/canvas/components/CanvasView/components/CanvasPropertiesPane/components/ChartSection/index.test.tsx
@@ -76,6 +76,13 @@ describe("ChartSection", () => {
     expect(lastCall.spec.title).toBeUndefined();
   });
 
+  it("shows the default max rows as the field value, not a placeholder", () => {
+    const { getByTestId } = render(
+      <ChartSection tabId={TAB} component={chart} onChange={vi.fn()} />,
+    );
+    expect((getByTestId("chart-max-rows") as HTMLInputElement).value).toBe("1000");
+  });
+
   it("edits the per-chart max rows", () => {
     const onChange = vi.fn();
     const { getByTestId } = render(

--- a/frontend/src/domains/canvas/components/CanvasView/components/CanvasPropertiesPane/components/ChartSection/index.tsx
+++ b/frontend/src/domains/canvas/components/CanvasView/components/CanvasPropertiesPane/components/ChartSection/index.tsx
@@ -34,7 +34,7 @@ function ChartSectionBody({
 
   return (
     <>
-      <div className="mdbc-pane-form">
+      <div className="mdbc-pane-form mdbc-canvas-chart-source">
         <span className="mdbc-pane-label">Source query</span>
         <Select
           value={component.sourceQueryId ?? ""}
@@ -48,8 +48,7 @@ function ChartSectionBody({
           type="number"
           min={1}
           className="mdbc-pane-input"
-          value={component.maxRows ?? ""}
-          placeholder={`Default (${DEFAULT_CHART_MAX_ROWS})`}
+          value={component.maxRows ?? DEFAULT_CHART_MAX_ROWS}
           onChange={(e) => {
             const n = Number(e.target.value);
             onChange({ maxRows: e.target.value === "" || n <= 0 ? undefined : n });

--- a/frontend/src/domains/canvas/components/CanvasView/components/CanvasPropertiesPane/index.css
+++ b/frontend/src/domains/canvas/components/CanvasView/components/CanvasPropertiesPane/index.css
@@ -53,6 +53,14 @@
   opacity: 0.45;
 }
 
+/* The chart cell's source/max-rows block sits above the shared chart-editor
+   sections; a rule below it separates it from the first (Data) section, matching
+   the dividers between the sections themselves. */
+.mdbc-canvas-chart-source {
+  padding-bottom: 10px;
+  border-bottom: 0.5px solid var(--m-sep);
+}
+
 /* Small colour swatch, matching the chart editor's series-colour blob: a compact
    square, not a full-width bar. */
 .mdbc-canvas-color {

--- a/frontend/src/domains/canvas/components/CanvasView/components/ChartNode/constants.ts
+++ b/frontend/src/domains/canvas/components/CanvasView/components/ChartNode/constants.ts
@@ -1,4 +1,8 @@
 /// Top-bar title shown when a chart is unbound (no source query) and untitled.
 const CHART_FALLBACK_TITLE = "Chart";
 
-export { CHART_FALLBACK_TITLE };
+/// Zero-pad width/char for the refreshed-at timestamp (YYYY-MM-DD HH:MM:SS).
+const CHART_TS_PAD_WIDTH = 2;
+const CHART_TS_PAD_CHAR = "0";
+
+export { CHART_FALLBACK_TITLE, CHART_TS_PAD_CHAR, CHART_TS_PAD_WIDTH };

--- a/frontend/src/domains/canvas/components/CanvasView/components/ChartNode/constants.ts
+++ b/frontend/src/domains/canvas/components/CanvasView/components/ChartNode/constants.ts
@@ -1,0 +1,4 @@
+/// Top-bar title shown when a chart is unbound (no source query) and untitled.
+const CHART_FALLBACK_TITLE = "Chart";
+
+export { CHART_FALLBACK_TITLE };

--- a/frontend/src/domains/canvas/components/CanvasView/components/ChartNode/index.test.tsx
+++ b/frontend/src/domains/canvas/components/CanvasView/components/ChartNode/index.test.tsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { act, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { ReactFlowProvider } from "reactflow";
 import type { NodeProps } from "reactflow";
 
@@ -245,6 +245,33 @@ describe("ChartNode", () => {
       useCanvasStore.getState().setRun(TAB, "q", { result, totalRows: 1000, running: false });
     });
     await waitFor(() => expect(queryCanvasCacheIPC).toHaveBeenCalled());
+  });
+
+  it("re-runs the bound source query when the refresh button is clicked", () => {
+    useCanvasStore.getState().ensureBoard(TAB, "");
+    useCanvasStore
+      .getState()
+      .addComponent(TAB, makeComponent({ kind: "query", id: "q", title: "Sales" }));
+    useCanvasStore.getState().addComponent(
+      TAB,
+      makeComponent({
+        kind: "chart",
+        id: "c",
+        sourceQueryId: "q",
+        spec: { kind: "bar", xColumn: "x", yColumns: ["y"] },
+      }),
+    );
+    const runSpy = vi
+      .spyOn(useCanvasStore.getState(), "runQueryComponent")
+      .mockResolvedValue(undefined);
+    render(
+      <ReactFlowProvider>
+        <ChartNode {...nodeProps("c")} />
+      </ReactFlowProvider>,
+    );
+    fireEvent.click(screen.getByLabelText("Refresh"));
+    expect(runSpy).toHaveBeenCalledWith(TAB, "q");
+    runSpy.mockRestore();
   });
 
   it("does not query when the source has not produced a result", () => {

--- a/frontend/src/domains/canvas/components/CanvasView/components/ChartNode/index.test.tsx
+++ b/frontend/src/domains/canvas/components/CanvasView/components/ChartNode/index.test.tsx
@@ -178,6 +178,36 @@ describe("ChartNode", () => {
     expect(screen.getByTestId("chart-node-error").textContent).toContain("No field named device");
   });
 
+  it("shows a sample-size and refresh status once the source has run", async () => {
+    useCanvasStore.getState().ensureBoard(TAB, "");
+    useCanvasStore
+      .getState()
+      .addComponent(TAB, makeComponent({ kind: "query", id: "q", title: "Sales" }));
+    useCanvasStore.getState().addComponent(
+      TAB,
+      makeComponent({
+        kind: "chart",
+        id: "c",
+        sourceQueryId: "q",
+        maxRows: 250,
+        spec: { kind: "bar", xColumn: "event_type", yColumns: [] },
+      }),
+    );
+    useCanvasStore.getState().setRun(TAB, "q", {
+      result: { columns: [{ name: "event_type", type_hint: "text" }], rows: [], elapsed: 0 },
+      totalRows: 1000,
+      endedAt: 1_700_000_000_000,
+    });
+    render(
+      <ReactFlowProvider>
+        <ChartNode {...nodeProps("c")} />
+      </ReactFlowProvider>,
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId("chart-node-status").textContent).toContain("up to 250 rows sampled"),
+    );
+  });
+
   it("does not query when the source has not produced a result", () => {
     useCanvasStore.getState().ensureBoard(TAB, "");
     useCanvasStore

--- a/frontend/src/domains/canvas/components/CanvasView/components/ChartNode/index.test.tsx
+++ b/frontend/src/domains/canvas/components/CanvasView/components/ChartNode/index.test.tsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import { ReactFlowProvider } from "reactflow";
 import type { NodeProps } from "reactflow";
 
@@ -206,6 +206,45 @@ describe("ChartNode", () => {
     await waitFor(() =>
       expect(screen.getByTestId("chart-node-status").textContent).toContain("up to 250 rows sampled"),
     );
+  });
+
+  it("waits for the source's full result to settle before querying the cache", async () => {
+    useCanvasStore.getState().ensureBoard(TAB, "");
+    useCanvasStore
+      .getState()
+      .addComponent(TAB, makeComponent({ kind: "query", id: "q", title: "Sales" }));
+    useCanvasStore.getState().addComponent(
+      TAB,
+      makeComponent({
+        kind: "chart",
+        id: "c",
+        sourceQueryId: "q",
+        spec: { kind: "bar", xColumn: "event_type", yColumns: ["amount"], aggregation: "sum" },
+      }),
+    );
+    const result = {
+      columns: [
+        { name: "event_type", type_hint: "text" },
+        { name: "amount", type_hint: "int" },
+      ],
+      rows: [],
+      elapsed: 0,
+    };
+    // Early page: the first page is in, but the full result has not drained yet
+    // (no totalRows), so the cell's table is not registered.
+    useCanvasStore.getState().setRun(TAB, "q", { result, running: true });
+    render(
+      <ReactFlowProvider>
+        <ChartNode {...nodeProps("c")} />
+      </ReactFlowProvider>,
+    );
+    expect(queryCanvasCacheIPC).not.toHaveBeenCalled();
+
+    // The drain completes: totals land and the table becomes queryable.
+    act(() => {
+      useCanvasStore.getState().setRun(TAB, "q", { result, totalRows: 1000, running: false });
+    });
+    await waitFor(() => expect(queryCanvasCacheIPC).toHaveBeenCalled());
   });
 
   it("does not query when the source has not produced a result", () => {

--- a/frontend/src/domains/canvas/components/CanvasView/components/ChartNode/index.test.tsx
+++ b/frontend/src/domains/canvas/components/CanvasView/components/ChartNode/index.test.tsx
@@ -81,6 +81,53 @@ describe("ChartNode", () => {
     expect(sql).toContain("FROM sales");
   });
 
+  it("defaults the top-bar title to the bound query's name", () => {
+    useCanvasStore.getState().ensureBoard(TAB, "");
+    useCanvasStore
+      .getState()
+      .addComponent(TAB, makeComponent({ kind: "query", id: "q", title: "Sales" }));
+    useCanvasStore.getState().addComponent(
+      TAB,
+      makeComponent({
+        kind: "chart",
+        id: "c",
+        sourceQueryId: "q",
+        spec: { kind: "bar", xColumn: "x", yColumns: ["y"] },
+      }),
+    );
+    render(
+      <ReactFlowProvider>
+        <ChartNode {...nodeProps("c")} />
+      </ReactFlowProvider>,
+    );
+    expect(screen.getByText("Sales")).toBeTruthy();
+  });
+
+  it("shows the source run error in the bottom status bar", () => {
+    useCanvasStore.getState().ensureBoard(TAB, "");
+    useCanvasStore
+      .getState()
+      .addComponent(TAB, makeComponent({ kind: "query", id: "q", title: "Sales" }));
+    useCanvasStore.getState().addComponent(
+      TAB,
+      makeComponent({
+        kind: "chart",
+        id: "c",
+        sourceQueryId: "q",
+        spec: { kind: "bar", xColumn: "x", yColumns: ["y"] },
+      }),
+    );
+    useCanvasStore
+      .getState()
+      .setRun(TAB, "q", { error: "query engine error: No field named device" });
+    render(
+      <ReactFlowProvider>
+        <ChartNode {...nodeProps("c")} />
+      </ReactFlowProvider>,
+    );
+    expect(screen.getByTestId("chart-node-error").textContent).toContain("No field named device");
+  });
+
   it("does not query when the source has not produced a result", () => {
     useCanvasStore.getState().ensureBoard(TAB, "");
     useCanvasStore

--- a/frontend/src/domains/canvas/components/CanvasView/components/ChartNode/index.test.tsx
+++ b/frontend/src/domains/canvas/components/CanvasView/components/ChartNode/index.test.tsx
@@ -3,9 +3,10 @@ import { render, screen, waitFor } from "@testing-library/react";
 import { ReactFlowProvider } from "reactflow";
 import type { NodeProps } from "reactflow";
 
-vi.mock("@domains/chart", () => ({
-  ChartView: () => <div data-testid="chart-view" />,
-}));
+vi.mock("@domains/chart", async (importActual) => {
+  const actual = await importActual<typeof import("@domains/chart")>();
+  return { ...actual, ChartView: () => <div data-testid="chart-view" /> };
+});
 
 vi.mock("../../../../ipc", () => ({
   queryCanvasCacheIPC: vi.fn(() => Promise.resolve({ columns: [], rows: [], elapsed: 0 })),
@@ -65,9 +66,17 @@ describe("ChartNode", () => {
         spec: { kind: "bar", xColumn: "event_type", yColumns: ["amount"], aggregation: "count" },
       }),
     );
-    useCanvasStore
-      .getState()
-      .setRun(TAB, "q", { result: { columns: [], rows: [], elapsed: 0 }, totalRows: 1000 });
+    useCanvasStore.getState().setRun(TAB, "q", {
+      result: {
+        columns: [
+          { name: "event_type", type_hint: "text" },
+          { name: "amount", type_hint: "int" },
+        ],
+        rows: [],
+        elapsed: 0,
+      },
+      totalRows: 1000,
+    });
     render(
       <ReactFlowProvider>
         <ChartNode {...nodeProps("c")} />
@@ -79,6 +88,47 @@ describe("ChartNode", () => {
     expect(sql).toContain('GROUP BY "event_type"');
     expect(sql).toContain('COUNT("amount")');
     expect(sql).toContain("FROM sales");
+  });
+
+  it("drops a stale axis column the source no longer has instead of querying it", async () => {
+    useCanvasStore.getState().ensureBoard(TAB, "");
+    useCanvasStore
+      .getState()
+      .addComponent(TAB, makeComponent({ kind: "query", id: "q", title: "Sales" }));
+    useCanvasStore.getState().addComponent(
+      TAB,
+      makeComponent({
+        kind: "chart",
+        id: "c",
+        sourceQueryId: "q",
+        // "amount" is not a column of the (re-pointed) source result below.
+        spec: { kind: "bar", xColumn: "event_type", yColumns: ["amount"], aggregation: "sum" },
+      }),
+    );
+    useCanvasStore.getState().setRun(TAB, "q", {
+      result: {
+        columns: [
+          { name: "event_type", type_hint: "text" },
+          { name: "duration_ms", type_hint: "int" },
+        ],
+        rows: [],
+        elapsed: 0,
+      },
+      totalRows: 1000,
+    });
+    render(
+      <ReactFlowProvider>
+        <ChartNode {...nodeProps("c")} />
+      </ReactFlowProvider>,
+    );
+    // No SQL is built for the missing column, so no cache query fires...
+    await waitFor(() => {
+      const chart = useCanvasStore
+        .getState()
+        .boards[TAB].doc.components.find((c) => c.id === "c");
+      expect(chart?.kind === "chart" && chart.spec.yColumns).toEqual([]);
+    });
+    expect(queryCanvasCacheIPC).not.toHaveBeenCalled();
   });
 
   it("defaults the top-bar title to the bound query's name", () => {

--- a/frontend/src/domains/canvas/components/CanvasView/components/ChartNode/index.tsx
+++ b/frontend/src/domains/canvas/components/CanvasView/components/ChartNode/index.tsx
@@ -2,6 +2,7 @@ import { memo, useEffect, useMemo, useState } from "react";
 import type { NodeProps } from "reactflow";
 import type { ChartSpec, QueryResult } from "@shared";
 import { ChartView, reconcileChartSpec } from "@domains/chart";
+import { IconButton } from "@shared/ui/IconButton";
 
 import { useCanvasStore } from "../../../../hooks";
 import { DEFAULT_CHART_MAX_ROWS } from "../../../../constants";
@@ -26,6 +27,7 @@ function ChartNodeImpl({ id, data, selected }: NodeProps<CanvasNodeData>) {
   const { tabId } = data;
   const board = useCanvasStore((s) => s.boards[tabId]);
   const updateComponent = useCanvasStore((s) => s.updateComponent);
+  const runQueryComponent = useCanvasStore((s) => s.runQueryComponent);
   const component = board?.doc.components.find((c) => c.id === id);
   const chart = component?.kind === "chart" ? component : undefined;
   const source = chart?.sourceQueryId
@@ -118,6 +120,18 @@ function ChartNodeImpl({ id, data, selected }: NodeProps<CanvasNodeData>) {
       <div className={`mdbc-canvas-node mdbc-canvas-chart nowheel${selected ? " selected" : ""}`}>
         <div className="mdbc-canvas-node-head">
           <span className="mdbc-canvas-node-title">{title}</span>
+          {chart?.sourceQueryId && (
+            <div className="mdbc-canvas-node-head-right">
+              <IconButton
+                icon="refreshCw"
+                label="Refresh"
+                size={14}
+                className="mdbc-canvas-run"
+                disabled={sourceRun?.running}
+                onClick={() => void runQueryComponent(tabId, chart.sourceQueryId!)}
+              />
+            </div>
+          )}
         </div>
         <div className="mdbc-canvas-chart-body">
           <ChartView

--- a/frontend/src/domains/canvas/components/CanvasView/components/ChartNode/index.tsx
+++ b/frontend/src/domains/canvas/components/CanvasView/components/ChartNode/index.tsx
@@ -4,11 +4,13 @@ import type { ChartSpec, QueryResult } from "@shared";
 import { ChartView, reconcileChartSpec } from "@domains/chart";
 
 import { useCanvasStore } from "../../../../hooks";
+import { DEFAULT_CHART_MAX_ROWS } from "../../../../constants";
 import { buildChartQuery, sanitizeCellTitle } from "../../../../utils";
 import { queryCanvasCacheIPC } from "../../../../ipc";
 import type { CanvasNodeData } from "../../types";
 import { CanvasResizer } from "../CanvasResizer";
 import { CHART_FALLBACK_TITLE } from "./constants";
+import { chartStatusSummary } from "./utils";
 
 /// The aggregated (or sampled) result the chart renders, fetched from the source
 /// cell's FULL cached result over IPC. Independent of the source's 500-row page.
@@ -96,6 +98,15 @@ function ChartNodeImpl({ id, data, selected }: NodeProps<CanvasNodeData>) {
   const title = component.title || sourceName || CHART_FALLBACK_TITLE;
   const error = sourceRun?.error ?? agg.error;
 
+  // Fall back to the source's result when the chart has nothing to plot yet (no
+  // measure picked), so ChartView shows "Configure the chart..." instead of the
+  // "Run a query" state even though the source already ran.
+  const viewResult = agg.result ?? (query ? undefined : sourceResult);
+  const sampleCap = maxRows && maxRows > 0 ? maxRows : DEFAULT_CHART_MAX_ROWS;
+  const status = sourceResult
+    ? chartStatusSummary(agg.result?.rows.length, sampleCap, sourceRun?.endedAt)
+    : null;
+
   return (
     <>
       <CanvasResizer tabId={tabId} id={id} visible={selected} />
@@ -106,14 +117,18 @@ function ChartNodeImpl({ id, data, selected }: NodeProps<CanvasNodeData>) {
         <div className="mdbc-canvas-chart-body">
           <ChartView
             spec={renderSpec}
-            result={agg.result}
+            result={viewResult}
             isRunning={sourceRun?.running || agg.loading}
             onEdit={() => {}}
           />
         </div>
         {error ? (
-          <div className="mdbc-canvas-chart-status" data-testid="chart-node-error">
+          <div className="mdbc-canvas-chart-status error" data-testid="chart-node-error">
             {error}
+          </div>
+        ) : status ? (
+          <div className="mdbc-canvas-chart-status" data-testid="chart-node-status">
+            {status}
           </div>
         ) : null}
       </div>

--- a/frontend/src/domains/canvas/components/CanvasView/components/ChartNode/index.tsx
+++ b/frontend/src/domains/canvas/components/CanvasView/components/ChartNode/index.tsx
@@ -8,6 +8,7 @@ import { buildChartQuery, sanitizeCellTitle } from "../../../../utils";
 import { queryCanvasCacheIPC } from "../../../../ipc";
 import type { CanvasNodeData } from "../../types";
 import { CanvasResizer } from "../CanvasResizer";
+import { CHART_FALLBACK_TITLE } from "./constants";
 
 /// The aggregated (or sampled) result the chart renders, fetched from the source
 /// cell's FULL cached result over IPC. Independent of the source's 500-row page.
@@ -30,6 +31,8 @@ function ChartNodeImpl({ id, data, selected }: NodeProps<CanvasNodeData>) {
   const sourceRun = chart?.sourceQueryId ? board?.runs[chart.sourceQueryId] : undefined;
   const sourceTitle =
     source?.kind === "query" && source.title ? sanitizeCellTitle(source.title) : undefined;
+  // Human-readable name of the bound query, used as the default cell title.
+  const sourceName = source?.kind === "query" ? source.title || source.id : undefined;
   const spec = chart?.spec;
   const maxRows = chart?.maxRows;
 
@@ -69,24 +72,31 @@ function ChartNodeImpl({ id, data, selected }: NodeProps<CanvasNodeData>) {
   // off; a sampled (raw) query keeps the spec as-is for the client mappers.
   const renderSpec = query?.aggregated ? { ...component.spec, aggregation: "none" as const } : component.spec;
 
+  // Title bar defaults to the bound query's name; the error surfaces in the
+  // bottom status bar (red) rather than as the chart body's empty message.
+  const title = component.title || sourceName || CHART_FALLBACK_TITLE;
+  const error = sourceRun?.error ?? agg.error;
+
   return (
     <>
       <CanvasResizer tabId={tabId} id={id} visible={selected} />
       <div className={`mdbc-canvas-node mdbc-canvas-chart nowheel${selected ? " selected" : ""}`}>
-        {component.title ? (
-          <div className="mdbc-canvas-node-head">
-            <span className="mdbc-canvas-node-title">{component.title}</span>
-          </div>
-        ) : null}
+        <div className="mdbc-canvas-node-head">
+          <span className="mdbc-canvas-node-title">{title}</span>
+        </div>
         <div className="mdbc-canvas-chart-body">
           <ChartView
             spec={renderSpec}
             result={agg.result}
             isRunning={sourceRun?.running || agg.loading}
-            error={sourceRun?.error ?? agg.error}
             onEdit={() => {}}
           />
         </div>
+        {error ? (
+          <div className="mdbc-canvas-chart-status" data-testid="chart-node-error">
+            {error}
+          </div>
+        ) : null}
       </div>
     </>
   );

--- a/frontend/src/domains/canvas/components/CanvasView/components/ChartNode/index.tsx
+++ b/frontend/src/domains/canvas/components/CanvasView/components/ChartNode/index.tsx
@@ -1,7 +1,7 @@
 import { memo, useEffect, useMemo, useState } from "react";
 import type { NodeProps } from "reactflow";
-import type { QueryResult } from "@shared";
-import { ChartView } from "@domains/chart";
+import type { ChartSpec, QueryResult } from "@shared";
+import { ChartView, reconcileChartSpec } from "@domains/chart";
 
 import { useCanvasStore } from "../../../../hooks";
 import { buildChartQuery, sanitizeCellTitle } from "../../../../utils";
@@ -23,6 +23,7 @@ interface ChartData {
 function ChartNodeImpl({ id, data, selected }: NodeProps<CanvasNodeData>) {
   const { tabId } = data;
   const board = useCanvasStore((s) => s.boards[tabId]);
+  const updateComponent = useCanvasStore((s) => s.updateComponent);
   const component = board?.doc.components.find((c) => c.id === id);
   const chart = component?.kind === "chart" ? component : undefined;
   const source = chart?.sourceQueryId
@@ -35,14 +36,31 @@ function ChartNodeImpl({ id, data, selected }: NodeProps<CanvasNodeData>) {
   const sourceName = source?.kind === "query" ? source.title || source.id : undefined;
   const spec = chart?.spec;
   const maxRows = chart?.maxRows;
+  const sourceResult = sourceRun?.result;
+
+  // Drop axis/series columns that the source no longer has (e.g. after the chart
+  // was re-pointed to a different query), so a stale column never reaches the SQL
+  // as `SUM("missing")`. Empty axes degrade to ChartView's "Customize chart" state
+  // instead of a hard schema error.
+  const effectiveSpec = useMemo(
+    () => (spec && sourceResult ? reconcileChartSpec(spec, sourceResult) : spec),
+    [spec, sourceResult],
+  );
 
   const query = useMemo(
-    () => (spec && sourceTitle ? buildChartQuery(spec, sourceTitle, maxRows) : null),
-    [spec, sourceTitle, maxRows],
+    () => (effectiveSpec && sourceTitle ? buildChartQuery(effectiveSpec, sourceTitle, maxRows) : null),
+    [effectiveSpec, sourceTitle, maxRows],
   );
 
   const [agg, setAgg] = useState<ChartData>({ loading: false });
-  const sourceResult = sourceRun?.result;
+
+  // Persist the reconciled spec so the properties pane reflects the valid columns.
+  useEffect(() => {
+    if (!spec || !effectiveSpec) return;
+    if (JSON.stringify(effectiveSpec) !== JSON.stringify(spec)) {
+      updateComponent(tabId, id, { spec: effectiveSpec as ChartSpec });
+    }
+  }, [tabId, id, spec, effectiveSpec, updateComponent]);
 
   useEffect(() => {
     // Aggregate only once the source has produced a result to read from.
@@ -70,7 +88,8 @@ function ChartNodeImpl({ id, data, selected }: NodeProps<CanvasNodeData>) {
 
   // The backend already aggregated, so turn ChartView's client-side aggregation
   // off; a sampled (raw) query keeps the spec as-is for the client mappers.
-  const renderSpec = query?.aggregated ? { ...component.spec, aggregation: "none" as const } : component.spec;
+  const drawSpec = effectiveSpec ?? component.spec;
+  const renderSpec = query?.aggregated ? { ...drawSpec, aggregation: "none" as const } : drawSpec;
 
   // Title bar defaults to the bound query's name; the error surfaces in the
   // bottom status bar (red) rather than as the chart body's empty message.

--- a/frontend/src/domains/canvas/components/CanvasView/components/ChartNode/index.tsx
+++ b/frontend/src/domains/canvas/components/CanvasView/components/ChartNode/index.tsx
@@ -56,6 +56,11 @@ function ChartNodeImpl({ id, data, selected }: NodeProps<CanvasNodeData>) {
 
   const [agg, setAgg] = useState<ChartData>({ loading: false });
 
+  // The backend registers the source cell's queryable table only once its full
+  // result has drained (signalled by `totalRows`); querying earlier, on the first
+  // page, hits an unregistered table ("table not found"). Wait for the settle.
+  const sourceSettled = sourceResult !== undefined && sourceRun?.totalRows !== undefined;
+
   // Persist the reconciled spec so the properties pane reflects the valid columns.
   useEffect(() => {
     if (!spec || !effectiveSpec) return;
@@ -65,8 +70,8 @@ function ChartNodeImpl({ id, data, selected }: NodeProps<CanvasNodeData>) {
   }, [tabId, id, spec, effectiveSpec, updateComponent]);
 
   useEffect(() => {
-    // Aggregate only once the source has produced a result to read from.
-    if (!query || !sourceResult) {
+    // Aggregate only once the source's full result is registered and queryable.
+    if (!query || !sourceSettled) {
       setAgg({ loading: false });
       return;
     }
@@ -84,7 +89,7 @@ function ChartNodeImpl({ id, data, selected }: NodeProps<CanvasNodeData>) {
     return () => {
       cancelled = true;
     };
-  }, [tabId, query, sourceResult]);
+  }, [tabId, query, sourceSettled]);
 
   if (!component || component.kind !== "chart") return null;
 

--- a/frontend/src/domains/canvas/components/CanvasView/components/ChartNode/utils.test.ts
+++ b/frontend/src/domains/canvas/components/CanvasView/components/ChartNode/utils.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import { chartStatusSummary, formatRefreshedAt } from "./utils";
+
+describe("chartStatusSummary", () => {
+  it("states just the sample cap when nothing is plotted yet", () => {
+    expect(chartStatusSummary(undefined, 1000, undefined)).toBe("up to 1,000 rows sampled");
+  });
+
+  it("includes the plotted count and the refresh timestamp", () => {
+    const summary = chartStatusSummary(50, 1000, 1_700_000_000_000);
+    expect(summary).toContain("50 plotted · up to 1,000 rows sampled · ");
+    expect(summary).toMatch(/\d{4}-\d\d-\d\d \d\d:\d\d:\d\d$/);
+  });
+});
+
+describe("formatRefreshedAt", () => {
+  it("is empty until the source settles", () => {
+    expect(formatRefreshedAt(undefined)).toBe("");
+  });
+
+  it("formats an epoch as YYYY-MM-DD HH:MM:SS", () => {
+    expect(formatRefreshedAt(1_700_000_000_000)).toMatch(/^\d{4}-\d\d-\d\d \d\d:\d\d:\d\d$/);
+  });
+});

--- a/frontend/src/domains/canvas/components/CanvasView/components/ChartNode/utils.test.ts
+++ b/frontend/src/domains/canvas/components/CanvasView/components/ChartNode/utils.test.ts
@@ -9,7 +9,7 @@ describe("chartStatusSummary", () => {
 
   it("includes the plotted count and the refresh timestamp", () => {
     const summary = chartStatusSummary(50, 1000, 1_700_000_000_000);
-    expect(summary).toContain("50 plotted · up to 1,000 rows sampled · ");
+    expect(summary).toContain("50 data points · up to 1,000 rows sampled · ");
     expect(summary).toMatch(/\d{4}-\d\d-\d\d \d\d:\d\d:\d\d$/);
   });
 });

--- a/frontend/src/domains/canvas/components/CanvasView/components/ChartNode/utils.ts
+++ b/frontend/src/domains/canvas/components/CanvasView/components/ChartNode/utils.ts
@@ -1,0 +1,31 @@
+import { CHART_TS_PAD_CHAR, CHART_TS_PAD_WIDTH } from "./constants";
+
+function pad(n: number): string {
+  return String(n).padStart(CHART_TS_PAD_WIDTH, CHART_TS_PAD_CHAR);
+}
+
+// The last-refresh wall-clock as "YYYY-MM-DD HH:MM:SS" (matches the query and
+// table cells), or "" when the source has not settled yet.
+function formatRefreshedAt(epochMs: number | undefined): string {
+  if (epochMs === undefined) return "";
+  const d = new Date(epochMs);
+  const date = `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+  const time = `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
+  return `${date} ${time}`;
+}
+
+// The chart footer status: how many marks are plotted, the row-sample cap driven
+// by the properties pane's "Max rows", and when the source last refreshed.
+// `plotted` is undefined until the chart has a plottable result.
+function chartStatusSummary(
+  plotted: number | undefined,
+  sampleCap: number,
+  endedAt: number | undefined,
+): string {
+  const cap = `up to ${sampleCap.toLocaleString()} rows sampled`;
+  const base = plotted != null ? `${plotted.toLocaleString()} plotted · ${cap}` : cap;
+  const ts = formatRefreshedAt(endedAt);
+  return ts ? `${base} · ${ts}` : base;
+}
+
+export { chartStatusSummary, formatRefreshedAt };

--- a/frontend/src/domains/canvas/components/CanvasView/components/ChartNode/utils.ts
+++ b/frontend/src/domains/canvas/components/CanvasView/components/ChartNode/utils.ts
@@ -23,7 +23,7 @@ function chartStatusSummary(
   endedAt: number | undefined,
 ): string {
   const cap = `up to ${sampleCap.toLocaleString()} rows sampled`;
-  const base = plotted != null ? `${plotted.toLocaleString()} plotted · ${cap}` : cap;
+  const base = plotted != null ? `${plotted.toLocaleString()} data points · ${cap}` : cap;
   const ts = formatRefreshedAt(endedAt);
   return ts ? `${base} · ${ts}` : base;
 }

--- a/frontend/src/domains/canvas/components/CanvasView/index.css
+++ b/frontend/src/domains/canvas/components/CanvasView/index.css
@@ -548,16 +548,20 @@
   position: relative;
 }
 
-/* Bottom status bar: shows the query/chart error in red. Only rendered when
-   something went wrong; wraps long schema-error text. */
+/* Bottom status bar: the sample-size and last-refresh readout (muted), or the
+   query/chart error in red (.error). Wraps long schema-error text. */
 .mdbc-canvas-chart-status {
   flex: 0 0 auto;
   padding: 6px 10px;
   border-top: 1px solid var(--m-sep);
   font-size: var(--m-fs-xs);
-  color: var(--m-red);
+  color: var(--m-fg-3);
   white-space: pre-wrap;
   overflow-wrap: anywhere;
+}
+
+.mdbc-canvas-chart-status.error {
+  color: var(--m-red);
 }
 
 /* ── sticky note ──────────────────────────────────────────────────────────── */

--- a/frontend/src/domains/canvas/components/CanvasView/index.css
+++ b/frontend/src/domains/canvas/components/CanvasView/index.css
@@ -548,6 +548,18 @@
   position: relative;
 }
 
+/* Bottom status bar: shows the query/chart error in red. Only rendered when
+   something went wrong; wraps long schema-error text. */
+.mdbc-canvas-chart-status {
+  flex: 0 0 auto;
+  padding: 6px 10px;
+  border-top: 1px solid var(--m-sep);
+  font-size: var(--m-fs-xs);
+  color: var(--m-red);
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
 /* ── sticky note ──────────────────────────────────────────────────────────── */
 
 .mdbc-canvas-sticky {

--- a/frontend/src/domains/canvas/components/CanvasView/index.css
+++ b/frontend/src/domains/canvas/components/CanvasView/index.css
@@ -200,6 +200,14 @@
   border-width: 1.5px;
 }
 
+/* The visible edge stays a hairline, but the grabbable strip extends 6px to
+   either side so width/height are easy to drag from the edge. */
+.mdbc-canvas-resize-line::before {
+  content: "";
+  position: absolute;
+  inset: -6px;
+}
+
 .mdbc-canvas-resize-handle {
   width: 16px;
   height: 16px;

--- a/frontend/src/domains/canvas/components/CanvasView/index.css
+++ b/frontend/src/domains/canvas/components/CanvasView/index.css
@@ -209,6 +209,15 @@
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
 }
 
+/* The visible dot stays 16px, but the grabbable area extends 10px past it on
+   every side so the pointer catches the corner without pixel-hunting. */
+.mdbc-canvas-resize-handle::before {
+  content: "";
+  position: absolute;
+  inset: -10px;
+  border-radius: 50%;
+}
+
 /* ── object node base ─────────────────────────────────────────────────────── */
 
 .mdbc-canvas-node {

--- a/frontend/src/domains/canvas/components/CanvasView/index.css
+++ b/frontend/src/domains/canvas/components/CanvasView/index.css
@@ -200,12 +200,12 @@
   border-width: 1.5px;
 }
 
-/* The visible edge stays a hairline, but the grabbable strip extends 6px to
+/* The visible edge stays a hairline, but the grabbable strip extends 12px to
    either side so width/height are easy to drag from the edge. */
 .mdbc-canvas-resize-line::before {
   content: "";
   position: absolute;
-  inset: -6px;
+  inset: -12px;
 }
 
 .mdbc-canvas-resize-handle {
@@ -217,12 +217,12 @@
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
 }
 
-/* The visible dot stays 16px, but the grabbable area extends 10px past it on
+/* The visible dot stays 16px, but the grabbable area extends 20px past it on
    every side so the pointer catches the corner without pixel-hunting. */
 .mdbc-canvas-resize-handle::before {
   content: "";
   position: absolute;
-  inset: -10px;
+  inset: -20px;
   border-radius: 50%;
 }
 

--- a/frontend/src/domains/chart/components/ChartEditorPanel/components/ChartEditorContent/index.tsx
+++ b/frontend/src/domains/chart/components/ChartEditorPanel/components/ChartEditorContent/index.tsx
@@ -15,6 +15,7 @@ import {
   LEGEND_POSITIONS,
   LINE_STYLE_KINDS,
   LINE_STYLES,
+  NUMBER_FORMATS,
   SERIES_COLUMN_KINDS,
   SORT_OPTIONS,
   STACK_KINDS,
@@ -245,6 +246,18 @@ function AxesSection({ pane }: { pane: ChartEditorPanelViewModel }) {
             label={scale === "linear" ? "Linear" : "Log"}
             active={(style?.yScale ?? "linear") === scale}
             onClick={() => pane.onChangeYAxisScale(scale)}
+          />
+        ))}
+      </div>
+
+      <label className="mdbc-pane-label">Y-axis number format</label>
+      <div className="mdbc-inline-row with-margin">
+        {NUMBER_FORMATS.map((format) => (
+          <ToggleBtn
+            key={format.value}
+            label={format.label}
+            active={(style?.yNumberFormat ?? "default") === format.value}
+            onClick={() => pane.onChangeYNumberFormat(format.value)}
           />
         ))}
       </div>

--- a/frontend/src/domains/chart/components/ChartEditorPanel/components/ChartEditorContent/index.tsx
+++ b/frontend/src/domains/chart/components/ChartEditorPanel/components/ChartEditorContent/index.tsx
@@ -322,6 +322,16 @@ function AxesSection({ pane }: { pane: ChartEditorPanelViewModel }) {
         onChange={(event) => pane.onChangeYAxisWidth(event.target.value)}
       />
 
+      <label className="mdbc-pane-label">Horizontal padding</label>
+      <input
+        className="mdbc-pane-input"
+        type="number"
+        min={0}
+        placeholder="Default (16)"
+        value={style?.plotPaddingX ?? ""}
+        onChange={(event) => pane.onChangePlotPaddingX(event.target.value)}
+      />
+
       <label className="mdbc-pane-label">Y tick count</label>
       <input
         className="mdbc-pane-input"

--- a/frontend/src/domains/chart/components/ChartEditorPanel/components/ChartEditorContent/index.tsx
+++ b/frontend/src/domains/chart/components/ChartEditorPanel/components/ChartEditorContent/index.tsx
@@ -238,6 +238,18 @@ function AxesSection({ pane }: { pane: ChartEditorPanelViewModel }) {
         ))}
       </div>
 
+      <label className="mdbc-pane-label">Y-label angle</label>
+      <div className="mdbc-inline-row with-margin">
+        {LABEL_ANGLES.map((angle) => (
+          <ToggleBtn
+            key={angle}
+            label={`${angle}°`}
+            active={(style?.yLabelAngle ?? 0) === angle}
+            onClick={() => pane.onChangeYLabelAngle(angle)}
+          />
+        ))}
+      </div>
+
       <label className="mdbc-pane-label">Y-axis scale</label>
       <div className="mdbc-inline-row with-margin">
         {Y_AXIS_SCALES.map((scale) => (
@@ -260,6 +272,76 @@ function AxesSection({ pane }: { pane: ChartEditorPanelViewModel }) {
             onClick={() => pane.onChangeYNumberFormat(format.value)}
           />
         ))}
+      </div>
+
+      <label className="mdbc-pane-label">X-axis number format</label>
+      <div className="mdbc-inline-row with-margin">
+        {NUMBER_FORMATS.map((format) => (
+          <ToggleBtn
+            key={format.value}
+            label={format.label}
+            active={(style?.xNumberFormat ?? "default") === format.value}
+            onClick={() => pane.onChangeXNumberFormat(format.value)}
+          />
+        ))}
+      </div>
+
+      <label className="mdbc-pane-label">Y decimals</label>
+      <input
+        className="mdbc-pane-input"
+        type="number"
+        min={0}
+        placeholder="Auto"
+        value={style?.yDecimals ?? ""}
+        onChange={(event) => pane.onChangeYDecimals(event.target.value)}
+      />
+
+      <label className="mdbc-pane-label">Y prefix / suffix</label>
+      <div className="mdbc-range-row">
+        <input
+          className="mdbc-pane-input compact"
+          placeholder="$"
+          value={style?.yPrefix ?? ""}
+          onChange={(event) => pane.onChangeYPrefix(event.target.value)}
+        />
+        <input
+          className="mdbc-pane-input compact"
+          placeholder="%"
+          value={style?.ySuffix ?? ""}
+          onChange={(event) => pane.onChangeYSuffix(event.target.value)}
+        />
+      </div>
+
+      <label className="mdbc-pane-label">Y-axis width</label>
+      <input
+        className="mdbc-pane-input"
+        type="number"
+        min={0}
+        placeholder="Auto"
+        value={style?.yAxisWidth ?? ""}
+        onChange={(event) => pane.onChangeYAxisWidth(event.target.value)}
+      />
+
+      <label className="mdbc-pane-label">Y tick count</label>
+      <input
+        className="mdbc-pane-input"
+        type="number"
+        min={0}
+        placeholder="Auto"
+        value={style?.yTickCount ?? ""}
+        onChange={(event) => pane.onChangeYTickCount(event.target.value)}
+      />
+
+      <div className="mdbc-check-row-group">
+        <label className="mdbc-check-row">
+          <input
+            type="checkbox"
+            className="mdbc-checkbox"
+            checked={style?.yAllowDecimals !== false}
+            onChange={(event) => pane.onChangeYAllowDecimals(event.target.checked)}
+          />
+          Allow decimal ticks
+        </label>
       </div>
     </Section>
   );

--- a/frontend/src/domains/chart/components/ChartEditorPanel/constants.ts
+++ b/frontend/src/domains/chart/components/ChartEditorPanel/constants.ts
@@ -7,6 +7,7 @@ import type {
   CurveType,
   LegendPosition,
   LineStyle,
+  NumberFormat,
   SortOrder,
   StackMode,
   YAxisScale,
@@ -90,6 +91,12 @@ const LEGEND_POSITIONS: LegendPosition[] = ["top", "bottom", "left", "right"];
 const STACK_MODES: StackMode[] = ["none", "stacked", "percent"];
 const Y_AXIS_SCALES: YAxisScale[] = ["linear", "log"];
 
+const NUMBER_FORMATS: ChartEditorOption<NumberFormat>[] = [
+  { value: "default", label: "Default" },
+  { value: "compact", label: "Compact" },
+  { value: "scientific", label: "Scientific" },
+];
+
 export {
   AGGREGATIONS,
   AGGREGATION_KINDS,
@@ -105,6 +112,7 @@ export {
   LEGEND_POSITIONS,
   LINE_STYLE_KINDS,
   LINE_STYLES,
+  NUMBER_FORMATS,
   SORT_OPTIONS,
   STACK_KINDS,
   STACK_MODES,

--- a/frontend/src/domains/chart/components/ChartEditorPanel/types.ts
+++ b/frontend/src/domains/chart/components/ChartEditorPanel/types.ts
@@ -53,6 +53,14 @@ interface ChartEditorPanelViewModel {
   onChangeXTickInterval: (value: string) => void;
   onChangeYAxisScale: (value: YAxisScale) => void;
   onChangeYNumberFormat: (value: NumberFormat) => void;
+  onChangeXNumberFormat: (value: NumberFormat) => void;
+  onChangeYLabelAngle: (value: number) => void;
+  onChangeYAxisWidth: (value: string) => void;
+  onChangeYDecimals: (value: string) => void;
+  onChangeYAllowDecimals: (value: boolean) => void;
+  onChangeYTickCount: (value: string) => void;
+  onChangeYPrefix: (value: string) => void;
+  onChangeYSuffix: (value: string) => void;
   onChangeYAxisTitle: (value: string) => void;
   onChangeYMax: (value: string) => void;
   onChangeYMin: (value: string) => void;

--- a/frontend/src/domains/chart/components/ChartEditorPanel/types.ts
+++ b/frontend/src/domains/chart/components/ChartEditorPanel/types.ts
@@ -56,6 +56,7 @@ interface ChartEditorPanelViewModel {
   onChangeXNumberFormat: (value: NumberFormat) => void;
   onChangeYLabelAngle: (value: number) => void;
   onChangeYAxisWidth: (value: string) => void;
+  onChangePlotPaddingX: (value: string) => void;
   onChangeYDecimals: (value: string) => void;
   onChangeYAllowDecimals: (value: boolean) => void;
   onChangeYTickCount: (value: string) => void;

--- a/frontend/src/domains/chart/components/ChartEditorPanel/types.ts
+++ b/frontend/src/domains/chart/components/ChartEditorPanel/types.ts
@@ -8,6 +8,7 @@ import type {
   CurveType,
   LegendPosition,
   LineStyle,
+  NumberFormat,
   SortOrder,
   StackMode,
   YAxisScale,
@@ -51,6 +52,7 @@ interface ChartEditorPanelViewModel {
   onChangeXMin: (value: string) => void;
   onChangeXTickInterval: (value: string) => void;
   onChangeYAxisScale: (value: YAxisScale) => void;
+  onChangeYNumberFormat: (value: NumberFormat) => void;
   onChangeYAxisTitle: (value: string) => void;
   onChangeYMax: (value: string) => void;
   onChangeYMin: (value: string) => void;
@@ -90,6 +92,7 @@ export type {
   CurveType,
   LegendPosition,
   LineStyle,
+  NumberFormat,
   SectionProps,
   SortOrder,
   StackMode,

--- a/frontend/src/domains/chart/components/ChartEditorPanel/utils.test.ts
+++ b/frontend/src/domains/chart/components/ChartEditorPanel/utils.test.ts
@@ -51,6 +51,14 @@ describe("buildChartEditorViewModel", () => {
     );
   });
 
+  it("sets a Y-axis number format, mapping 'default' back to undefined", () => {
+    const { vm, writeSpec } = setup();
+    vm.onChangeYNumberFormat("compact");
+    expect(writeSpec).toHaveBeenCalledWith({ ...BASE, style: { yNumberFormat: "compact" } });
+    vm.onChangeYNumberFormat("default");
+    expect(writeSpec).toHaveBeenCalledWith({ ...BASE, style: { yNumberFormat: undefined } });
+  });
+
   it("delegates reset to the supplied resetSpec", () => {
     const { vm, resetSpec } = setup();
     vm.onClickReset();

--- a/frontend/src/domains/chart/components/ChartEditorPanel/utils.test.ts
+++ b/frontend/src/domains/chart/components/ChartEditorPanel/utils.test.ts
@@ -81,6 +81,14 @@ describe("buildChartEditorViewModel", () => {
     expect(writeSpec).toHaveBeenCalledWith({ ...BASE, style: { yAllowDecimals: undefined } });
   });
 
+  it("writes a horizontal plot padding, clearing it when emptied", () => {
+    const { vm, writeSpec } = setup();
+    vm.onChangePlotPaddingX("40");
+    expect(writeSpec).toHaveBeenCalledWith({ ...BASE, style: { plotPaddingX: 40 } });
+    vm.onChangePlotPaddingX("");
+    expect(writeSpec).toHaveBeenCalledWith({ ...BASE, style: { plotPaddingX: undefined } });
+  });
+
   it("delegates reset to the supplied resetSpec", () => {
     const { vm, resetSpec } = setup();
     vm.onClickReset();

--- a/frontend/src/domains/chart/components/ChartEditorPanel/utils.test.ts
+++ b/frontend/src/domains/chart/components/ChartEditorPanel/utils.test.ts
@@ -59,6 +59,28 @@ describe("buildChartEditorViewModel", () => {
     expect(writeSpec).toHaveBeenCalledWith({ ...BASE, style: { yNumberFormat: undefined } });
   });
 
+  it("sets an X-axis number format, mapping 'default' back to undefined", () => {
+    const { vm, writeSpec } = setup();
+    vm.onChangeXNumberFormat("compact");
+    expect(writeSpec).toHaveBeenCalledWith({ ...BASE, style: { xNumberFormat: "compact" } });
+  });
+
+  it("writes a Y prefix and clears it when emptied", () => {
+    const { vm, writeSpec } = setup();
+    vm.onChangeYPrefix("$");
+    expect(writeSpec).toHaveBeenCalledWith({ ...BASE, style: { yPrefix: "$" } });
+    vm.onChangeYPrefix("");
+    expect(writeSpec).toHaveBeenCalledWith({ ...BASE, style: { yPrefix: undefined } });
+  });
+
+  it("maps the allow-decimals toggle to false only when unchecked", () => {
+    const { vm, writeSpec } = setup();
+    vm.onChangeYAllowDecimals(false);
+    expect(writeSpec).toHaveBeenCalledWith({ ...BASE, style: { yAllowDecimals: false } });
+    vm.onChangeYAllowDecimals(true);
+    expect(writeSpec).toHaveBeenCalledWith({ ...BASE, style: { yAllowDecimals: undefined } });
+  });
+
   it("delegates reset to the supplied resetSpec", () => {
     const { vm, resetSpec } = setup();
     vm.onClickReset();

--- a/frontend/src/domains/chart/components/ChartEditorPanel/utils.ts
+++ b/frontend/src/domains/chart/components/ChartEditorPanel/utils.ts
@@ -12,6 +12,7 @@ import type {
   CurveType,
   LegendPosition,
   LineStyle,
+  NumberFormat,
   SortOrder,
   StackMode,
   YAxisScale,
@@ -122,6 +123,8 @@ function buildChartEditorViewModel(args: {
     onChangeXMin: (value: string) => patchStyle({ xMin: numberOrUndefined(value) }),
     onChangeXTickInterval: (value: string) => patchStyle({ xTickInterval: numberOrUndefined(value) }),
     onChangeYAxisScale: (value: YAxisScale) => patchStyle({ yScale: value }),
+    onChangeYNumberFormat: (value: NumberFormat) =>
+      patchStyle({ yNumberFormat: value === "default" ? undefined : value }),
     onChangeYAxisTitle: (value: string) => patchStyle({ yAxisTitle: value || undefined }),
     onChangeYMax: (value: string) => patchStyle({ yMax: numberOrUndefined(value) }),
     onChangeYMin: (value: string) => patchStyle({ yMin: numberOrUndefined(value) }),

--- a/frontend/src/domains/chart/components/ChartEditorPanel/utils.ts
+++ b/frontend/src/domains/chart/components/ChartEditorPanel/utils.ts
@@ -125,6 +125,16 @@ function buildChartEditorViewModel(args: {
     onChangeYAxisScale: (value: YAxisScale) => patchStyle({ yScale: value }),
     onChangeYNumberFormat: (value: NumberFormat) =>
       patchStyle({ yNumberFormat: value === "default" ? undefined : value }),
+    onChangeXNumberFormat: (value: NumberFormat) =>
+      patchStyle({ xNumberFormat: value === "default" ? undefined : value }),
+    onChangeYLabelAngle: (value: number) => patchStyle({ yLabelAngle: value }),
+    onChangeYAxisWidth: (value: string) => patchStyle({ yAxisWidth: numberOrUndefined(value) }),
+    onChangeYDecimals: (value: string) => patchStyle({ yDecimals: numberOrUndefined(value) }),
+    onChangeYAllowDecimals: (value: boolean) =>
+      patchStyle({ yAllowDecimals: value ? undefined : false }),
+    onChangeYTickCount: (value: string) => patchStyle({ yTickCount: numberOrUndefined(value) }),
+    onChangeYPrefix: (value: string) => patchStyle({ yPrefix: value || undefined }),
+    onChangeYSuffix: (value: string) => patchStyle({ ySuffix: value || undefined }),
     onChangeYAxisTitle: (value: string) => patchStyle({ yAxisTitle: value || undefined }),
     onChangeYMax: (value: string) => patchStyle({ yMax: numberOrUndefined(value) }),
     onChangeYMin: (value: string) => patchStyle({ yMin: numberOrUndefined(value) }),

--- a/frontend/src/domains/chart/components/ChartEditorPanel/utils.ts
+++ b/frontend/src/domains/chart/components/ChartEditorPanel/utils.ts
@@ -129,6 +129,7 @@ function buildChartEditorViewModel(args: {
       patchStyle({ xNumberFormat: value === "default" ? undefined : value }),
     onChangeYLabelAngle: (value: number) => patchStyle({ yLabelAngle: value }),
     onChangeYAxisWidth: (value: string) => patchStyle({ yAxisWidth: numberOrUndefined(value) }),
+    onChangePlotPaddingX: (value: string) => patchStyle({ plotPaddingX: numberOrUndefined(value) }),
     onChangeYDecimals: (value: string) => patchStyle({ yDecimals: numberOrUndefined(value) }),
     onChangeYAllowDecimals: (value: boolean) =>
       patchStyle({ yAllowDecimals: value ? undefined : false }),

--- a/frontend/src/domains/chart/components/ChartView/constants.ts
+++ b/frontend/src/domains/chart/components/ChartView/constants.ts
@@ -19,7 +19,11 @@ const TOOLTIP_STYLE = {
 // meaningless when every series is the same measure.
 const CARTESIAN_SERIES_KINDS = new Set(["bar", "line", "area"]);
 
+// Significant digits kept when abbreviating axis tick numbers.
+const AXIS_NUMBER_FRACTION_DIGITS = 1;
+
 export {
+  AXIS_NUMBER_FRACTION_DIGITS,
   CARTESIAN_SERIES_KINDS,
   DEFAULT_PALETTE,
   TOOLTIP_STYLE,

--- a/frontend/src/domains/chart/components/ChartView/constants.ts
+++ b/frontend/src/domains/chart/components/ChartView/constants.ts
@@ -22,9 +22,18 @@ const CARTESIAN_SERIES_KINDS = new Set(["bar", "line", "area"]);
 // Significant digits kept when abbreviating axis tick numbers.
 const AXIS_NUMBER_FRACTION_DIGITS = 1;
 
+// Default left/right plot margin (px). Wider than Recharts' default so long Y
+// tick labels are not clipped at the container edge; overridable per chart.
+const DEFAULT_PLOT_PADDING_X = 16;
+
+// Fixed top/bottom plot margin (px), matching Recharts' small default.
+const PLOT_PADDING_Y = 5;
+
 export {
   AXIS_NUMBER_FRACTION_DIGITS,
   CARTESIAN_SERIES_KINDS,
   DEFAULT_PALETTE,
+  DEFAULT_PLOT_PADDING_X,
+  PLOT_PADDING_Y,
   TOOLTIP_STYLE,
 };

--- a/frontend/src/domains/chart/components/ChartView/index.css
+++ b/frontend/src/domains/chart/components/ChartView/index.css
@@ -30,6 +30,9 @@
 .mdbc-chart-empty-label {
   font-size: var(--m-fs-sm);
 }
+.mdbc-chart-empty-icon.spinning {
+  animation: mdbc-spin 1s linear infinite;
+}
 .mdbc-chart-kpi-body {
   display: flex;
   flex-direction: column;

--- a/frontend/src/domains/chart/components/ChartView/index.test.tsx
+++ b/frontend/src/domains/chart/components/ChartView/index.test.tsx
@@ -55,6 +55,19 @@ describe("ChartView", () => {
     expect(screen.getByTestId("chart-view-empty").textContent).toContain("Running");
   });
 
+  it("spins the empty-state icon while running", () => {
+    const { container } = render(
+      <ChartView spec={SPEC} result={undefined} isRunning onEdit={vi.fn()} />,
+    );
+    expect(container.querySelector(".mdbc-chart-empty-icon.spinning")).toBeTruthy();
+  });
+
+  it("does not spin the empty-state icon when idle", () => {
+    const { container } = render(<ChartView spec={undefined} result={RESULT} onEdit={vi.fn()} />);
+    expect(container.querySelector(".mdbc-chart-empty-icon.spinning")).toBeNull();
+    expect(container.querySelector(".mdbc-chart-empty-icon")).toBeTruthy();
+  });
+
   it("shows error state", () => {
     render(<ChartView spec={SPEC} result={undefined} error="boom" onEdit={vi.fn()} />);
     expect(screen.getByTestId("chart-view-empty").textContent).toContain("boom");

--- a/frontend/src/domains/chart/components/ChartView/index.test.tsx
+++ b/frontend/src/domains/chart/components/ChartView/index.test.tsx
@@ -47,7 +47,7 @@ describe("ChartView", () => {
 
   it("prompts to customize when spec has no x/y", () => {
     render(<ChartView spec={undefined} result={RESULT} onEdit={vi.fn()} />);
-    expect(screen.getByTestId("chart-view-empty").textContent).toContain("Customize chart");
+    expect(screen.getByTestId("chart-view-empty").textContent).toContain("Configure the chart to view the data");
   });
 
   it("shows running state", () => {

--- a/frontend/src/domains/chart/components/ChartView/index.tsx
+++ b/frontend/src/domains/chart/components/ChartView/index.tsx
@@ -12,7 +12,12 @@ function ChartView(props: ChartViewProps) {
       <div className="mdbc-chart-view" ref={props.containerRef}>
         <div className="mdbc-chart-view-body">
           <div className="mdbc-chart-empty" data-testid="chart-view-empty">
-            <Icon name="barChart" size={32} color="var(--m-fg-3, #555)" />
+            <Icon
+              name="barChart"
+              size={32}
+              color="var(--m-fg-3, #555)"
+              className={props.isRunning ? "mdbc-chart-empty-icon spinning" : "mdbc-chart-empty-icon"}
+            />
             <span className="mdbc-chart-empty-label">{emptyMessage}</span>
             {canCustomize && (
               <button

--- a/frontend/src/domains/chart/components/ChartView/utils.test.tsx
+++ b/frontend/src/domains/chart/components/ChartView/utils.test.tsx
@@ -3,6 +3,7 @@ import type { ChartSpec } from "@shared";
 import type { QueryResult } from "@domains/results";
 import {
   axisTickFormatter,
+  yValueFormatter,
   barSegmentRadius,
   cartesianSeries,
   chartImageFilename,
@@ -472,5 +473,27 @@ describe("axisTickFormatter", () => {
   it("uses scientific notation when selected", () => {
     const fmt = axisTickFormatter("scientific");
     expect(fmt?.(10_000_000_000)).toBe("1E10");
+  });
+});
+
+describe("yValueFormatter", () => {
+  it("returns undefined when no Y formatting is configured", () => {
+    expect(yValueFormatter(undefined)).toBeUndefined();
+    expect(yValueFormatter({ yNumberFormat: "default" })).toBeUndefined();
+  });
+
+  it("combines compact notation with a prefix and suffix", () => {
+    const fmt = yValueFormatter({ yNumberFormat: "compact", yPrefix: "$", ySuffix: "/mo" });
+    expect(fmt?.(10_000_000_000)).toBe("$10B/mo");
+  });
+
+  it("applies fixed decimals even without a notation change", () => {
+    const fmt = yValueFormatter({ yDecimals: 2, yPrefix: "$" });
+    expect(fmt?.(1234)).toBe("$1,234.00");
+  });
+
+  it("passes non-numeric values through untouched", () => {
+    const fmt = yValueFormatter({ ySuffix: "%" });
+    expect(fmt?.("n/a" as unknown as number)).toBe("n/a");
   });
 });

--- a/frontend/src/domains/chart/components/ChartView/utils.test.tsx
+++ b/frontend/src/domains/chart/components/ChartView/utils.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import type { ChartSpec } from "@shared";
 import type { QueryResult } from "@domains/results";
 import {
+  axisTickFormatter,
   barSegmentRadius,
   cartesianSeries,
   chartImageFilename,
@@ -452,5 +453,24 @@ describe("yAxisDomainFor", () => {
     expect(
       yAxisDomainFor({ kind: "bar", xColumn: "x", yColumns: ["y"], style: { yMin: 10 } }),
     ).toEqual([10, "auto"]);
+  });
+});
+
+describe("axisTickFormatter", () => {
+  it("returns undefined for the default (Recharts' own formatting)", () => {
+    expect(axisTickFormatter(undefined)).toBeUndefined();
+    expect(axisTickFormatter("default")).toBeUndefined();
+  });
+
+  it("abbreviates large magnitudes in compact mode", () => {
+    const fmt = axisTickFormatter("compact");
+    expect(fmt).toBeDefined();
+    expect(fmt?.(10_000_000_000)).toBe("10B");
+    expect(fmt?.(1_500_000)).toBe("1.5M");
+  });
+
+  it("uses scientific notation when selected", () => {
+    const fmt = axisTickFormatter("scientific");
+    expect(fmt?.(10_000_000_000)).toBe("1E10");
   });
 });

--- a/frontend/src/domains/chart/components/ChartView/utils.test.tsx
+++ b/frontend/src/domains/chart/components/ChartView/utils.test.tsx
@@ -3,6 +3,7 @@ import type { ChartSpec } from "@shared";
 import type { QueryResult } from "@domains/results";
 import {
   axisTickFormatter,
+  cartesianMargin,
   yValueFormatter,
   barSegmentRadius,
   cartesianSeries,
@@ -473,6 +474,16 @@ describe("axisTickFormatter", () => {
   it("uses scientific notation when selected", () => {
     const fmt = axisTickFormatter("scientific");
     expect(fmt?.(10_000_000_000)).toBe("1E10");
+  });
+});
+
+describe("cartesianMargin", () => {
+  it("uses the wider default horizontal padding so labels are not clipped", () => {
+    expect(cartesianMargin(undefined)).toEqual({ top: 5, right: 16, bottom: 5, left: 16 });
+  });
+
+  it("applies an explicit horizontal padding to both sides", () => {
+    expect(cartesianMargin({ plotPaddingX: 48 })).toEqual({ top: 5, right: 48, bottom: 5, left: 48 });
   });
 });
 

--- a/frontend/src/domains/chart/components/ChartView/utils.tsx
+++ b/frontend/src/domains/chart/components/ChartView/utils.tsx
@@ -74,6 +74,7 @@ function strokeDasharray(style: ChartStyle | undefined): string | undefined {
 // A Recharts tick formatter for the chosen number format, or undefined for the
 // default (Recharts' own formatting). "compact" abbreviates large magnitudes
 // (10000000000 -> 10B) so a tall Y axis stays readable; "scientific" -> 1E10.
+// Non-numeric ticks (category axes) pass through untouched.
 function axisTickFormatter(
   format: NumberFormat | undefined,
 ): ((value: number) => string) | undefined {
@@ -84,6 +85,32 @@ function axisTickFormatter(
     maximumFractionDigits: AXIS_NUMBER_FRACTION_DIGITS,
   });
   return (value: number) => (Number.isFinite(value) ? nf.format(value) : String(value));
+}
+
+// The Y-value formatter shared by the axis ticks, the tooltip, and the data
+// labels, combining number notation, fixed decimals, and a prefix/suffix. Returns
+// undefined when nothing is customized (so Recharts' own formatting stands).
+function yValueFormatter(
+  style: ChartStyle | undefined,
+): ((value: number) => string) | undefined {
+  const format = style?.yNumberFormat;
+  const decimals = style?.yDecimals;
+  const prefix = style?.yPrefix ?? "";
+  const suffix = style?.ySuffix ?? "";
+  const notationSet = !!format && format !== "default";
+  if (!notationSet && decimals == null && !prefix && !suffix) return undefined;
+
+  const options: Intl.NumberFormatOptions = {
+    notation: format === "compact" ? "compact" : format === "scientific" ? "scientific" : "standard",
+  };
+  if (decimals != null) {
+    options.minimumFractionDigits = decimals;
+    options.maximumFractionDigits = decimals;
+  } else if (notationSet) {
+    options.maximumFractionDigits = AXIS_NUMBER_FRACTION_DIGITS;
+  }
+  const nf = new Intl.NumberFormat(undefined, options);
+  return (value: number) => (Number.isFinite(value) ? `${prefix}${nf.format(value)}${suffix}` : String(value));
 }
 
 function chartFontScale(uiFontSize: number): ChartFontScale {
@@ -432,6 +459,8 @@ function buildAxes(spec: ChartSpec, fonts: ChartFontScale) {
   if (style?.xAxisTitle) {
     xAxisProps.label = { value: style.xAxisTitle, position: "insideBottom", offset: -5, fontSize: fonts.axis, fill: "rgb(var(--m-overlay-rgb) / 0.5)" };
   }
+  const xTickFormatter = axisTickFormatter(style?.xNumberFormat);
+  if (xTickFormatter) xAxisProps.tickFormatter = xTickFormatter;
   const xAxisDomain = xDomain(style);
   if (xAxisDomain) {
     xAxisProps.domain = xAxisDomain;
@@ -450,8 +479,11 @@ function buildAxes(spec: ChartSpec, fonts: ChartFontScale) {
   const yAxisDomain = yAxisDomainFor(spec);
   if (yAxisDomain) yAxisProps.domain = yAxisDomain;
   if (style?.yScale === "log") yAxisProps.scale = "log";
-  const yTickFormatter = axisTickFormatter(style?.yNumberFormat);
-  if (yTickFormatter) yAxisProps.tickFormatter = yTickFormatter;
+  const yFmt = yValueFormatter(style);
+  if (yFmt) yAxisProps.tickFormatter = yFmt;
+  if (style?.yAxisWidth != null) yAxisProps.width = style.yAxisWidth;
+  if (style?.yAllowDecimals === false) yAxisProps.allowDecimals = false;
+  if (style?.yTickCount != null) yAxisProps.tickCount = style.yTickCount;
   if (isHorizontal) {
     yAxisProps.dataKey = spec.xColumn;
     yAxisProps.type = "category" as const;
@@ -462,7 +494,7 @@ function buildAxes(spec: ChartSpec, fonts: ChartFontScale) {
       {showGrid && <CartesianGrid stroke="rgb(var(--m-overlay-rgb) / 0.05)" strokeDasharray="3 3" />}
       <XAxis {...xAxisProps} />
       <YAxis {...yAxisProps} />
-      <Tooltip contentStyle={TOOLTIP_STYLE} />
+      <Tooltip contentStyle={TOOLTIP_STYLE} formatter={yFmt} />
       {showLegend && <Legend {...legendProps(style?.legendPosition)} />}
       {style?.referenceLineY != null && (
         <ReferenceLine y={style.referenceLineY} stroke="rgb(var(--m-overlay-rgb) / 0.3)" strokeDasharray="6 3" />
@@ -530,7 +562,7 @@ function renderBarChart(spec: ChartSpec, data: DataDispatch, fonts: ChartFontSca
           radius={barSegmentRadius(index, count, stacked, isHorizontal)}
           stackId={stackId}
         >
-          {style?.showDataLabels && <LabelList dataKey={column} fontSize={fonts.dataLabel} fill="rgb(var(--m-overlay-rgb) / 0.7)" />}
+          {style?.showDataLabels && <LabelList dataKey={column} fontSize={fonts.dataLabel} fill="rgb(var(--m-overlay-rgb) / 0.7)" formatter={yValueFormatter(style)} />}
         </Bar>
       ))}
     </BarChart>
@@ -554,7 +586,7 @@ function renderLineChart(spec: ChartSpec, data: DataDispatch, fonts: ChartFontSc
           strokeDasharray={dash}
           dot={false}
         >
-          {style?.showDataLabels && <LabelList dataKey={column} fontSize={fonts.dataLabel} fill="rgb(var(--m-overlay-rgb) / 0.7)" />}
+          {style?.showDataLabels && <LabelList dataKey={column} fontSize={fonts.dataLabel} fill="rgb(var(--m-overlay-rgb) / 0.7)" formatter={yValueFormatter(style)} />}
         </Line>
       ))}
     </LineChart>
@@ -584,7 +616,7 @@ function renderAreaChart(spec: ChartSpec, data: DataDispatch, fonts: ChartFontSc
           strokeDasharray={dash}
           stackId={stackId}
         >
-          {style?.showDataLabels && <LabelList dataKey={column} fontSize={fonts.dataLabel} fill="rgb(var(--m-overlay-rgb) / 0.7)" />}
+          {style?.showDataLabels && <LabelList dataKey={column} fontSize={fonts.dataLabel} fill="rgb(var(--m-overlay-rgb) / 0.7)" formatter={yValueFormatter(style)} />}
         </Area>
       ))}
     </AreaChart>
@@ -609,7 +641,7 @@ function renderPieChart(spec: ChartSpec, data: DataDispatch, fonts: ChartFontSca
           <Cell key={index} fill={getColor(style, index)} />
         ))}
       </Pie>
-      <Tooltip contentStyle={TOOLTIP_STYLE} />
+      <Tooltip contentStyle={TOOLTIP_STYLE} formatter={yValueFormatter(style)} />
       {showLegend && <Legend {...legendProps(style?.legendPosition)} />}
     </PieChart>
   );
@@ -635,7 +667,7 @@ function renderDonutChart(spec: ChartSpec, data: DataDispatch, fonts: ChartFontS
           <Cell key={index} fill={getColor(style, index)} />
         ))}
       </Pie>
-      <Tooltip contentStyle={TOOLTIP_STYLE} />
+      <Tooltip contentStyle={TOOLTIP_STYLE} formatter={yValueFormatter(style)} />
       {showLegend && <Legend {...legendProps(style?.legendPosition)} />}
     </PieChart>
   );
@@ -666,10 +698,10 @@ function renderScatterChart(spec: ChartSpec, data: DataDispatch, fonts: ChartFon
         scale={style?.yScale === "log" ? "log" : undefined}
         label={style?.yAxisTitle ? { value: style.yAxisTitle, angle: -90, position: "insideLeft", fontSize: fonts.axis, fill: "rgb(var(--m-overlay-rgb) / 0.5)" } : undefined}
       />
-      <Tooltip contentStyle={TOOLTIP_STYLE} />
+      <Tooltip contentStyle={TOOLTIP_STYLE} formatter={yValueFormatter(style)} />
       {showLegend && <Legend {...legendProps(style?.legendPosition)} />}
       <Scatter data={data.scatter} fill={getColor(style, 0)}>
-        {style?.showDataLabels && <LabelList dataKey="y" fontSize={fonts.dataLabel} fill="rgb(var(--m-overlay-rgb) / 0.7)" />}
+        {style?.showDataLabels && <LabelList dataKey="y" fontSize={fonts.dataLabel} fill="rgb(var(--m-overlay-rgb) / 0.7)" formatter={yValueFormatter(style)} />}
       </Scatter>
     </ScatterChart>
   );
@@ -684,7 +716,7 @@ function renderBubbleChart(spec: ChartSpec, data: DataDispatch, fonts: ChartFont
       <XAxis dataKey="x" type="number" name={spec.xColumn} stroke="rgb(var(--m-overlay-rgb) / 0.4)" fontSize={fonts.axis} domain={xDomain(style)} />
       <YAxis dataKey="y" type="number" name={spec.yColumns[0]} stroke="rgb(var(--m-overlay-rgb) / 0.4)" fontSize={fonts.axis} domain={yDomain(style)} />
       <ZAxis dataKey="z" range={[20, 400]} name={spec.zColumn ?? "size"} />
-      <Tooltip contentStyle={TOOLTIP_STYLE} />
+      <Tooltip contentStyle={TOOLTIP_STYLE} formatter={yValueFormatter(style)} />
       {showLegend && <Legend {...legendProps(style?.legendPosition)} />}
       <Scatter data={data.scatter} fill={getColor(style, 0)} fillOpacity={0.6} />
     </ScatterChart>
@@ -702,7 +734,7 @@ function renderComboChart(spec: ChartSpec, data: DataDispatch, fonts: ChartFontS
       {data.cartesianSeries.map((column, index) =>
         index === 0 ? (
           <Bar key={column} dataKey={column} fill={getColor(style, index)} radius={4}>
-            {style?.showDataLabels && <LabelList dataKey={column} fontSize={fonts.dataLabel} fill="rgb(var(--m-overlay-rgb) / 0.7)" />}
+            {style?.showDataLabels && <LabelList dataKey={column} fontSize={fonts.dataLabel} fill="rgb(var(--m-overlay-rgb) / 0.7)" formatter={yValueFormatter(style)} />}
           </Bar>
         ) : (
           <Line
@@ -715,7 +747,7 @@ function renderComboChart(spec: ChartSpec, data: DataDispatch, fonts: ChartFontS
             dot={false}
             yAxisId="right"
           >
-            {style?.showDataLabels && <LabelList dataKey={column} fontSize={fonts.dataLabel} fill="rgb(var(--m-overlay-rgb) / 0.7)" />}
+            {style?.showDataLabels && <LabelList dataKey={column} fontSize={fonts.dataLabel} fill="rgb(var(--m-overlay-rgb) / 0.7)" formatter={yValueFormatter(style)} />}
           </Line>
         ),
       )}
@@ -730,7 +762,7 @@ function renderHistogramChart(spec: ChartSpec, data: DataDispatch, fonts: ChartF
       <CartesianGrid stroke="rgb(var(--m-overlay-rgb) / 0.05)" strokeDasharray="3 3" />
       <XAxis dataKey="bin" stroke="rgb(var(--m-overlay-rgb) / 0.4)" fontSize={fonts.histogramTick} angle={-45} textAnchor="end" height={50} />
       <YAxis stroke="rgb(var(--m-overlay-rgb) / 0.4)" fontSize={fonts.axis} />
-      <Tooltip contentStyle={TOOLTIP_STYLE} />
+      <Tooltip contentStyle={TOOLTIP_STYLE} formatter={yValueFormatter(style)} />
       <Bar dataKey="count" fill={getColor(style, 0)}>
         {style?.showDataLabels && <LabelList dataKey="count" fontSize={fonts.dataLabel} fill="rgb(var(--m-overlay-rgb) / 0.7)" />}
       </Bar>
@@ -749,7 +781,7 @@ function renderRadarChart(spec: ChartSpec, data: DataDispatch, fonts: ChartFontS
       {spec.yColumns.map((column, index) => (
         <Radar key={column} name={column} dataKey={column} stroke={getColor(style, index)} fill={getColor(style, index)} fillOpacity={0.2} />
       ))}
-      <Tooltip contentStyle={TOOLTIP_STYLE} />
+      <Tooltip contentStyle={TOOLTIP_STYLE} formatter={yValueFormatter(style)} />
       {showLegend && <Legend {...legendProps(style?.legendPosition)} />}
     </RadarChart>
   );
@@ -789,7 +821,7 @@ function renderFunnelChart(spec: ChartSpec, data: DataDispatch, fonts: ChartFont
   const showLegend = style?.showLegend === true;
   return (
     <FunnelChart>
-      <Tooltip contentStyle={TOOLTIP_STYLE} />
+      <Tooltip contentStyle={TOOLTIP_STYLE} formatter={yValueFormatter(style)} />
       {showLegend && <Legend {...legendProps(style?.legendPosition)} />}
       <Funnel dataKey="value" data={data.funnel} isAnimationActive>
         {data.funnel.map((entry, index) => (
@@ -945,6 +977,7 @@ function chartEmptyMessage(
 
 export {
   axisTickFormatter,
+  yValueFormatter,
   barSegmentRadius,
   cartesianSeries,
   chartEmptyMessage,

--- a/frontend/src/domains/chart/components/ChartView/utils.tsx
+++ b/frontend/src/domains/chart/components/ChartView/utils.tsx
@@ -38,10 +38,12 @@ import type {
   ChartStyle,
   CurveType,
   LegendPosition,
+  NumberFormat,
   SortOrder,
 } from "@shared";
 import type { ColumnSpec, QueryResult } from "@domains/results";
 import {
+  AXIS_NUMBER_FRACTION_DIGITS,
   CARTESIAN_SERIES_KINDS,
   DEFAULT_PALETTE,
   TOOLTIP_STYLE,
@@ -67,6 +69,21 @@ function strokeDasharray(style: ChartStyle | undefined): string | undefined {
   if (!style?.lineStyle || style.lineStyle === "solid") return undefined;
   if (style.lineStyle === "dashed") return "8 4";
   return "2 2";
+}
+
+// A Recharts tick formatter for the chosen number format, or undefined for the
+// default (Recharts' own formatting). "compact" abbreviates large magnitudes
+// (10000000000 -> 10B) so a tall Y axis stays readable; "scientific" -> 1E10.
+function axisTickFormatter(
+  format: NumberFormat | undefined,
+): ((value: number) => string) | undefined {
+  if (!format || format === "default") return undefined;
+  const notation = format === "compact" ? "compact" : "scientific";
+  const nf = new Intl.NumberFormat(undefined, {
+    notation,
+    maximumFractionDigits: AXIS_NUMBER_FRACTION_DIGITS,
+  });
+  return (value: number) => (Number.isFinite(value) ? nf.format(value) : String(value));
 }
 
 function chartFontScale(uiFontSize: number): ChartFontScale {
@@ -433,6 +450,8 @@ function buildAxes(spec: ChartSpec, fonts: ChartFontScale) {
   const yAxisDomain = yAxisDomainFor(spec);
   if (yAxisDomain) yAxisProps.domain = yAxisDomain;
   if (style?.yScale === "log") yAxisProps.scale = "log";
+  const yTickFormatter = axisTickFormatter(style?.yNumberFormat);
+  if (yTickFormatter) yAxisProps.tickFormatter = yTickFormatter;
   if (isHorizontal) {
     yAxisProps.dataKey = spec.xColumn;
     yAxisProps.type = "category" as const;
@@ -925,6 +944,7 @@ function chartEmptyMessage(
 }
 
 export {
+  axisTickFormatter,
   barSegmentRadius,
   cartesianSeries,
   chartEmptyMessage,

--- a/frontend/src/domains/chart/components/ChartView/utils.tsx
+++ b/frontend/src/domains/chart/components/ChartView/utils.tsx
@@ -46,6 +46,8 @@ import {
   AXIS_NUMBER_FRACTION_DIGITS,
   CARTESIAN_SERIES_KINDS,
   DEFAULT_PALETTE,
+  DEFAULT_PLOT_PADDING_X,
+  PLOT_PADDING_Y,
   TOOLTIP_STYLE,
 } from "./constants";
 import type {
@@ -442,6 +444,13 @@ function toKpiData(
   };
 }
 
+// Left/right plot margin so long axis labels are not clipped at the container
+// edge; overridable via `plotPaddingX`. Top/bottom stay at the small default.
+function cartesianMargin(style: ChartStyle | undefined) {
+  const x = style?.plotPaddingX ?? DEFAULT_PLOT_PADDING_X;
+  return { top: PLOT_PADDING_Y, right: x, bottom: PLOT_PADDING_Y, left: x };
+}
+
 function buildAxes(spec: ChartSpec, fonts: ChartFontScale) {
   const style = spec.style;
   const showGrid = style?.showGrid !== false;
@@ -552,7 +561,7 @@ function renderBarChart(spec: ChartSpec, data: DataDispatch, fonts: ChartFontSca
   const stackId = stacked ? "a" : undefined;
   const count = data.cartesianSeries.length;
   return (
-    <BarChart data={data.cartesian} layout={isHorizontal ? "vertical" : "horizontal"}>
+    <BarChart data={data.cartesian} layout={isHorizontal ? "vertical" : "horizontal"} margin={cartesianMargin(style)}>
       {buildAxes(spec, fonts)}
       {data.cartesianSeries.map((column, index) => (
         <Bar
@@ -574,7 +583,7 @@ function renderLineChart(spec: ChartSpec, data: DataDispatch, fonts: ChartFontSc
   const strokeWidth = style?.strokeWidth ?? 2;
   const dash = strokeDasharray(style);
   return (
-    <LineChart data={data.cartesian}>
+    <LineChart data={data.cartesian} margin={cartesianMargin(style)}>
       {buildAxes(spec, fonts)}
       {data.cartesianSeries.map((column, index) => (
         <Line
@@ -602,7 +611,7 @@ function renderAreaChart(spec: ChartSpec, data: DataDispatch, fonts: ChartFontSc
   const stackId = stacked ? "a" : undefined;
   const stackOffset = style?.stackMode === "percent" ? "expand" : undefined;
   return (
-    <AreaChart data={data.cartesian} stackOffset={stackOffset}>
+    <AreaChart data={data.cartesian} stackOffset={stackOffset} margin={cartesianMargin(style)}>
       {buildAxes(spec, fonts)}
       {data.cartesianSeries.map((column, index) => (
         <Area
@@ -728,7 +737,7 @@ function renderComboChart(spec: ChartSpec, data: DataDispatch, fonts: ChartFontS
   const strokeWidth = style?.strokeWidth ?? 2;
   const dash = strokeDasharray(style);
   return (
-    <ComposedChart data={data.cartesian}>
+    <ComposedChart data={data.cartesian} margin={cartesianMargin(style)}>
       {buildAxes(spec, fonts)}
       <YAxis yAxisId="right" orientation="right" stroke="rgb(var(--m-overlay-rgb) / 0.4)" fontSize={fonts.axis} />
       {data.cartesianSeries.map((column, index) =>
@@ -758,7 +767,7 @@ function renderComboChart(spec: ChartSpec, data: DataDispatch, fonts: ChartFontS
 function renderHistogramChart(spec: ChartSpec, data: DataDispatch, fonts: ChartFontScale): ReactElement {
   const style = spec.style;
   return (
-    <BarChart data={data.histogram} barGap={0} barCategoryGap={0}>
+    <BarChart data={data.histogram} barGap={0} barCategoryGap={0} margin={cartesianMargin(style)}>
       <CartesianGrid stroke="rgb(var(--m-overlay-rgb) / 0.05)" strokeDasharray="3 3" />
       <XAxis dataKey="bin" stroke="rgb(var(--m-overlay-rgb) / 0.4)" fontSize={fonts.histogramTick} angle={-45} textAnchor="end" height={50} />
       <YAxis stroke="rgb(var(--m-overlay-rgb) / 0.4)" fontSize={fonts.axis} />
@@ -977,6 +986,7 @@ function chartEmptyMessage(
 
 export {
   axisTickFormatter,
+  cartesianMargin,
   yValueFormatter,
   barSegmentRadius,
   cartesianSeries,

--- a/frontend/src/domains/chart/components/ChartView/utils.tsx
+++ b/frontend/src/domains/chart/components/ChartView/utils.tsx
@@ -969,7 +969,7 @@ function chartEmptyMessage(
   if (error) return error;
   if (!result) return "Run a query to see a chart";
   if (!spec || !spec.kind || !spec.xColumn || spec.yColumns.length === 0) {
-    return "Customize chart";
+    return "Configure the chart to view the data";
   }
   if (!hasData) return "No data";
   return null;

--- a/frontend/src/shared/backendTypes.ts
+++ b/frontend/src/shared/backendTypes.ts
@@ -363,6 +363,9 @@ interface ChartStyle {
   ySuffix?: string;
   // Reserved pixel width for the Y axis so long tick labels are not clipped.
   yAxisWidth?: number;
+  // Left/right plot margin (px) so axis labels have breathing room and are not
+  // clipped at the container edge.
+  plotPaddingX?: number;
   // Whether the Y axis may place ticks at fractional values (default true).
   yAllowDecimals?: boolean;
   // Suggested number of Y-axis ticks (Recharts treats it as a hint).

--- a/frontend/src/shared/backendTypes.ts
+++ b/frontend/src/shared/backendTypes.ts
@@ -331,6 +331,7 @@ type BarOrientation = "vertical" | "horizontal";
 type LegendPosition = "top" | "bottom" | "left" | "right";
 type CurveType = "linear" | "monotone" | "step" | "natural";
 type YAxisScale = "linear" | "log";
+type NumberFormat = "default" | "compact" | "scientific";
 type SortOrder = "none" | "asc" | "desc";
 type AggFn = "none" | "sum" | "avg" | "min" | "max" | "count";
 
@@ -350,6 +351,9 @@ interface ChartStyle {
   xLabelAngle?: number;
   yLabelAngle?: number;
   yScale?: YAxisScale;
+  // How Y-axis tick numbers render: "compact" abbreviates large values
+  // (10000000000 -> 10B) so they stay readable; "scientific" uses 1E10.
+  yNumberFormat?: NumberFormat;
   showDataLabels?: boolean;
   stackMode?: StackMode;
   barOrientation?: BarOrientation;
@@ -667,6 +671,7 @@ export type {
   LegendPosition,
   CurveType,
   YAxisScale,
+  NumberFormat,
   SortOrder,
   AggFn,
   ChartStyle,

--- a/frontend/src/shared/backendTypes.ts
+++ b/frontend/src/shared/backendTypes.ts
@@ -351,9 +351,22 @@ interface ChartStyle {
   xLabelAngle?: number;
   yLabelAngle?: number;
   yScale?: YAxisScale;
-  // How Y-axis tick numbers render: "compact" abbreviates large values
-  // (10000000000 -> 10B) so they stay readable; "scientific" uses 1E10.
+  // How Y-axis numbers render (axis ticks, tooltip, and data labels alike):
+  // "compact" abbreviates large values (10000000000 -> 10B) so they stay
+  // readable; "scientific" uses 1E10. Same option for the X axis.
   yNumberFormat?: NumberFormat;
+  xNumberFormat?: NumberFormat;
+  // Fixed decimal places for Y numbers (overrides the format's default rounding).
+  yDecimals?: number;
+  // Text wrapped around each formatted Y number, e.g. prefix "$" or suffix "%".
+  yPrefix?: string;
+  ySuffix?: string;
+  // Reserved pixel width for the Y axis so long tick labels are not clipped.
+  yAxisWidth?: number;
+  // Whether the Y axis may place ticks at fractional values (default true).
+  yAllowDecimals?: boolean;
+  // Suggested number of Y-axis ticks (Recharts treats it as a hint).
+  yTickCount?: number;
   showDataLabels?: boolean;
   stackMode?: StackMode;
   barOrientation?: BarOrientation;


### PR DESCRIPTION
## What does this PR do?

Enriches the canvas chart node with a title/status/refresh top bar, richer axis formatting for big numbers, and a fix for the first-run race that showed an incorrect "table not found" message. Also enlarges the canvas resize hit areas so nodes are easier to grab.

Changes:
- Chart top bar: title + refresh button that re-runs the source query; error surfaces in a red bottom status bar showing data-point count, row-sample cap, and last-refresh timestamp.
- Axis formatting: X/Y number format (default/compact/scientific), decimals, prefix/suffix, Y-axis width, tick count, allow-decimals, label angle, and configurable horizontal plot padding so large Y values stay visible.
- Stale-column & first-run fixes: reconcile the spec against the source result to drop removed columns instead of a schema error, and gate aggregation until the source's full result has drained (its cache table registered), removing the first-run "table not found".
- Empty-state polish: "Configure the chart to view the data" when no measure is picked; chart icon spins while the source loads.
- Improve resizing: transparent `::before` pads enlarge corner-handle and edge hit areas (no visual change) for easier drag-to-resize.
- Properties pane: Max rows shows the real default value, section separators, and the new formatting controls.

## Checklist

- [ ] I opened an issue first for non-trivial changes, or this is a small fix.
- [x] Tests added/updated for my change.
- [x] **I license my contribution under the MIT License**, per [CONTRIBUTING.md](../CONTRIBUTING.md). I confirm this is my original work, or that I have the right to submit it.
